### PR TITLE
Fix: Elide enum value search

### DIFF
--- a/packages/data/addon/adapters/dimensions/elide.ts
+++ b/packages/data/addon/adapters/dimensions/elide.ts
@@ -1,18 +1,19 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Description: The adapter for the Elide dimension model.
  */
-import { getOwner } from '@ember/application';
 import EmberObject from '@ember/object';
-import NaviDimensionAdapter, { DimensionFilter } from './interface';
-import { ServiceOptions } from 'navi-data/services/navi-dimension';
-import { AsyncQueryResponse, FilterOperator, QueryStatus, RequestV2 } from '../facts/interface';
-import ElideFactsAdapter, { getElideField } from '../facts/elide';
-import { DimensionColumn } from 'navi-data/models/metadata/dimension';
-import ElideDimensionMetadataModel from 'navi-data/models/metadata/elide/dimension';
+import { getOwner } from '@ember/application';
 import { assert } from '@ember/debug';
+import { AsyncQueryResponse, FilterOperator, QueryStatus, RequestV2 } from '../facts/interface';
+import type NaviDimensionAdapter from './interface';
+import type { DimensionFilter } from './interface';
+import type { ServiceOptions } from 'navi-data/services/navi-dimension';
+import type ElideFactsAdapter from '../facts/elide';
+import type { DimensionColumn } from 'navi-data/models/metadata/dimension';
+import type ElideDimensionMetadataModel from 'navi-data/models/metadata/elide/dimension';
 
 type EnumFilter = (values: string[], filterValues: (string | number)[]) => (string | number)[];
 
@@ -30,8 +31,8 @@ export default class ElideDimensionAdapter extends EmberObject implements NaviDi
   private factAdapter: ElideFactsAdapter = getOwner(this).lookup('adapter:facts/elide');
 
   private formatEnumResponse(dimension: DimensionColumn, values: (string | number)[]): AsyncQueryResponse {
-    const { id, tableId } = dimension.columnMetadata;
-    const field = getElideField(id, dimension.parameters);
+    const { tableId } = dimension.columnMetadata;
+    const field = 'col0';
     const nodes = values.map((value) => `{"node":{"${field}":"${value}"}}`);
     const responseBody = `{"data":{"${tableId}":{"edges":[${nodes.join(',')}]}}}`;
 

--- a/packages/data/addon/adapters/dimensions/elide.ts
+++ b/packages/data/addon/adapters/dimensions/elide.ts
@@ -32,8 +32,7 @@ export default class ElideDimensionAdapter extends EmberObject implements NaviDi
 
   private formatEnumResponse(dimension: DimensionColumn, values: (string | number)[]): AsyncQueryResponse {
     const { tableId } = dimension.columnMetadata;
-    const field = 'col0';
-    const nodes = values.map((value) => `{"node":{"${field}":"${value}"}}`);
+    const nodes = values.map((value) => `{"node":{"col0":"${value}"}}`);
     const responseBody = `{"data":{"${tableId}":{"edges":[${nodes.join(',')}]}}}`;
 
     return {

--- a/packages/data/tests/unit/adapters/dimensions/elide-test.ts
+++ b/packages/data/tests/unit/adapters/dimensions/elide-test.ts
@@ -36,8 +36,8 @@ function assertRequest(context: TestContext, callback: (request: RequestV2, opti
 function extractDimValues(dimension: DimensionColumn, rawResponse: AsyncQueryResponse): string[] {
   const responseStr = rawResponse?.asyncQuery.edges[0].node.result?.responseBody || '';
   const response = JSON.parse(responseStr);
-  const { id: dimensionName, tableId } = dimension.columnMetadata;
-  return response.data[tableId as string].edges.map((edge: ResponseEdge) => edge.node[getElideField(dimensionName)]);
+  const { tableId } = dimension.columnMetadata;
+  return response.data[tableId as string].edges.map((edge: ResponseEdge) => edge.node.col0);
 }
 
 module('Unit | Adapter | Dimensions | Elide', function (hooks) {

--- a/packages/data/tests/unit/adapters/dimensions/elide-test.ts
+++ b/packages/data/tests/unit/adapters/dimensions/elide-test.ts
@@ -10,7 +10,6 @@ import ElideTwoScenario from 'navi-data/mirage/scenarios/elide-two';
 // @ts-ignore
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { Server } from 'miragejs';
-import { getElideField } from 'navi-data/adapters/facts/elide';
 import { ResponseEdge } from 'navi-data/serializers/dimensions/elide';
 
 interface TestContext extends Context {

--- a/packages/data/tests/unit/services/navi-dimension-test.ts
+++ b/packages/data/tests/unit/services/navi-dimension-test.ts
@@ -44,6 +44,29 @@ module('Unit | Service | navi-dimension', function (hooks) {
     assert.deepEqual(all, expectedDimensionModels, '`all` gets all the unfiltered values for a dimension');
   });
 
+  test('all - enum', async function (this: TestContext, assert) {
+    const service = this.owner.lookup('service:navi-dimension') as NaviDimensionService;
+    const columnMetadata = this.metadataService.getById(
+      'dimension',
+      'table0.dimension1',
+      'elideOne'
+    ) as DimensionMetadataModel;
+    const expectedDimensionModels = [
+      'Practical Frozen Fish (enum)',
+      'Practical Concrete Chair (enum)',
+      'Awesome Steel Chicken (enum)',
+      'Tasty Fresh Towels (enum)',
+      'Intelligent Steel Pizza (enum)',
+    ].map((dimVal) => NaviDimensionModel.create({ value: dimVal, dimensionColumn: { columnMetadata } }));
+    const all = await service.all({ columnMetadata });
+
+    assert.deepEqual(
+      all,
+      expectedDimensionModels,
+      '`all` gets all the unfiltered values for a dimension with enum values'
+    );
+  });
+
   test('find', async function (this: TestContext, assert) {
     const service = this.owner.lookup('service:navi-dimension') as NaviDimensionService;
     const columnMetadata = this.metadataService.getById(


### PR DESCRIPTION
## Description
We used `colN` aliasing convention for elide columns but didn't implement this for our mock enum response

## Proposed Changes
- use 'col0' as field instead of elideField for enum responses

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
