### PR TITLE
Update: Export style cleanup

### DIFF
--- a/packages/reports/addon/components/report-actions/export.hbs
+++ b/packages/reports/addon/components/report-actions/export.hbs
@@ -1,4 +1,4 @@
 {{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file
 for terms. --}}
 {{yield (perform this.getDownloadURLTask)}}
-<div id="export__download-url"></div>
+<span id="export__download-url"></span>

--- a/packages/reports/addon/templates/components/report-actions.hbs
+++ b/packages/reports/addon/templates/components/report-actions.hbs
@@ -54,11 +54,10 @@
       {{#let (component "report-actions/multiple-format-export") as |ExportAction|}}
         <ExportAction
           class="report-actions__export-btn button is-text is-medium {{unless @model.validations.isTruelyValid "is-disabled"}}"
-          id="report-actions__export-btn"
           @report={{@model}}
           @disabled={{not @model.validations.isTruelyValid}}
         >
-          <DenaliIcon @icon="download" />
+          <DenaliIcon id="report-actions__export-btn" @icon="download" />
           Export
         </ExportAction>
       {{/let}}
@@ -71,6 +70,7 @@
           as |onClick|
         >
           <DenaliButton
+            id="report-actions__export-btn"
             @style="text"
             @size="medium"
             @icon="download"
@@ -84,7 +84,7 @@
       {{/let}}
     {{/if}}
   {{/let}}
-  <EmberTooltip class="report-actions__export-btn">
+  <EmberTooltip @targetId="report-actions__export-btn" class="report-actions__export-btn">
     {{if @model.request.validations.isTruelyValid "Export the report" "Run a valid report to enable export"}}
   </EmberTooltip>
 {{/if}}


### PR DESCRIPTION
## Description
The report action list started to wrap after the div element and the export tooltip was not in the correct place

## Proposed Changes
- `div` -> `span`
- add targetId for tooltip

## Screenshots
<img alt="report-action list" src="https://user-images.githubusercontent.com/12093492/116300361-6cde2c80-a764-11eb-8f2f-e50e7d74bb70.png" width="360px" /> <img alt="export tooltip" src="https://user-images.githubusercontent.com/12093492/116300358-6bacff80-a764-11eb-8b9e-25536866f369.png" width="300px" /> 


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
