### PR TITLE
Fix: Delete widget button didn't show modal

### DIFF
--- a/packages/dashboards/addon/templates/components/navi-widget.hbs
+++ b/packages/dashboards/addon/templates/components/navi-widget.hbs
@@ -37,12 +37,14 @@
           class="link"
           @model={{@model}}
           @deleteAction={{route-action "deleteWidget"}}
+          as |showDeleteModal|
         >
           <DenaliIcon 
             id="navi-widget__delete-btn-{{@index}}" 
             @size="small" 
             @icon="trash" 
-            class="navi-widget__delete-btn link" 
+            class="navi-widget__delete-btn link"
+            {{on "click" showDeleteModal}}
           />
           <EmberTooltip @popperContainer="body" @text="Delete" @targetId="navi-widget__delete-btn-{{@index}}" />
         </CommonActions::Delete>

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -287,6 +287,25 @@ module('Acceptance | Dashboards', function (hooks) {
     );
   });
 
+  test('Delete a widget', async function (assert) {
+    await visit('/dashboards/2');
+
+    assert.deepEqual(
+      findAll('.navi-widget__title').map((el) => el.textContent.trim()),
+      ['Clicks', 'Last Week By OS'],
+      'The widgets are shown'
+    );
+
+    await click('.navi-widget__delete-btn');
+    await click('.delete__modal-delete-btn');
+
+    assert.deepEqual(
+      findAll('.navi-widget__title').map((el) => el.textContent.trim()),
+      ['Last Week By OS'],
+      'The widget is deleted'
+    );
+  });
+
   test('favorite dashboards', async function (assert) {
     assert.expect(2);
 

--- a/packages/dashboards/tests/integration/components/navi-widget-test.js
+++ b/packages/dashboards/tests/integration/components/navi-widget-test.js
@@ -3,7 +3,7 @@ import Component from '@ember/component';
 import { helper as buildHelper } from '@ember/component/helper';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, triggerEvent } from '@ember/test-helpers';
+import { render, click, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { assertTooltipContent } from 'ember-tooltips/test-support';
 import { ForbiddenError } from 'ember-ajax/errors';
@@ -22,7 +22,7 @@ module('Integration | Component | navi widget', function (hooks) {
   hooks.beforeEach(function () {
     this.owner.register(
       'helper:route-action',
-      buildHelper(() => undefined),
+      buildHelper(() => () => undefined),
       {
         instantiate: false,
       }
@@ -179,8 +179,6 @@ module('Integration | Component | navi widget', function (hooks) {
   });
 
   test('delete action visibility', async function (assert) {
-    assert.expect(2);
-
     this.set('widgetModel', WIDGET);
 
     await render(hbs`
@@ -192,6 +190,10 @@ module('Integration | Component | navi widget', function (hooks) {
 
     this.set('canEdit', true);
     assert.dom('.navi-widget__delete-btn').isVisible('Delete action is visible when user can edit');
+
+    await click('.navi-widget__delete-btn');
+    assert.dom('.delete__modal').exists('The delete modal is shown');
+    await click('.modal-container .close');
 
     this.set('canEdit', false);
     assert.dom('.navi-widget__delete-btn').isNotVisible('Delete action is hidden when user can not edit');


### PR DESCRIPTION
## Description
The delete button for dashboard widgets was not wired up to show the modal on click

## Proposed Changes
- add on click listener and tests

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
