### PR TITLE
Update: Add week, isoweek, month grains for elide

### DIFF
--- a/packages/webservice/app/src/main/resources/demo-configs/models/tables/DemoTables.hjson
+++ b/packages/webservice/app/src/main/resources/demo-configs/models/tables/DemoTables.hjson
@@ -65,11 +65,32 @@
           grains: [
             {
                type: DAY
+               sql :  '''
+               PARSEDATETIME(FORMATDATETIME({{}}, 'yyyy-MM-dd'), 'yyyy-MM-dd')
+               '''
+            }
+            {
+               type: WEEK
+               sql :  '''
+               PARSEDATETIME(FORMATDATETIME({{}}, 'YYYY-ww'), 'YYYY-ww')
+               '''
+            }
+            {
+               type: ISOWEEK
+               sql :  '''
+               DATEADD('DAY', 1, PARSEDATETIME(FORMATDATETIME({{}}, 'YYYY-ww'), 'YYYY-ww'))
+               '''
+            }
+            {
+               type: MONTH
+               sql :  '''
+               PARSEDATETIME(FORMATDATETIME({{}}, 'yyyy-MM'), 'yyyy-MM')
+               '''
             }
             {
                type: YEAR
                sql :  '''
-               PARSEDATETIME(YEAR({{}}), 'YYYY')
+               PARSEDATETIME(YEAR({{}}), 'yyyy')
                '''
             }
           ]


### PR DESCRIPTION
## Description
Fix day grain definition, adds week, isoweek, month grains

Standard week seems to work well in the UI without any changes

## Proposed Changes
- fixes an issue with day grain not having sql definition
- Fixes Year grain definition (was using [weekyear](https://stackoverflow.com/a/12781297))

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
