### PR TITLE
New: Add total/subtotal mock support

### DIFF
--- a/packages/data/addon/mirage/routes/bard-lite.js
+++ b/packages/data/addon/mirage/routes/bard-lite.js
@@ -274,7 +274,6 @@ export default function(
           let groupedRow = Object.values(groupBy(row, dim === 'dateTime' ? dim : `${dim}|id`));
           groupedRow = groupedRow.reduce((aggAcc, aggRow) => {
             const subtotalRow = aggRow.reduce((acc, row) => {
-              console.log(row, 'row');
               if (row.__rollupMask !== getMask(['dateTime', ...dimensions])) {
                 //subtotal row, skip
                 return acc;
@@ -298,7 +297,6 @@ export default function(
               });
 
               const nullDims = difference(['dateTime', ...dimensions], [...processedDims, dim]);
-              console.log(nullDims, [...processedDims, dim], dimensions);
               nullDims.forEach(nullDim => {
                 if (nullDim === 'dateTime') {
                   acc.dateTime = null;

--- a/packages/data/addon/mirage/routes/bard-lite.js
+++ b/packages/data/addon/mirage/routes/bard-lite.js
@@ -279,20 +279,15 @@ export default function(
                 //subtotal row, skip
                 return acc;
               }
-              processedDims.forEach(prevDim => {
-                if (prevDim === 'dateTime') {
+              const presentDims = [...processedDims, dim];
+              presentDims.forEach(dim => {
+                if (dim === 'dateTime') {
                   acc.dateTime = row.dateTime;
                 } else {
-                  acc[`${prevDim}|id`] = row[`${prevDim}|id`];
-                  acc[`${prevDim}|desc`] = row[`${prevDim}|desc`];
+                  acc[`${dim}|id`] = row[`${dim}|id`];
+                  acc[`${dim}|desc`] = row[`${dim}|desc`];
                 }
               });
-              if (dim === 'dateTime') {
-                acc.dateTime = row.dateTime;
-              } else {
-                acc[`${dim}|id`] = row[`${dim}|id`];
-                acc[`${dim}|desc`] = row[`${dim}|desc`];
-              }
 
               if (hasRollUpDim) {
                 acc.__rollupMask = getMask([...processedDims, dim]);

--- a/packages/data/addon/mirage/routes/bard-lite.js
+++ b/packages/data/addon/mirage/routes/bard-lite.js
@@ -268,6 +268,12 @@ export default function(
           }
           return acc;
         }, null);
+      } else {
+        rows = rows.map(row => {
+          if (hasRollUpDim) {
+            row.__rollupMask = fullMask;
+          }
+        });
       }
 
       rollupDimensions.forEach(dim => {

--- a/packages/data/addon/mirage/routes/bard-lite.js
+++ b/packages/data/addon/mirage/routes/bard-lite.js
@@ -246,6 +246,7 @@ export default function(
         const flagMap = rollupDimensionMask.map(rolledDim => (rolledupDims.includes(rolledDim) ? 1 : 0));
         return parseInt(flagMap.join(''), 2);
       };
+      const fullMask = getMask(['dateTime', ...dimensions]);
       let grandTotalRow;
 
       if (request.queryParams.rollupGrandTotal) {
@@ -263,7 +264,7 @@ export default function(
           });
 
           if (hasRollUpDim) {
-            row.__rollupMask = getMask(['dateTime', ...dimensions]);
+            row.__rollupMask = fullMask;
           }
           return acc;
         }, null);
@@ -274,16 +275,24 @@ export default function(
           let groupedRow = Object.values(groupBy(row, dim === 'dateTime' ? dim : `${dim}|id`));
           groupedRow = groupedRow.reduce((aggAcc, aggRow) => {
             const subtotalRow = aggRow.reduce((acc, row) => {
-              if (row.__rollupMask !== getMask(['dateTime', ...dimensions])) {
+              if (row.__rollupMask !== fullMask) {
                 //subtotal row, skip
                 return acc;
               }
               processedDims.forEach(prevDim => {
-                acc[`${prevDim}|id`] = row[`${prevDim}|id`];
-                acc[`${prevDim}|desc`] = row[`${prevDim}|desc`];
+                if (prevDim === 'dateTime') {
+                  acc.dateTime = row.dateTime;
+                } else {
+                  acc[`${prevDim}|id`] = row[`${prevDim}|id`];
+                  acc[`${prevDim}|desc`] = row[`${prevDim}|desc`];
+                }
               });
-              acc[`${dim}|id`] = row[`${dim}|id`];
-              acc[`${dim}|desc`] = row[`${dim}|desc`];
+              if (dim === 'dateTime') {
+                acc.dateTime = row.dateTime;
+              } else {
+                acc[`${dim}|id`] = row[`${dim}|id`];
+                acc[`${dim}|desc`] = row[`${dim}|desc`];
+              }
 
               if (hasRollUpDim) {
                 acc.__rollupMask = getMask([...processedDims, dim]);
@@ -307,6 +316,7 @@ export default function(
               });
               return acc;
             }, {});
+
             if (Object.keys(subtotalRow).length > 0) {
               aggAcc.push([...aggRow, subtotalRow]);
             } else {


### PR DESCRIPTION
## Description

Adds subtotal/total mock to bard-lite

## Proposed Changes

- Post process the mock rows so that it groups by each requested rollup dimension, adding a subtotal row to each group via reduce. Then flattening the final row set.
- Verified with bard team. 

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
