### PR TITLE
Fix: Dimensions should obey sorting from service

### DIFF
--- a/packages/reports/addon/components/filter-values/dimension-select.js
+++ b/packages/reports/addon/components/filter-values/dimension-select.js
@@ -134,7 +134,6 @@ export default class DimensionSelectComponent extends Component {
     if (isNumericDimensionArray(dimensions)) {
       return sortBy(dimensions, [d => Number(d.option.value)]);
     }
-    console.log('odering by description');
     return sortBy(dimensions, ['option.description']);
   }
 

--- a/packages/reports/addon/components/filter-values/dimension-select.js
+++ b/packages/reports/addon/components/filter-values/dimension-select.js
@@ -58,7 +58,7 @@ export default class DimensionSelectComponent extends Component {
   /**
    * @property {BardDimensionArray} dimensionOptions - list of all dimension values
    */
-  @computed('dimensionName', 'searchTerm', 'filter.subject.source')
+  @computed('dimensionName', 'searchTerm', 'filter.subject.source', 'isSmallCardinality')
   get dimensionOptions() {
     if (this.searchTerm !== undefined) {
       return undefined; // we are searching, so only show search results
@@ -66,15 +66,22 @@ export default class DimensionSelectComponent extends Component {
 
     const dimensionName = get(this, 'dimensionName'),
       dimensionService = get(this, '_dimensionService'),
-      metadataService = get(this, '_metadataService'),
-      source = get(this, 'filter.subject.source'),
-      loadedDimension = metadataService.getById('dimension', dimensionName, source);
+      source = get(this, 'filter.subject.source');
 
-    if (dimensionName && loadedDimension?.cardinality === CARDINALITY_SIZES[0]) {
+    if (this.isSmallCardinality) {
       return dimensionService.all(dimensionName, { dataSourceName: source });
     }
 
     return undefined;
+  }
+
+  @computed('dimensionName', 'filter.subject.source')
+  get isSmallCardinality() {
+    const dimensionName = get(this, 'dimensionName'),
+      metadataService = get(this, '_metadataService'),
+      source = get(this, 'filter.subject.source'),
+      loadedDimension = metadataService.getById('dimension', dimensionName, source);
+    return dimensionName && loadedDimension?.cardinality === CARDINALITY_SIZES[0];
   }
 
   /**
@@ -120,9 +127,14 @@ export default class DimensionSelectComponent extends Component {
 
   @action
   sortValues(dimensions) {
+    //don't sort if searching on server
+    if (!this.isSmallCardinality) {
+      return dimensions;
+    }
     if (isNumericDimensionArray(dimensions)) {
       return sortBy(dimensions, [d => Number(d.option.value)]);
     }
+    console.log('odering by description');
     return sortBy(dimensions, ['option.description']);
   }
 


### PR DESCRIPTION
## Description

Issue where sortFn was messing with searchAPI sorting of results.

## Proposed Changes

- Obey sorting from dimensionService when cardinality is MEDIUM or above.
- Testing was fruitless because ordering of sortFn is done visually only and does not reflect in DOM. (matrix display magic).

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
