### PR TITLE
Update: Remove defaultDataTable config option

### DIFF
--- a/packages/app/tests/acceptance/custom-reports-test.js
+++ b/packages/app/tests/acceptance/custom-reports-test.js
@@ -5,9 +5,11 @@ import { click, currentURL, find, visit } from '@ember/test-helpers';
 import { linkContains } from 'navi-core/test-support/contains-helpers';
 import { selectChoose } from 'ember-power-select/test-support';
 import { clickItemFilter } from 'navi-reports/test-support/report-builder';
+import { setupAnimationTest, animationsSettled } from 'ember-animated/test-support';
 
 module('Acceptance | custom reports', function (hooks) {
   setupApplicationTest(hooks);
+  setupAnimationTest(hooks);
   setupMirage(hooks);
 
   test('Viewing saved reports', async function (assert) {
@@ -45,6 +47,8 @@ module('Acceptance | custom reports', function (hooks) {
 
   test('Run report with a filter', async function (assert) {
     await visit('/reports/new');
+    await click('.report-builder-source-selector__source-button[data-source-name="Game Stats"]');
+    await animationsSettled();
 
     // Add filter
     await clickItemFilter('dimension', 'Character');

--- a/packages/dashboards/addon/routes/dashboards/dashboard/widgets/new.ts
+++ b/packages/dashboards/addon/routes/dashboards/dashboard/widgets/new.ts
@@ -22,18 +22,12 @@ export default class DashboardsDashboardWidgetsNewRoute extends ReportsNewRoute 
   protected async newModel() {
     const author = await this.user.findOrRegister();
     const defaultVisualization = this.naviVisualizations.defaultVisualization();
-    const table = await this.getDefaultTable();
     const dashboard = this.modelFor('dashboards.dashboard');
 
     const widget = this.store.createRecord('dashboard-widget', {
       author,
       dashboard,
-      requests: A([
-        this.store.createFragment('bard-request-v2/request', {
-          table: table?.id,
-          dataSource: table?.source,
-        }),
-      ]),
+      requests: A([this.store.createFragment('bard-request-v2/request', {})]),
       visualization: { type: defaultVisualization },
     });
 

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -8,11 +8,13 @@ import { Response } from 'ember-cli-mirage';
 import { selectChoose } from 'ember-power-select/test-support';
 import { clickItem } from 'navi-reports/test-support/report-builder';
 import $ from 'jquery';
+import { setupAnimationTest, animationsSettled } from 'ember-animated/test-support';
 
 let confirm;
 
 module('Acceptance | Dashboards', function (hooks) {
   setupApplicationTest(hooks);
+  setupAnimationTest(hooks);
   setupMirage(hooks);
 
   hooks.beforeEach(() => {
@@ -386,6 +388,8 @@ module('Acceptance | Dashboards', function (hooks) {
     // Create new widget
     await click('.dashboard-header__add-widget-btn');
     await click('.add-widget__new-btn');
+    await click('.report-builder-source-selector__source-button[data-source-name="Network"]');
+    await animationsSettled();
 
     // Fill out request
     await selectChoose('.filter-builder__operator-trigger', 'In The Past');
@@ -419,6 +423,8 @@ module('Acceptance | Dashboards', function (hooks) {
     // Create another new widget
     await click('.dashboard-header__add-widget-btn');
     await click('.add-widget__new-btn');
+    await click('.report-builder-source-selector__source-button[data-source-name="Network"]');
+    await animationsSettled();
 
     // Fill out request
     await selectChoose('.filter-builder__operator-trigger', 'In The Past');
@@ -506,6 +512,9 @@ module('Acceptance | Dashboards', function (hooks) {
 
     // Create widget
     await visit('/dashboards/1/widgets/new');
+    await animationsSettled();
+    await click('.report-builder-source-selector__source-button[data-source-name="Network"]');
+    await animationsSettled();
 
     // Build Request
     await selectChoose('.filter-builder__operator-trigger', 'In The Past');
@@ -692,6 +701,8 @@ module('Acceptance | Dashboards', function (hooks) {
     // Create new widget
     await click('.dashboard-header__add-widget-btn');
     await click('.add-widget__new-btn');
+    await click('.report-builder-source-selector__source-button[data-source-name="Network"]');
+    await animationsSettled();
 
     // Fill out request
     await selectChoose('.filter-builder__operator-trigger', 'In The Past');

--- a/packages/dashboards/tests/acceptance/explore-widget-test.js
+++ b/packages/dashboards/tests/acceptance/explore-widget-test.js
@@ -10,12 +10,14 @@ import { clickItem } from 'navi-reports/test-support/report-builder';
 import { selectChoose } from 'ember-power-select/test-support';
 import { triggerCopySuccess } from 'ember-cli-clipboard/test-support';
 import Service from '@ember/service';
+import { setupAnimationTest, animationsSettled } from 'ember-animated/test-support';
 
 // Regex to check that a string ends with "{uuid}/view"
 const TempIdRegex = /\/reports\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/view$/;
 
 module('Acceptance | Exploring Widgets', function (hooks) {
   setupApplicationTest(hooks);
+  setupAnimationTest(hooks);
   setupMirage(hooks);
 
   test('Widget title', async function (assert) {
@@ -223,6 +225,9 @@ module('Acceptance | Exploring Widgets', function (hooks) {
 
     /* == Unsaved widget == */
     await visit('/dashboards/1/widgets/new');
+    await click('.report-builder-source-selector__source-button[data-source-name="Network"]');
+    await animationsSettled();
+
     await clickItem('metric', 'Ad Clicks');
     await click('.navi-report-widget__run-btn');
 

--- a/packages/dashboards/tests/dummy/config/environment.js
+++ b/packages/dashboards/tests/dummy/config/environment.js
@@ -25,7 +25,6 @@ module.exports = function (environment) {
     navi: {
       user: 'navi_user',
       widgetsRequestsMaxConcurrency: 2,
-      defaultDataTable: 'network',
       dataSources: [
         {
           name: 'bardOne',

--- a/packages/dashboards/tests/unit/routes/dashboards/dashboard/widgets/new-test.js
+++ b/packages/dashboards/tests/unit/routes/dashboards/dashboard/widgets/new-test.js
@@ -1,16 +1,13 @@
-import { set } from '@ember/object';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { settled } from '@ember/test-helpers';
-import config from 'ember-get-config';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-const defaultDataTable = config.navi.defaultDataTable;
 const NEW_MODEL = {
   createdOn: null,
   requests: [
     {
-      table: 'tableA',
+      table: null,
       filters: [],
       columns: [],
       sorts: [],
@@ -53,13 +50,7 @@ module('Unit | Route | dashboards/dashboard/widgets/new', function (hooks) {
       },
     });
 
-    set(config, 'navi.defaultDataTable', 'tableA');
-
     await this.owner.lookup('service:navi-metadata').loadMetadata();
-  });
-
-  hooks.afterEach(function () {
-    set(config, 'navi.defaultDataTable', defaultDataTable);
   });
 
   test('model', async function (assert) {

--- a/packages/reports/addon/routes/reports/new.ts
+++ b/packages/reports/addon/routes/reports/new.ts
@@ -4,7 +4,6 @@
  */
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import config from 'ember-get-config';
 import type NaviNotificationsService from 'navi-core/services/interfaces/navi-notifications';
 import type NaviVisualizationsService from 'navi-reports/services/navi-visualizations';
 import type CompressionService from 'navi-core/services/compression';
@@ -12,7 +11,6 @@ import type NaviMetadataService from 'navi-data/services/navi-metadata';
 import type UserService from 'navi-core/services/user';
 import type { Transition } from 'navi-core/utils/type-utils';
 import type ReportModel from 'navi-core/models/report';
-import type TableMetadataModel from 'navi-data/models/metadata/table';
 import type { ReportLike } from 'navi-reports/routes/reports/report';
 
 export default class ReportsNewRoute extends Route {
@@ -55,27 +53,12 @@ export default class ReportsNewRoute extends Route {
   protected async newModel(): Promise<ReportLike> {
     const author = this.user.getUser();
     const defaultVisualization = this.naviVisualizations.defaultVisualization();
-    const table = await this.getDefaultTable();
 
     const report = this.store.createRecord('report', {
       author,
-      request: this.store.createFragment('bard-request-v2/request', {
-        table: table?.id,
-        dataSource: table?.source,
-      }),
+      request: this.store.createFragment('bard-request-v2/request', {}),
       visualization: { type: defaultVisualization },
     });
     return report;
-  }
-
-  /**
-   * Returns a default table model for new report
-   * @returns table model
-   */
-  async getDefaultTable(): Promise<TableMetadataModel | undefined> {
-    const { metadataService } = this;
-    await metadataService.loadMetadata();
-    const factTables = metadataService.all('table').filter((t) => t.isFact === true);
-    return factTables.find((t) => t.id === config.navi.defaultDataTable);
   }
 }

--- a/packages/reports/config/navi-config.d.ts
+++ b/packages/reports/config/navi-config.d.ts
@@ -2,7 +2,6 @@ declare module 'navi-config' {
   import { Grain } from 'navi-data/utils/date';
   export default interface NaviConfig {
     schedule?: { frequencies: string[]; formats: string[] };
-    defaultDataTable?: string;
     predefinedIntervalRanges: Record<Grain, string[] | undefined>;
   }
 }

--- a/packages/reports/tests/acceptance/column-config-test.ts
+++ b/packages/reports/tests/acceptance/column-config-test.ts
@@ -22,6 +22,12 @@ async function getRequestURL() {
   return new URL(url);
 }
 
+async function newReport() {
+  await visit('/reports/new');
+  await click('.report-builder-source-selector__source-button[data-source-name="Network"]');
+  await animationsSettled();
+}
+
 module('Acceptance | Navi Report | Column Config', function (hooks) {
   setupApplicationTest(hooks);
   setupAnimationTest(hooks);
@@ -41,7 +47,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   });
 
   test('Creating new report shows column config', async function (assert) {
-    await visit('/reports/new');
+    await newReport();
 
     assert.ok(currentURL().endsWith('/edit'), 'We are on the edit report route');
 
@@ -55,7 +61,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   });
 
   test('accordion behavior and highlighting last added item', async function (assert) {
-    await visit('/reports/new');
+    await newReport();
     assert.deepEqual(getColumns(), [], 'Initially no columns are present');
 
     //add Date Time
@@ -282,7 +288,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
   test('adding, removing and changing a sort', async function (assert) {
     assert.expect(6);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('dimension', 'Date Time');
     assert.deepEqual(
@@ -322,7 +328,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
   test('toggling a sort', async function (assert) {
     assert.expect(3);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('dimension', 'Date Time');
     assert.deepEqual(
@@ -348,7 +354,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
   test('reordering columns', async function (assert) {
     assert.expect(2);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('dimension', 'Date Time');
     await clickItem('dimension', 'Age');
@@ -373,7 +379,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
   test('clicking filter button always adds a new filter', async function (assert) {
     assert.expect(3);
-    await visit('/reports/new');
+    await newReport();
 
     assert.dom('.filter-builder__subject').exists({ count: 1 }, 'There is 1 filter to start');
     await clickItem('dimension', 'Age');
@@ -386,7 +392,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   });
 
   test('adding - metrics', async function (assert) {
-    await visit('/reports/new');
+    await newReport();
 
     assert.deepEqual(getColumns(), [], 'Initially there are no columns');
     await clickItem('metric', 'Ad Clicks');
@@ -403,7 +409,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
   test('removing - metrics from start and end', async function (assert) {
     assert.expect(3);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Ad Clicks');
     await clickItem('metric', 'Nav Link Clicks');
@@ -439,7 +445,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
   test('adding - dimensions', async function (assert) {
     assert.expect(3);
-    await visit('/reports/new');
+    await newReport();
 
     assert.deepEqual(getColumns(), [], 'Initially no columns are visible');
     await clickItem('dimension', 'Age');
@@ -456,7 +462,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
   test('removing - dimensions from start and end', async function (assert) {
     assert.expect(3);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('dimension', 'Age');
     await clickItem('dimension', 'Browser');
@@ -488,7 +494,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
   test('adding - metrics and dimensions', async function (assert) {
     assert.expect(2);
-    await visit('/reports/new');
+    await newReport();
 
     assert.deepEqual(getColumns(), [], 'Initially no columns are visible');
     await clickItem('dimension', 'Date Time');
@@ -508,7 +514,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
   skip('config - renaming - date time', async function (assert) {
     assert.expect(4);
-    await visit('/reports/new');
+    await newReport();
 
     assert.deepEqual(getColumns(), ['Date Time (Day)'], 'Initially only the date time is visible');
 
@@ -526,7 +532,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
   skip('config - renaming - metrics', async function (assert) {
     assert.expect(7);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Ad Clicks');
     await clickItem('metric', 'Nav Link Clicks');
@@ -573,7 +579,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
   skip('config - renaming - parameterized metrics', async function (assert) {
     assert.expect(7);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Platform Revenue');
     await clickItem('metric', 'button click count');
@@ -620,7 +626,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
   skip('config - renaming - dimensions', async function (assert) {
     assert.expect(7);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('dimension', 'Age');
     await clickItem('dimension', 'Browser');
@@ -658,7 +664,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   });
 
   test('config - parameters - metrics change first instance parameter', async function (assert) {
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Platform Revenue');
     await clickItem('metric', 'button click count');
@@ -682,7 +688,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   });
 
   test('config - parameters - metrics change last instance parameter', async function (assert) {
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Platform Revenue');
     await clickItem('metric', 'button click count');
@@ -705,7 +711,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   });
 
   test('config - clone - dimension', async function (assert) {
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('dimension', 'Age');
     await clickItem('dimension', 'Browser');
@@ -741,7 +747,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   });
 
   test('config - clone - metric', async function (assert) {
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Ad Clicks');
     await clickItem('metric', 'Nav Link Clicks');
@@ -781,7 +787,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   });
 
   test('config - clone - parameterized metric', async function (assert) {
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Platform Revenue');
     await clickItem('metric', 'Nav Link Clicks');
@@ -828,7 +834,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
   skip('config - duplicate columns - can configure multiple of the same base metrics', async function (assert) {
     assert.expect(2);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Ad Clicks');
     await clickItem('metric', 'Nav Link Clicks');
@@ -855,7 +861,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
   skip('config - duplicate columns - can configure multiple of the same base dimension', async function (assert) {
     assert.expect(2);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('dimension', 'Age');
     await clickItem('dimension', 'Browser');
@@ -879,7 +885,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   skip('config - filters - dimensions - expand on add', async function (assert) {
     //TODO update when filter updates are complete
     assert.expect(9);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('dimension', 'Age');
     await animationsSettled();
@@ -937,7 +943,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   skip('config - filters - metrics - expand on add', async function (assert) {
     //TODO update when filter updates are complete
     assert.expect(9);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Ad Clicks');
     await animationsSettled();
@@ -999,7 +1005,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   skip('config - filters - parameterized metrics - expand on add', async function (assert) {
     //TODO update when filter updates are complete
     assert.expect(10);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Platform Revenue');
     await animationsSettled();
@@ -1066,7 +1072,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   skip('config - filters - parameterized metrics - different parameters make different filters', async function (assert) {
     //TODO update when filter updates are complete
     assert.expect(10);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Platform Revenue');
     await clickItem('metric', 'Platform Revenue');
@@ -1136,7 +1142,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   skip('config - filters - metrics - stay collapsed on remove', async function (assert) {
     //TODO update when filter updates are complete
     assert.expect(4);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Ad Clicks');
     await animationsSettled();
@@ -1167,7 +1173,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   skip('config - filters - parameterized metrics - stay collapsed on remove', async function (assert) {
     //TODO update when filter updates are complete
     assert.expect(4);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Platform Revenue');
     await animationsSettled();
@@ -1198,7 +1204,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   skip('config - filters - dimensions - stay collapsed on remove', async function (assert) {
     //TODO update when filter updates are complete
     assert.expect(4);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('dimension', 'Age');
     await animationsSettled();
@@ -1227,7 +1233,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   });
 
   test('config - parameterized metric - search parameters', async function (assert) {
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Platform Revenue');
 
@@ -1260,7 +1266,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   skip('Sort gets removed when metric is removed', async function (assert) {
     //TODO update when table updates are complete
     assert.expect(6);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Platform Revenue');
 
@@ -1280,7 +1286,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
     assert.notOk(apiURL.searchParams.has('sort'), 'Sort is removed from request when metric is removed');
 
     //test param changing
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('metric', 'Platform Revenue');
 

--- a/packages/reports/tests/acceptance/dropdown-parameter-picker-test.ts
+++ b/packages/reports/tests/acceptance/dropdown-parameter-picker-test.ts
@@ -1,17 +1,22 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { findAll, visit } from '@ember/test-helpers';
+import { findAll, visit, click } from '@ember/test-helpers';
 //@ts-ignore
 import { setupMirage } from 'ember-cli-mirage/test-support';
 //@ts-ignore
 import { clickTrigger, selectChoose } from 'ember-power-select/test-support/helpers';
+//@ts-ignore
+import { setupAnimationTest, animationsSettled } from 'ember-animated/test-support';
 
 module('Acceptance | Dropdown Parameter Picker test', function (hooks) {
   setupApplicationTest(hooks);
+  setupAnimationTest(hooks);
   setupMirage(hooks);
 
   test('verify dropdown parameter picker', async function (assert) {
     await visit('/reports/new');
+    await click('.report-builder-source-selector__source-button[data-source-name="Network"]');
+    await animationsSettled();
 
     assert.dom('.dropdown-parameter-picker .chips').hasText('day', 'Date Time parameter is shown properly upon open');
 

--- a/packages/reports/tests/acceptance/fili-datasource-test.ts
+++ b/packages/reports/tests/acceptance/fili-datasource-test.ts
@@ -12,6 +12,12 @@ import { selectChoose } from 'ember-power-select/test-support';
 import { clickItem } from 'navi-reports/test-support/report-builder';
 import { capitalize } from '@ember/string';
 
+async function newReport() {
+  await visit('/reports/new');
+  await click('.report-builder-source-selector__source-button[data-source-name="Network"]');
+  await animationsSettled();
+}
+
 module('Acceptance | fili datasource', function (hooks) {
   setupApplicationTest(hooks);
   setupAnimationTest(hooks);
@@ -82,7 +88,7 @@ module('Acceptance | fili datasource', function (hooks) {
   test('Fili Required filters on new report', async function (assert) {
     assert.expect(5);
 
-    await visit('/reports/new');
+    await newReport();
 
     assert.dom('.report-builder-sidebar__source').hasText('Network', 'A fili table is selected');
 
@@ -99,7 +105,7 @@ module('Acceptance | fili datasource', function (hooks) {
   test('Fili Required filters when changing table', async function (assert) {
     assert.expect(2);
 
-    await visit('/reports/new');
+    await newReport();
     await click('.report-builder-sidebar__breadcrumb-item[data-level="1"]');
     await click('.report-builder-source-selector__source-button[data-source-name="Table A"]');
     await animationsSettled();
@@ -111,7 +117,7 @@ module('Acceptance | fili datasource', function (hooks) {
   test('Fili Required filters when changing table without all grain', async function (assert) {
     assert.expect(4);
 
-    await visit('/reports/new');
+    await newReport();
     await click('.report-builder-sidebar__breadcrumb-item[data-level="1"]');
     await click('.report-builder-source-selector__source-button[data-source-name="Table C"]');
     await animationsSettled();
@@ -128,7 +134,7 @@ module('Acceptance | fili datasource', function (hooks) {
   test('Fili supports since and before operators', async function (assert) {
     assert.expect(2);
 
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('dimension', 'Date Time');
     await selectChoose('.navi-column-config-item__parameter', 'Year');
@@ -148,7 +154,7 @@ module('Acceptance | fili datasource', function (hooks) {
 
   test('Fili Dimension sorting disabled', async function (assert) {
     assert.expect(4);
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('dimension', 'Date Time');
     assert

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -23,6 +23,12 @@ const PersistedIdRegex = /\/\d+\/view$/;
 
 let CompressionService;
 
+async function newReport() {
+  await visit('/reports/new');
+  await click('.report-builder-source-selector__source-button[data-source-name="Network"]');
+  await animationsSettled();
+}
+
 module('Acceptance | Navi Report', function (hooks) {
   setupApplicationTest(hooks);
   setupAnimationTest(hooks);
@@ -103,7 +109,7 @@ module('Acceptance | Navi Report', function (hooks) {
     assert.expect(4);
     let originalFlag = config.navi.FEATURES.exportFileTypes;
     config.navi.FEATURES.exportFileTypes = ['csv', 'png'];
-    await visit('/reports/new');
+    await newReport();
 
     /* == Add filter == */
     await clickItemFilter('dimension', 'Operating System');
@@ -146,7 +152,7 @@ module('Acceptance | Navi Report', function (hooks) {
   test('New report - copy api', async function (assert) {
     assert.expect(3);
 
-    await visit('/reports/new');
+    await newReport();
     await clickItem('metric', 'Ad Clicks');
 
     //add date-dimension
@@ -225,7 +231,7 @@ module('Acceptance | Navi Report', function (hooks) {
   test('Revert changes - new report', async function (assert) {
     assert.expect(2);
 
-    await visit('/reports/new');
+    await newReport();
 
     assert.dom('.navi-report__revert-btn').isNotVisible('Revert changes button is not initially visible');
 
@@ -240,7 +246,7 @@ module('Acceptance | Navi Report', function (hooks) {
     assert.expect(4);
 
     await visit('/reports');
-    await visit('/reports/new');
+    await newReport();
 
     await clickItem('dimension', 'Date Time');
     await selectChoose('.navi-column-config-item__parameter-trigger', 'Day');
@@ -298,7 +304,7 @@ module('Acceptance | Navi Report', function (hooks) {
     assert.expect(6);
 
     await visit('/reports');
-    await visit('/reports/new');
+    await newReport();
 
     //Add a metrics and save the report
     await clickItem('dimension', 'Date Time');
@@ -476,7 +482,7 @@ module('Acceptance | Navi Report', function (hooks) {
     assert.expect(4);
 
     await visit('/reports');
-    await visit('/reports/new');
+    await newReport();
 
     assert.dom('.navi-report__save-btn').isVisible('Save button is visible in the new route');
 
@@ -848,7 +854,7 @@ module('Acceptance | Navi Report', function (hooks) {
     assert.expect(4);
 
     // Delete is not Disabled on new
-    await visit('/reports/new');
+    await newReport();
 
     assert
       .dom('.report-actions__delete-btn')
@@ -1090,7 +1096,7 @@ module('Acceptance | Navi Report', function (hooks) {
 
     /* == Create report == */
     await visit('/reports');
-    await visit('/reports/new');
+    await newReport();
     await clickItem('metric', 'Ad Clicks');
     await clickItem('dimension', 'Date Time');
     await selectChoose('.navi-column-config-item__parameter-trigger', 'Day');
@@ -1376,7 +1382,7 @@ module('Acceptance | Navi Report', function (hooks) {
   skip('Running a report against unauthorized table shows unauthorized route', async function (assert) {
     //build-data issues
     assert.expect(5);
-    await visit('/reports/new');
+    await newReport();
 
     await click('.report-builder-sidebar__breadcrumb-item[data-level="1"]');
     await click('.report-builder-source-selector__source-button[data-source-name="Protected Table"]');
@@ -1695,7 +1701,7 @@ module('Acceptance | Navi Report', function (hooks) {
     assert.expect(2);
     let option;
     const dropdownSelector = '.filter-values--dimension-select__trigger';
-    await visit('/reports/new');
+    await newReport();
 
     // Load table A as it has the large cardinality dimensions, and choose a large cardinality dimension
     await click('.report-builder-sidebar__breadcrumb-item[data-level="1"]');
@@ -1738,7 +1744,7 @@ module('Acceptance | Navi Report', function (hooks) {
   });
 
   test('dimension select filter works with dimension ids containing commas', async function (assert) {
-    await visit('/reports/new');
+    await newReport();
     await clickItemFilter('dimension', 'Dimension with comma');
 
     await selectChoose('.filter-values--dimension-select__trigger', 'no');

--- a/packages/reports/tests/dummy/config/environment.js
+++ b/packages/reports/tests/dummy/config/environment.js
@@ -33,7 +33,6 @@ module.exports = function (environment) {
     navi: {
       user: 'navi_user',
       defaultTimeGrain: 'day',
-      defaultDataTable: 'network',
       dataSources: [
         {
           name: 'bardOne',

--- a/packages/reports/tests/unit/routes/reports/new-test.ts
+++ b/packages/reports/tests/unit/routes/reports/new-test.ts
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import config from 'ember-get-config';
 //@ts-ignore
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
@@ -18,7 +17,7 @@ const NEW_MODEL = {
     limit: null,
     requestVersion: '2.0',
     sorts: [],
-    table: 'network',
+    table: null,
   },
   title: 'Untitled Report',
   updatedOn: null,
@@ -82,19 +81,5 @@ module('Unit | Route | reports/new', function (hooks) {
           'When modelString fails to deserialize, a rejected promise is returned'
         )
       );
-  });
-
-  test('getDefaultTable', async function (assert) {
-    const route = this.owner.lookup('route:reports/new');
-    let table = await route.getDefaultTable();
-    assert.deepEqual(table.id, 'network', 'Return table based on alphabetical order if default config not specified');
-
-    const defaultDataTable = config.navi.defaultDataTable;
-
-    config.navi.defaultDataTable = 'tableA';
-    table = await route.getDefaultTable();
-    assert.equal(table.id, 'tableA', 'Return default table');
-
-    config.navi.defaultDataTable = defaultDataTable;
   });
 });


### PR DESCRIPTION
## Description
The `defaultDataTable` flag is currently not very useful because it would require loading all tables from all sources and does not guarantee there is a unique table with the given name

## Proposed Changes
- Removes the `defaultDataTable` config option

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
