### PR TITLE
Build: Add navi-core as a devDep to notifications

### DIFF
--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -83,6 +83,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-qunit": "^4.0.0",
     "loader.js": "^4.7.0",
+    "navi-core": "0.2.0",
     "npm-run-all": "^4.1.5",
     "qunit": "^2.14.0",
     "qunit-dom": "^1.6.0",

--- a/packages/notifications/tests/dummy/config/environment.js
+++ b/packages/notifications/tests/dummy/config/environment.js
@@ -25,6 +25,16 @@ module.exports = function (environment) {
        * when it is created
        */
     },
+    navi: {
+      user: 'navi_user',
+      dataEpoch: '2013-01-01',
+      dataSources: [{ name: 'bardOne', uri: 'https://data.naviapp.io', type: 'bard' }],
+      appPersistence: {
+        type: 'webservice',
+        uri: 'https://persistence.naviapp.io',
+        timeout: 90000,
+      },
+    },
   };
 
   if (environment === 'development') {

--- a/packages/notifications/tests/dummy/mirage/config.js
+++ b/packages/notifications/tests/dummy/mirage/config.js
@@ -1,0 +1,1 @@
+export default function () {}

--- a/packages/notifications/tsconfig.json
+++ b/packages/notifications/tsconfig.json
@@ -21,24 +21,17 @@
     "module": "es6",
     "experimentalDecorators": true,
     "paths": {
-      "dummy/tests/*": [ "tests/*" ],
-      "dummy/*": [ "tests/dummy/app/*", "app/*" ],
-      "navi-notifications": [ "addon" ],
-      "navi-notifications/*": [ "addon/*" ],
-      "navi-notifications/test-support": [ "addon-test-support" ],
-      "navi-notifications/test-support/*": [ "addon-test-support/*" ],
-      "navi-core": ["../core/addon"],
-      "navi-core/*": ["../core/addon/*"],
-      "ember-cli-flash/*": [ "node_modules/ember-cli-flash" ], //https://github.com/poteto/ember-cli-flash/issues/348
-      "*": [ "types/*" ],
+      "dummy/tests/*": ["tests/*"],
+      "dummy/*": ["tests/dummy/app/*", "app/*"],
+      "navi-notifications": ["addon"],
+      "navi-notifications/*": ["addon/*"],
+      "navi-notifications/test-support": ["addon-test-support"],
+      "navi-notifications/test-support/*": ["addon-test-support/*"],
+      "navi-core": ["node_modules/navi-core/addon"],
+      "navi-core/*": ["node_modules/navi-core/addon/*"],
+      "ember-cli-flash/*": ["node_modules/ember-cli-flash"], //https://github.com/poteto/ember-cli-flash/issues/348
+      "*": ["types/*"]
     }
   },
-  "include": [
-    "app/**/*",
-    "addon/**/*",
-    "tests/**/*",
-    "types/**/*",
-    "test-support/**/*",
-    "addon-test-support/**/*"
-  ]
+  "include": ["app/**/*", "addon/**/*", "tests/**/*", "types/**/*", "test-support/**/*", "addon-test-support/**/*"]
 }


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description
This PR adds navi-core as a devDep to notifications for its TS notification definition and refactors the tsconfig to fix the build:

```
 addon/components/navi-notifications/alert.ts:7:51 - error TS6059: File '/sd/workspace/src/github.com/yavin-dev/framework/packages/core/addon/services/interfaces/navi-notifications.ts' is not under 'rootDir' '/sd/workspace/src/github.com/yavin-dev/framework/packages/notifications'. 'rootDir' is expected to contain all source files.
```
https://cd.screwdriver.cd/pipelines/6102/builds/691308/steps/publish

## Proposed Changes

-

## Screenshots

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
