### PR TITLE
New: header support in elide adapter

### DIFF
--- a/packages/data/addon/adapters/facts/elide.ts
+++ b/packages/data/addon/adapters/facts/elide.ts
@@ -264,9 +264,14 @@ export default class ElideFactsAdapter extends EmberObject implements NaviFactAd
     const asyncAfterSeconds = DEFAULT_ASYNC_AFTER_SECONDS;
     const id: string = options.requestId || v1();
     const dataSourceName = request.dataSource || options.dataSourceName;
+    const headers = options.customHeaders || {};
 
     // TODO: Add other options based on RequestOptions
-    const queryOptions = { mutation, variables: { id, query, asyncAfterSeconds }, context: { dataSourceName } };
+    const queryOptions = {
+      mutation,
+      variables: { id, query, asyncAfterSeconds },
+      context: { dataSourceName, headers },
+    };
     return this.apollo.mutate(queryOptions);
   }
 

--- a/packages/data/addon/adapters/metadata/elide.ts
+++ b/packages/data/addon/adapters/metadata/elide.ts
@@ -40,6 +40,7 @@ export default class ElideMetadataAdapter extends EmberObject implements NaviMet
       ...(isPresent(id) && { variables: { ids: [id] } }),
       context: {
         dataSourceName: options.dataSourceName,
+        headers: options.customHeaders,
       },
       ...options,
     };

--- a/packages/data/addon/adapters/metadata/interface.ts
+++ b/packages/data/addon/adapters/metadata/interface.ts
@@ -8,6 +8,7 @@ export type MetadataOptions = {
   clientId?: string;
   timeout?: number;
   dataSourceName?: string;
+  customHeaders?: Record<string, string>;
 };
 
 export default interface NaviMetadataAdapter {

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -389,6 +389,44 @@ module('Unit | Adapter | facts/elide', function (hooks) {
     assert.deepEqual(asyncQuery, response, 'createAsyncQuery returns the correct response payload');
   });
 
+  test('createAsyncQuery - header', async function (assert) {
+    assert.expect(2);
+    const adapter: ElideFactsAdapter = this.owner.lookup('adapter:facts/elide');
+
+    let response;
+    Server.post(HOST, function ({ requestBody, requestHeaders }) {
+      const requestObj = JSON.parse(requestBody);
+
+      assert.deepEqual(requestHeaders.Authentication, 'Bearer: abc-123', 'createAsyncQuery sends custom headers');
+
+      response = {
+        asyncQuery: {
+          edges: [
+            {
+              node: {
+                id: requestObj.variables.id,
+                query: requestObj.variables.query,
+                queryType: 'GRAPHQL_V1_0',
+                status: 'QUEUED',
+                result: null,
+              },
+            },
+          ],
+        },
+      };
+
+      return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: response })];
+    });
+
+    const asyncQuery = await adapter.createAsyncQuery(TestRequest, {
+      customHeaders: {
+        Authentication: 'Bearer: abc-123',
+      }
+    });
+
+    assert.deepEqual(asyncQuery, response, 'createAsyncQuery returns the correct response payload');
+  });
+
   test('createAsyncQuery - error', async function (assert) {
     assert.expect(1);
 

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -390,7 +390,7 @@ module('Unit | Adapter | facts/elide', function (hooks) {
   });
 
   test('createAsyncQuery - header', async function (assert) {
-    assert.expect(2);
+    assert.expect(1);
     const adapter: ElideFactsAdapter = this.owner.lookup('adapter:facts/elide');
 
     let response;
@@ -418,13 +418,11 @@ module('Unit | Adapter | facts/elide', function (hooks) {
       return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: response })];
     });
 
-    const asyncQuery = await adapter.createAsyncQuery(TestRequest, {
+    await adapter.createAsyncQuery(TestRequest, {
       customHeaders: {
         Authentication: 'Bearer abc-123',
       },
     });
-
-    assert.deepEqual(asyncQuery, response, 'createAsyncQuery returns the correct response payload');
   });
 
   test('createAsyncQuery - error', async function (assert) {

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -397,7 +397,7 @@ module('Unit | Adapter | facts/elide', function (hooks) {
     Server.post(HOST, function ({ requestBody, requestHeaders }) {
       const requestObj = JSON.parse(requestBody);
 
-      assert.deepEqual(requestHeaders.Authentication, 'Bearer: abc-123', 'createAsyncQuery sends custom headers');
+      assert.equal(requestHeaders.Authentication, 'Bearer abc-123', 'createAsyncQuery sends custom headers');
 
       response = {
         asyncQuery: {
@@ -420,8 +420,8 @@ module('Unit | Adapter | facts/elide', function (hooks) {
 
     const asyncQuery = await adapter.createAsyncQuery(TestRequest, {
       customHeaders: {
-        Authentication: 'Bearer: abc-123',
-      }
+        Authentication: 'Bearer abc-123',
+      },
     });
 
     assert.deepEqual(asyncQuery, response, 'createAsyncQuery returns the correct response payload');

--- a/packages/data/tests/unit/adapters/metadata/elide-test.ts
+++ b/packages/data/tests/unit/adapters/metadata/elide-test.ts
@@ -70,6 +70,23 @@ module('Unit | Adapter | metadata/elide', function (hooks) {
     await Adapter.fetchById('table', 'foo');
   });
 
+  test('fetchById - request headers', async function (this: MirageTestContext, assert) {
+    assert.expect(1);
+
+    this.server.post(
+      'https://data.naviapp.io',
+      (_schema: TODO, { requestHeaders }: { requestHeaders: Record<string, string> }) => {
+        assert.equal(requestHeaders.Authentication, 'Bearer abc-123', 'fetchById sends custom headers');
+        return [];
+      }
+    );
+    await Adapter.fetchById('table', 'foo', {
+      customHeaders: {
+        Authentication: 'Bearer abc-123',
+      },
+    });
+  });
+
   test('fetchAll - response', async function (this: MirageTestContext, assert) {
     assert.expect(6);
 


### PR DESCRIPTION
## Description

Add support for custom headers in the Elide adapters.

## Proposed Changes

- Added passthrough of headers in RequestOptions to Apollo
- Added passthrough of headers in MetadataOptions to Apollo

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
