### PR TITLE
Fix: Use options fetching metricFn from everything

### DIFF
--- a/packages/data/addon/adapters/metadata/bard.ts
+++ b/packages/data/addon/adapters/metadata/bard.ts
@@ -68,7 +68,7 @@ export default class BardMetadataAdapter extends EmberObject implements NaviMeta
 
   async fetchEverything(options?: MetadataOptions): Promise<TODO> {
     const fullViewReq = this.query('table', '', { query: { format: 'fullview' }, ...options });
-    const metricFunctionsReq = this.fetchAll('columnFunction');
+    const metricFunctionsReq = this.fetchAll('columnFunction', options);
     const [{ tables }, metricFunctions] = await Promise.all([fullViewReq, metricFunctionsReq]);
     return { tables, metricFunctions };
   }


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description

## Proposed Changes

- When fetching a non default bard datasource metadata, default datasource metric functions where being fetched. This PR fixes that.

## Screenshots

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
