### PR TITLE
configurable docker image(container)

### DIFF
--- a/container/docker/Dockerfile.alpine
+++ b/container/docker/Dockerfile.alpine
@@ -17,6 +17,11 @@ WORKDIR /usr/src/yavin/packages/webservice
 RUN ./gradlew bootJar -x installUIDependencies
 RUN cp -r ./../app/dist app/build/resources/main/META-INF/resources/ui
 
+RUN sed -i 's|path: demo-configs|path: /hjson-configs|' app/src/main/resources/application.yaml
+RUN mkdir /hjson-configs
+RUN mv app/src/main/resources/demo-configs/* /hjson-configs/
+VOLUME /hjson-configs
+
 WORKDIR /
 RUN cp /usr/src/yavin/packages/webservice/app/build/libs/app-*.jar /usr/local/lib/
 RUN rm -rf /usr/src/yavin

--- a/container/docker/README.md
+++ b/container/docker/README.md
@@ -47,6 +47,22 @@ To run yavin demo using docker container:
 ```
 docker run -p 9999:8080 verizonmedia/yavin_demo:latest
 ```
+### Add custom hjson to docker container for exploring additional data sources
+Assuming you already have the container running from the previous step, first you need to figure out the path where docker container is storin
+```
+$ bash get_hjson_path.sh
+[{"Type":"volume","Name":"d4d0ae3ca09f752454b3a22c7fa3d551b9366aa6618995356b89048b12e3c436","Source":"/var/lib/docker/volumes/d4d0ae3ca09f7524
+
+
+Look for "Source" key in above json and use its value to find hjson location
+```
+In the above example the path can be found from
+```
+"Source":"/var/lib/docker/volumes/d4d0ae3ca09f752454b3a22c7fa3d551b9366aa6618995356b89048b12e3c436/_data"
+```
+
+The path is managed by docker so it will need sudo or admin access to modify/add files to it.
+
 
 ## Launch in Dokcer using PWD
 

--- a/scripts/get_hjson_path.sh
+++ b/scripts/get_hjson_path.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This script will extract the path on local machine where
+# we can add hjson/db files to get access to more data sources
+set -e
+
+# Look for yavin_demo based container only
+ct_id=$(docker ps -f ancestor=yavin_demo --format "{{.ID}}")
+if [ ! -z $ct_id ]
+ then
+  # extract mount info which should show a json output.
+  pth=$(docker container inspect ${ct_id} -f "{{json .Mounts}}")
+  echo $pth
+  echo "Look for \"Source\" key in above json and use its value to find hjson location"
+else
+  echo "No container found matching our filter" && exit
+fi


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description
When demo docker container is launched users cannot add additional data sources.

## Proposed Changes

Create docker managed volume and load the hjson config files on to that.
After container is launched with example netflix data, users can add more
hjson files to explore their own data sources.

A helper script is added to help in the process. This is a shell script so possibly
will not work on windows.
-

## Screenshots

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
