### PR TITLE
Update: Accept null for sortByField

### DIFF
--- a/packages/reports/addon/components/grouped-list.ts
+++ b/packages/reports/addon/components/grouped-list.ts
@@ -13,7 +13,7 @@ interface Args {
   shouldOpenAllGroups: boolean;
   containerSelector: string;
   groupByField: string;
-  sortByField?: string;
+  sortByField?: string | null;
 }
 
 export default class GroupedListComponent extends Component<Args> {
@@ -23,7 +23,8 @@ export default class GroupedListComponent extends Component<Args> {
   guid = guidFor(this);
 
   get groupedItems() {
-    const { items, groupByField, sortByField = '' } = this.args;
+    const { items, groupByField } = this.args;
+    const sortByField = this.args.sortByField || '';
 
     const grouped = groupBy(items, (row) => row[groupByField]?.split(',')[0] || `Uncategorized`);
 


### PR DESCRIPTION
## Description
Getting an error in the `app` repo where sortByField is being set to null so use a more forgiving type

## Proposed Changes
- accept null sortByField

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
