### PR TITLE
Update: Ember sortable should only use the drag handle

### DIFF
--- a/packages/data/tests/test-helper.ts
+++ b/packages/data/tests/test-helper.ts
@@ -1,12 +1,13 @@
 // @ts-ignore
-import Application from '../app';
-import config from '../config/environment';
+import Application from 'dummy/app';
+import config from 'dummy/config/environment';
+import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
+import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
-
 // Install types for qunit-dom
 import 'qunit-dom';
 
 setApplication(Application.create(config.APP));
-
+setup(QUnit.assert);
 start();

--- a/packages/reports/addon-test-support/column-config.ts
+++ b/packages/reports/addon-test-support/column-config.ts
@@ -1,0 +1,34 @@
+import { find, findAll, triggerEvent } from '@ember/test-helpers';
+import { assert } from '@ember/debug';
+//@ts-ignore
+import { drag } from 'ember-sortable/test-support/helpers/drag';
+//@ts-ignore
+import { getOffset } from 'ember-sortable/test-support/utils/offset';
+
+const OVERSHOOT = 3;
+const COLUMN_CONFIG_ITEM = 'navi-column-config-item';
+const COLUMN_CONFIG_HANDLE = `${COLUMN_CONFIG_ITEM}__handle`;
+
+/**
+ * Custom reorder helper for the column config because it requires a mouseenter in each item
+ * @param canonicalNames - list of canonical names in desired order
+ * @see https://github.com/adopted-ember-addons/ember-sortable/blob/526293454cf5073d603298fce33dffdaad2bafe2/addon-test-support/helpers/reorder.js#L33
+ */
+export async function reorderColumns(...canonicalNames: string[]) {
+  const selectors = canonicalNames.map((name) => `.${COLUMN_CONFIG_ITEM}[data-name="${name}"]`);
+  for (let targetIndex = 0; targetIndex < selectors.length; targetIndex++) {
+    const items = findAll(`.${COLUMN_CONFIG_ITEM}`);
+    const sourceElement = find(selectors[targetIndex]);
+    const targetElement = items[targetIndex];
+    const dx = getOffset(targetElement).left - OVERSHOOT - getOffset(sourceElement).left;
+    const dy = getOffset(targetElement).top - OVERSHOOT - getOffset(sourceElement).top;
+
+    assert('sourceElement exists', sourceElement);
+    await triggerEvent(sourceElement, 'mouseenter');
+    const sourceElementHandle = find(`${selectors[targetIndex]} .${COLUMN_CONFIG_HANDLE}`);
+    await drag('mouse', sourceElementHandle, () => {
+      return { dx: dx, dy: dy };
+    });
+    await triggerEvent(sourceElement, 'mouseleave');
+  }
+}

--- a/packages/reports/addon/components/navi-column-config/item.hbs
+++ b/packages/reports/addon/components/navi-column-config/item.hbs
@@ -6,7 +6,7 @@
   {{did-insert this.setupElement}}
   {{on "mouseenter" (fn (mut this.canDrag) true)}}
   {{on "mouseleave" (fn (mut this.canDrag) false)}}
-  {{sortable-item groupName="navi-column-config" model=@column}}
+  {{sortable-item groupName="navi-column-config" model=@column isDraggingDisabled=(not this.canDrag)}}
 >
   <div class="navi-column-config-item__header">
     <button

--- a/packages/reports/tests/acceptance/column-config-test.ts
+++ b/packages/reports/tests/acceptance/column-config-test.ts
@@ -9,8 +9,7 @@ import { clickItem } from 'navi-reports/test-support/report-builder';
 import { setupAnimationTest, animationsSettled } from 'ember-animated/test-support';
 //@ts-ignore
 import { selectChoose } from 'ember-power-select/test-support';
-//@ts-ignore
-import { reorder } from 'ember-sortable/test-support/helpers';
+import { reorderColumns } from 'navi-reports/test-support/column-config';
 
 function getColumns() {
   return findAll('.navi-column-config-item__name').map((el) => el.textContent?.trim());
@@ -446,7 +445,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   });
 
   test('reordering columns', async function (assert) {
-    assert.expect(1);
+    assert.expect(2);
     await visit('/reports/new');
 
     await clickItem('dimension', 'Date Time');
@@ -455,18 +454,17 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
     await clickItem('dimension', 'Browser');
     await animationsSettled();
 
-    await reorder(
-      'mouse',
-      '.navi-column-config-item',
-      '.navi-column-config-item[data-name="browser(field=id)"]',
-      '.navi-column-config-item[data-name="age(field=id)"]',
-      '.navi-column-config-item[data-name="revenue(currency=USD)"]',
-      '.navi-column-config-item[data-name="network.dateTime(grain=day)"]'
+    assert.deepEqual(
+      getColumns(),
+      ['Date Time (day)', 'Age (id)', 'Revenue (USD)', 'Browser (id)'],
+      'The columns are ordered as inserted'
     );
+
+    await reorderColumns('browser(field=id)', 'revenue(currency=USD)', 'age(field=id)', 'network.dateTime(grain=day)');
 
     assert.deepEqual(
       getColumns(),
-      ['Browser (id)', 'Age (id)', 'Revenue (USD)', 'Date Time (day)'],
+      ['Browser (id)', 'Revenue (USD)', 'Age (id)', 'Date Time (day)'],
       'The columns are reordered'
     );
   });


### PR DESCRIPTION
## Description
`ember-sortable` was using the whole element while the handle element was hidden making it sometimes impossible to rename a column

## Proposed Changes
- disable dragging when mouse is not in column

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
