### PR TITLE
Fili Data source fixups

### DIFF
--- a/packages/data/addon/mirage/routes/bard-lite.ts
+++ b/packages/data/addon/mirage/routes/bard-lite.ts
@@ -17,7 +17,7 @@ import {
   parseHavings,
   parseMetrics,
 } from './bard-lite-parsers';
-import { getPeriodForGrain, Grain } from 'navi-data/utils/date';
+import { getPeriodForGrain } from 'navi-data/utils/date';
 import { GrainWithAll } from 'navi-data/serializers/metadata/bard';
 
 const API_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss.SSS';
@@ -176,7 +176,7 @@ export default function (
 
   this.get('/data/*path', function (_db, request) {
     faker.seed(request.url.length);
-    let [table, grain, ...dimensionPaths] = request.params.path.split('/') as [string, Grain] & string[];
+    let [table, grain, ...dimensionPaths] = request.params.path.split('/') as [string, GrainWithAll] & string[];
     const dimensions = dimensionPaths
       .filter((d) => d.length > 0)
       .sort()
@@ -194,6 +194,14 @@ export default function (
         {},
         {
           description: `Date time cannot have zero length intervals. ${start}/${end}.`,
+        }
+      );
+    } else if (grain === 'all' && !(moment(start).isValid() && moment(end).isValid())) {
+      return new Response(
+        400,
+        {},
+        {
+          description: `Invalid interval for 'all' grain.`,
         }
       );
     }

--- a/packages/data/tests/unit/services/navi-facts-bard-test.ts
+++ b/packages/data/tests/unit/services/navi-facts-bard-test.ts
@@ -1,0 +1,84 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+// @ts-ignore
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { taskFor } from 'ember-concurrency-ts';
+import type { Server } from 'miragejs';
+import type { RequestV2 } from 'navi-data/adapters/facts/interface';
+import type { TestContext as Context } from 'ember-test-helpers';
+import type NaviFactsService from 'navi-data/services/navi-facts';
+import type NaviMetadataService from 'navi-data/services/navi-metadata';
+import type { Grain } from 'navi-data/utils/date';
+
+interface TestContext extends Context {
+  service: NaviFactsService;
+  server: Server;
+}
+
+const EmptyRequest: RequestV2 = {
+  table: 'table1',
+  columns: [],
+  filters: [],
+  sorts: [],
+  limit: null,
+  requestVersion: '2.0',
+  dataSource: 'bardOne',
+};
+
+const allWithFilterGrain = (grain: Grain, values: string[]): RequestV2 => ({
+  ...EmptyRequest,
+  filters: [
+    {
+      type: 'timeDimension',
+      field: '.dateTime',
+      parameters: { grain },
+      operator: 'bet',
+      values,
+    },
+  ],
+});
+
+module('Unit | Service | Navi Facts - Bard', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function (this: TestContext) {
+    this.service = this.owner.lookup('service:navi-facts');
+    const metadataService = this.owner.lookup('service:navi-metadata') as NaviMetadataService;
+    await metadataService.loadMetadata({ dataSourceName: 'bardOne' });
+  });
+
+  test('fetch and catch error', async function (this: TestContext, assert) {
+    const request = allWithFilterGrain('day', ['P1D', 'current']);
+
+    await taskFor(this.service.fetch)
+      .perform(request, { dataSourceName: request.dataSource })
+      .catch((response) => {
+        assert.ok(true, 'A request error falls into the promise catch block');
+        assert.equal(
+          response.details[0],
+          "Invalid interval for 'all' grain.",
+          'Error is thrown for using macros with "all" grain'
+        );
+      });
+
+    const request2 = allWithFilterGrain('day', ['value1', 'value1']);
+    request2.columns = [
+      {
+        type: 'timeDimension',
+        field: '.dateTime',
+        parameters: { grain: 'day' },
+      },
+    ];
+
+    await taskFor(this.service.fetch)
+      .perform(request2, { dataSourceName: request2.dataSource })
+      .catch((response) => {
+        assert.equal(
+          response.details[0],
+          'Date time cannot have zero length intervals. value1/value1.',
+          'Error is thrown for using macros with "all" grain'
+        );
+      });
+  });
+});

--- a/packages/reports/tests/acceptance/column-config-test.ts
+++ b/packages/reports/tests/acceptance/column-config-test.ts
@@ -483,41 +483,6 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
     assert.dom('.filter-builder__subject').exists({ count: 3 }, 'Clicking the filter button again adds a new filter');
   });
 
-  test('adding, removing and changing - date time', async function (assert) {
-    assert.expect(7);
-    await visit('reports/1/edit');
-
-    assert.dom('.filter-builder__subject').hasText('Date Time day', 'Time grain is initially day');
-
-    await click('.navi-column-config-item__remove-icon'); // Remove Date Time (day)
-
-    assert.dom('.filter-builder__subject').hasText('Date Time hour', 'Deselecting day changes time grain to hour');
-    await animationsSettled();
-    assert.deepEqual(getColumns(), ['Property (id)', 'Ad Clicks', 'Nav Link Clicks'], 'Date Time is removed');
-
-    await clickItem('dimension', 'Date Time');
-    await animationsSettled();
-
-    assert
-      .dom('.filter-builder__subject')
-      .hasText('Date Time hour', 'Date time matches existing filter grain on the report');
-    assert.deepEqual(
-      getColumns(),
-      ['Property (id)', 'Ad Clicks', 'Nav Link Clicks', 'Date Time (hour)'],
-      'A Date Time (hour) column is added'
-    );
-    await selectChoose('.navi-column-config-item__parameter-trigger', 'Week');
-
-    assert
-      .dom('.filter-builder__subject')
-      .hasText('Date Time isoWeek', 'Choosing week changes timegrain from day to week');
-    assert.deepEqual(
-      getColumns(),
-      ['Property (id)', 'Ad Clicks', 'Nav Link Clicks', 'Date Time (isoWeek)'],
-      'Column is changed to Date Time (isoWeek)'
-    );
-  });
-
   test('adding - metrics', async function (assert) {
     await visit('/reports/new');
 

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -1642,54 +1642,6 @@ module('Acceptance | Navi Report', function (hooks) {
     assert.dom('.filter-builder__values').hasText(`The current day. (${today})`, 'The current day');
   });
 
-  test('Fili Datasource: Remove time column (all grain)', async function (assert) {
-    assert.expect(7);
-
-    await visit('/reports/1');
-
-    // select month grain
-    await click('.navi-column-config-item__trigger');
-    await selectChoose('.navi-column-config-item__parameter', 'Month');
-
-    await clickTrigger('.filter-values--date-range-input__low-value');
-    await click($('.ember-power-calendar-selector-month:contains(Jan)')[0]);
-
-    await clickTrigger('.filter-values--date-range-input__high-value');
-    await click($('.ember-power-calendar-selector-month:contains(May)')[0]);
-
-    assert
-      .dom('.filter-values--date-range-input__low-value input')
-      .hasValue('Jan 2015', 'The start date is month Jan 2015');
-    assert
-      .dom('.filter-values--date-range-input__high-value input')
-      .hasValue('May 2015', 'The end date is month May 2015');
-
-    // Remove date time group by
-    await click('.navi-column-config-item__remove-icon[aria-label="delete time-dimension Date Time (month)"]');
-    assert.dom('.filter-builder__subject').hasText('Date Time hour', 'The filter grain is set to the lowest grain');
-    // TODO: Better support for hour grain
-
-    assert
-      .dom('.filter-values--date-range-input__low-value input')
-      .hasValue('Jan 01, 2015', 'The start date is beginning of Jan, 2015');
-    assert
-      .dom('.filter-values--date-range-input__high-value input')
-      .hasValue('May 31, 2015', 'The end date is end of May, 2015');
-
-    await clickTrigger('.filter-values--date-range-input__high-value');
-    await click('.ember-power-calendar-day[data-date="2015-05-30"]');
-    assert
-      .dom('.filter-values--date-range-input__high-value input')
-      .hasValue('May 30, 2015', 'Calendar defaults "all" grain  to show the lowest grain which is day');
-
-    await click('.navi-report__run-btn');
-    assert.deepEqual(
-      findAll('li.table-header-cell').map((el) => el.textContent.trim()),
-      ['Property (id)', 'Ad Clicks', 'Nav Link Clicks'],
-      'The table is successfully queried with no Date Time group by because it supports the all grain'
-    );
-  });
-
   skip("Date picker advanced doesn't modify interval", async function (assert) {
     //TODO advanced date picker has been disabled
     assert.expect(6);


### PR DESCRIPTION
## Description
Fixes some behavior for fili datasources

## Proposed Changes
- when no dateTime column is present (all grain), any macros are converted to absolute dates using the filter's grain
- When removing the dateTime column (moving to all grain) no longer drop to the lowest time grain
- Updating the dateTime filter grain now also updates the column grain

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
