### PR TITLE
Build: Set unsafe-perm true when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "lerna run lint --stream",
     "lint:ws:fix": "cd packages/webservice && ./gradlew formatKotlin -d && true",
     "lerna-ci-publish": "lerna publish --canary --exact preminor --force-publish=* --yes",
-    "lerna-ci-publish-beta": "lerna publish --canary --preid beta --dist-tag beta --exact preminor --force-publish=* --yes -- --unsafe-perm"
+    "lerna-ci-publish-beta": "lerna publish --canary --preid beta --dist-tag beta --exact preminor --force-publish=* --yes"
   },
   "devDependencies": {
     "husky": "^4.2.5",

--- a/scripts/npm-publish.sh
+++ b/scripts/npm-publish.sh
@@ -4,6 +4,9 @@ set -e # Exit with nonzero exit code if anything fails
 # Login to NPM
 npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
 
+# Fix pre/post publish warnings
+npm config set unsafe-perm true
+
 BRANCH=$(git rev-parse --abbrev-ref HEAD);
 
 echo "Deploying yavin npm packages for branch $BRANCH"


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description
Looks like we are not publishing TS definitions. Caught this in the logs:
```
lerna WARN lifecycle navi-data@0.2.0-beta.580+0564b8fc~prepublishOnly: 
cannot run in wd navi-data@0.2.0-beta.580+0564b8fc ember ts:precompile (wd=/sd/workspace/src/github.com/yavin-dev/framework/packages/data)
```
https://cd.screwdriver.cd/pipelines/6102/builds/690514/steps/publish

Hopefully this can fix it.

## Proposed Changes

- Set unsafe-perm true when publishing

## Screenshots

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
