### PR TITLE
Set max size for filter selection box

### DIFF
--- a/packages/reports/app/styles/navi-reports/components/filter-collection.less
+++ b/packages/reports/app/styles/navi-reports/components/filter-collection.less
@@ -5,6 +5,7 @@
 
 @filter-collection-column-margin: 3px;
 @filter-collection-row-height: 30px;
+@filter-collection-max-row-height: 90px;
 @filter-collection-font-size: @font-size-base;
 
 .filter-collection {
@@ -18,6 +19,7 @@
   .ember-power-select-trigger {
     border-radius: 0;
     min-height: @filter-collection-row-height;
+    max-height: @filter-collection-max-row-height;
   }
 
   .ember-power-select-trigger-multiple-input {


### PR DESCRIPTION
## Description
The current design makes the dashboard filter box to expand and take over the screen as more values are added.
## Proposed Changes
Set a max height for the filter box. We will be able to scroll if more values are added.
-

## Screenshots
Before
<img width="1856" alt="Screen Shot 2021-04-06 at 6 30 50 PM" src="https://user-images.githubusercontent.com/24281432/113790356-d1c6d980-9706-11eb-9619-df495d44012d.png">
After
<img width="859" alt="Screen Shot 2021-04-06 at 6 33 49 PM" src="https://user-images.githubusercontent.com/24281432/113790365-d5f2f700-9706-11eb-8f9f-ed465b430d78.png">

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
