### PR TITLE
Update: Add displayName for server-generated-config

### DIFF
--- a/assets/server-generated-config.js
+++ b/assets/server-generated-config.js
@@ -1,11 +1,11 @@
 window.NAVI_APP = {
 	version: '1.0.0',
-  dataSources: [{ name: "default", uri: "https://www.naviapp.io/fact", type: "bard" }],
-  appPersistence: {
-    type: "elide",
-    uri: "https://www.naviapp.io/persistence",
-    timeout: 90000
-  },
-  user: 'navi_user',
-	FEATURES: {}
+	dataSources: [{ name: 'default', displayName: 'Default', uri: 'https://www.naviapp.io/fact', type: 'bard' }],
+	appPersistence: {
+		type: 'elide',
+		uri: 'https://www.naviapp.io/persistence',
+		timeout: 90000,
+	},
+	user: 'navi_user',
+	FEATURES: {},
 };


### PR DESCRIPTION
## Description
The server generated config does not define a displayName for the datasource

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
