### PR TITLE
Build: Don't force `ci` during lerna bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Assuming you have git, node (>=10), and [ember-cli](https://cli.emberjs.com/rele
 
 - `git clone https://github.com/yavin-dev/framework.git`
 - `cd yavin`
-- `npm install`
+- `CI=true npm install` (`CI=true` makes use of each package's `package-lock.json` file)
 - `cd packages/reports` (or whichever package)
 - `ember s` to run a local server
 - Then `npm test` to test your changes

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build-ui": "lerna run build --scope navi-app --stream",
     "start": "cd packages/webservice && ./gradlew bootRun",
-    "postinstall": "lerna bootstrap --concurrency 2 --ci",
+    "postinstall": "lerna bootstrap --concurrency 2",
     "test": "lerna run test --stream",
     "lint": "lerna run lint --stream",
     "lint:ws:fix": "cd packages/webservice && ./gradlew formatKotlin -d && true",


### PR DESCRIPTION
Resolves #

## Description

Lerna is aware of CI environments and runs `npm ci` if `process.env.CI` is `true`. Since there are times when you don't want `npm ci`, such as when update a dependency. This PR changes the lerna bootstrap command to run `npm ci` only when `process.env.CI` is `true`.

## Proposed Changes

- Remove the `--ci` flag from the `bootstrap` cmd

## Screenshots

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
