### PR TITLE
Update: SD disable chrome cache

### DIFF
--- a/build-scripts/setup-chrome.sh
+++ b/build-scripts/setup-chrome.sh
@@ -2,16 +2,7 @@
 
 CHROME_DESTINATION=/usr/bin/chrome
 
-echo "Test: start";
-test -f "$CHROME_DESTINATION"; echo $?
-test -e "$CHROME_DESTINATION"; echo $?
-test -x "$CHROME_DESTINATION"; echo $?
-test -L "$CHROME_DESTINATION"; echo $?
-
-ls -l "$CHROME_DESTINATION"
-echo "Test: end";
-
-if [ -e "$CHROME_DESTINATION" ]; then
+if [ -L "$CHROME_DESTINATION" ]; then
   echo "$CHROME_DESTINATION exists. Skipping download."
 else 
   echo "$CHROME_DESTINATION does not exist. Starting download."
@@ -19,5 +10,5 @@ else
   sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
   apt-get update -qy
   apt-get install -qy google-chrome-stable
-  ln -f -s /usr/bin/google-chrome ${CHROME_DESTINATION}
+  ln -s /usr/bin/google-chrome ${CHROME_DESTINATION}
 fi

--- a/build-scripts/setup-chrome.sh
+++ b/build-scripts/setup-chrome.sh
@@ -2,6 +2,15 @@
 
 CHROME_DESTINATION=/usr/bin/chrome
 
+echo "Test: start";
+test -f "$CHROME_DESTINATION"; echo $?
+test -e "$CHROME_DESTINATION"; echo $?
+test -x "$CHROME_DESTINATION"; echo $?
+test -L "$CHROME_DESTINATION"; echo $?
+
+ls -l "$CHROME_DESTINATION"
+echo "Test: end";
+
 if [ -e "$CHROME_DESTINATION" ]; then
   echo "$CHROME_DESTINATION exists. Skipping download."
 else 
@@ -10,5 +19,5 @@ else
   sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
   apt-get update -qy
   apt-get install -qy google-chrome-stable
-  ln -s /usr/bin/google-chrome ${CHROME_DESTINATION}
+  ln -f -s /usr/bin/google-chrome ${CHROME_DESTINATION}
 fi

--- a/build-scripts/setup-chrome.sh
+++ b/build-scripts/setup-chrome.sh
@@ -2,13 +2,8 @@
 
 CHROME_DESTINATION=/usr/bin/chrome
 
-if [ -L "$CHROME_DESTINATION" ]; then
-  echo "$CHROME_DESTINATION exists. Skipping download."
-else 
-  echo "$CHROME_DESTINATION does not exist. Starting download."
-  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-  sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-  apt-get update -qy
-  apt-get install -qy google-chrome-stable
-  ln -s /usr/bin/google-chrome ${CHROME_DESTINATION}
-fi
+wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+apt-get update -qy
+apt-get install -qy google-chrome-stable
+ln -s /usr/bin/google-chrome ${CHROME_DESTINATION}

--- a/build-scripts/setup-chrome.sh
+++ b/build-scripts/setup-chrome.sh
@@ -2,7 +2,7 @@
 
 CHROME_DESTINATION=/usr/bin/chrome
 
-if [ -f "$CHROME_DESTINATION" ]; then
+if [ -e "$CHROME_DESTINATION" ]; then
   echo "$CHROME_DESTINATION exists. Skipping download."
 else 
   echo "$CHROME_DESTINATION does not exist. Starting download."

--- a/build-scripts/setup-chrome.sh
+++ b/build-scripts/setup-chrome.sh
@@ -2,7 +2,7 @@
 
 CHROME_DESTINATION=/usr/bin/chrome
 
-if [[ -f "$CHROME_DESTINATION" ]]; then
+if [ -f "$CHROME_DESTINATION" ]; then
   echo "$CHROME_DESTINATION exists. Skipping download."
 else 
   echo "$CHROME_DESTINATION does not exist. Starting download."

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 cache:
-  pipeline: [~/.npm, ~/.gradle, /usr/bin/chrome]
+  pipeline: [~/.npm, ~/.gradle]
 
 shared:
   image: maven:3.6.3-jdk-8


### PR DESCRIPTION
## Description
SD was not able to interpret the `[[` command which worked when there was no cache, but now that it exists is breaking

```
./build-scripts/setup-chrome.sh: 5: ./build-scripts/setup-chrome.sh: [[: not found
17:17:34 /usr/bin/chrome does not exist. Starting download.
```


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
