### PR TITLE
Rollup dim toggle UI

### DIFF
--- a/packages/core/addon/models/bard-request/fragments/dimension.js
+++ b/packages/core/addon/models/bard-request/fragments/dimension.js
@@ -1,11 +1,12 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
 import DS from 'ember-data';
 import Fragment from 'ember-data-model-fragments/fragment';
 import { validator, buildValidations } from 'ember-cp-validations';
+import { Copyable } from 'ember-copy';
 
 const Validations = buildValidations({
   dimension: validator('presence', {
@@ -14,6 +15,11 @@ const Validations = buildValidations({
   })
 });
 
-export default Fragment.extend(Validations, {
-  dimension: DS.attr('dimension')
+export default Fragment.extend(Validations, Copyable, {
+  dimension: DS.attr('dimension'),
+  copy() {
+    return this.store.createFragment('bard-request/fragments/dimension', {
+      dimension: this.dimension
+    });
+  }
 });

--- a/packages/reports/addon/components/navi-column-config/base.hbs
+++ b/packages/reports/addon/components/navi-column-config/base.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class="navi-column-config-base" ...attributes>
   <div class="navi-column-config-base__body">
   <div class="navi-column-config-base__option navi-column-config-base-type">
@@ -7,6 +7,13 @@
       <span class="navi-column-config-base__header-icons">
         {{!-- TODO: Favorites are not supported yet --}}
         {{!-- <NaviIcon @icon="star-o" class="navi-column-config-base__star-icon" role="button" /> --}}
+        {{#if (and (not-eq @column.type "metric") (feature-flag "enableFiliTotals"))}}
+          <NaviIcon @icon="calculator"
+            class="navi-column-config-base__rollup-icon {{if @column.isRollup "navi-column-config-base__rollup-icon--active"}}"
+            role="button"
+            {{on "click" @toggleRollup}}
+          />
+        {{/if}}
         <NaviIcon @icon="clone"
           class="navi-column-config-base__clone-icon {{if (eq @column.name "dateTime") "navi-column-config-base__clone-icon--disabled"}}"
           role="button"

--- a/packages/reports/addon/components/navi-column-config/base.hbs
+++ b/packages/reports/addon/components/navi-column-config/base.hbs
@@ -12,7 +12,11 @@
             class="navi-column-config-base__rollup-icon {{if @column.isRollup "navi-column-config-base__rollup-icon--active"}}"
             role="button"
             {{on "click" @toggleRollup}}
-          />
+          >
+            <EmberTooltip>
+              Click to {{if @column.isRollup 'Remove' 'Add'}} subtotal rows based on this column.
+            </EmberTooltip>
+          </NaviIcon>
         {{/if}}
         <NaviIcon @icon="clone"
           class="navi-column-config-base__clone-icon {{if (eq @column.name "dateTime") "navi-column-config-base__clone-icon--disabled"}}"

--- a/packages/reports/addon/templates/components/navi-column-config.hbs
+++ b/packages/reports/addon/templates/components/navi-column-config.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <AnimatedContainer class="navi-column-config" ...attributes
   {{did-insert this.setupElement}}
   {{did-update this.openDefaultColumn this.columns}}>
@@ -16,6 +16,7 @@
             @onRemoveColumn={{fn this.removeColumn column}}
             @cloneColumn={{fn this.cloneColumn column}}
             @toggleColumnFilter={{fn this.toggleColumnFilter column}}
+            @toggleRollup={{fn this.toggleRollup column}}
           />
         {{/each}}
       </ul>

--- a/packages/reports/addon/templates/components/navi-column-config/item.hbs
+++ b/packages/reports/addon/templates/components/navi-column-config/item.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <li
   class="navi-column-config-item navi-column-config-item--{{dasherize @column.type}} {{if @isOpen "navi-column-config-item--open"}}"
   data-name={{@column.name}}
@@ -37,6 +37,7 @@
       @metadata={{@visualization.metadata}}
       @cloneColumn={{@cloneColumn}}
       @toggleColumnFilter={{@toggleColumnFilter}}
+      @toggleRollup={{@toggleRollup}}
       @onUpdateColumnName={{this.updateColumnName}}
     />
   {{/if}}

--- a/packages/reports/addon/templates/reports/report.hbs
+++ b/packages/reports/addon/templates/reports/report.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class="navi-report">
   <div class="navi-report__breadcrumb">
     {{#if (feature-flag "enableDirectory")}}
@@ -69,6 +69,8 @@
           @onToggleDimFilter={{update-report-action "TOGGLE_DIM_FILTER"}}
           @onToggleMetricFilter={{update-report-action "TOGGLE_METRIC_FILTER"}}
           @onToggleParameterizedMetricFilter={{update-report-action "TOGGLE_PARAMETERIZED_METRIC_FILTER"}}
+          @onPushRollup={{update-report-action "PUSH_ROLLUP_COLUMN"}}
+          @onRemoveRollup={{update-report-action "REMOVE_ROLLUP_COLUMN"}}
         />
 
         <div class="report-view__columns-toggle">

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config/base.less
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config/base.less
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -52,8 +52,27 @@
 
   &__clone-icon,
   &__filter-icon,
-  &__star-icon {
+  &__star-icon,
+  &__rollup-icon {
     .navi-column-config-icon;
     margin: 0 4px;
+  }
+
+  &__rollup-icon {
+    border-radius: 5px;
+    color: @denali-brand-700;
+    padding: 5px;
+    background-color: transparent;
+    &:hover {
+      color: @denali-brand-600;
+    }
+    &--active {
+      color: white;
+      background-color: @denali-brand-700;
+      &:hover {
+        color: white;
+        background-color: @denali-brand-600;
+      }
+    }
   }
 }

--- a/packages/reports/tests/acceptance/column-config-test.js
+++ b/packages/reports/tests/acceptance/column-config-test.js
@@ -1395,6 +1395,54 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     assert.notOk(apiURL.searchParams.has('sort'), 'Sort is removed from request when metric params changed');
   });
 
+  test('Rollup test', async function(assert) {
+    assert.expect(4);
+    const OG = config.navi.FEATURES.enableFiliTotals;
+    config.navi.FEATURES.enableFiliTotals = true;
+    await visit('/reports/1/view');
+    let apiURL = await getRequestURL();
+    assert.equal(
+      apiURL.href,
+      'https://data.naviapp.io/v1/data/network/day/property/?dateTime=2015-11-09%2000%3A00%3A00.000%2F2015-11-16%2000%3A00%3A00.000&metrics=adClicks%2CnavClicks&sort=navClicks%7Casc&format=json',
+      'Default query with no rollup'
+    );
+
+    await click('span[title="Date Time (Day)"');
+    await click('.navi-column-config-base__rollup-icon');
+
+    apiURL = await getRequestURL();
+    assert.equal(
+      apiURL.href,
+      'https://data.naviapp.io/v1/data/network/day/property/__rollupMask/?dateTime=2015-11-09%2000%3A00%3A00.000%2F2015-11-16%2000%3A00%3A00.000&metrics=adClicks%2CnavClicks&sort=navClicks%7Casc&rollupTo=dateTime&format=json',
+      'Datetime rollup added to query'
+    );
+
+    await click('span[title="Date Time (Day)"');
+    await click('span[title="Property"');
+    await click('.navi-column-config-base__rollup-icon');
+
+    apiURL = await getRequestURL();
+    assert.equal(
+      apiURL.href,
+      'https://data.naviapp.io/v1/data/network/day/property/__rollupMask/?dateTime=2015-11-09%2000%3A00%3A00.000%2F2015-11-16%2000%3A00%3A00.000&metrics=adClicks%2CnavClicks&sort=navClicks%7Casc&rollupTo=dateTime%2Cproperty&format=json',
+      'Property rollup added to query'
+    );
+
+    await click('.navi-column-config-base__rollup-icon');
+    await click('span[title="Property"');
+    await click('span[title="Date Time (Day)"');
+    await click('.navi-column-config-base__rollup-icon');
+
+    apiURL = await getRequestURL();
+    assert.equal(
+      apiURL.href,
+      'https://data.naviapp.io/v1/data/network/day/property/?dateTime=2015-11-09%2000%3A00%3A00.000%2F2015-11-16%2000%3A00%3A00.000&metrics=adClicks%2CnavClicks&sort=navClicks%7Casc&format=json',
+      'Rollup removed from query after toggling off both dimensions'
+    );
+
+    config.navi.FEATURES.enableFiliTotals = OG;
+  });
+
   function getColumns() {
     return findAll('.navi-column-config-item__name').map(el => el.textContent.trim());
   }

--- a/packages/reports/tests/acceptance/column-config-test.js
+++ b/packages/reports/tests/acceptance/column-config-test.js
@@ -1407,7 +1407,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       'Default query with no rollup'
     );
 
-    await click('span[title="Date Time (Day)"');
+    await click('span[title="Date Time (Day)"]');
     await click('.navi-column-config-base__rollup-icon');
 
     apiURL = await getRequestURL();
@@ -1417,7 +1417,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
       'Datetime rollup added to query'
     );
 
-    await click('span[title="Date Time (Day)"');
+    await click('span[title="Date Time (Day)"]');
     await click('span[title="Property"');
     await click('.navi-column-config-base__rollup-icon');
 
@@ -1430,7 +1430,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
 
     await click('.navi-column-config-base__rollup-icon');
     await click('span[title="Property"');
-    await click('span[title="Date Time (Day)"');
+    await click('span[title="Date Time (Day)"]');
     await click('.navi-column-config-base__rollup-icon');
 
     apiURL = await getRequestURL();

--- a/packages/reports/tests/acceptance/column-config-test.js
+++ b/packages/reports/tests/acceptance/column-config-test.js
@@ -1418,7 +1418,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     );
 
     await click('span[title="Date Time (Day)"]');
-    await click('span[title="Property"');
+    await click('span[title="Property"]');
     await click('.navi-column-config-base__rollup-icon');
 
     apiURL = await getRequestURL();
@@ -1429,7 +1429,7 @@ module('Acceptance | Navi Report | Column Config', function(hooks) {
     );
 
     await click('.navi-column-config-base__rollup-icon');
-    await click('span[title="Property"');
+    await click('span[title="Property"]');
     await click('span[title="Date Time (Day)"]');
     await click('.navi-column-config-base__rollup-icon');
 

--- a/packages/reports/tests/dummy/config/environment.js
+++ b/packages/reports/tests/dummy/config/environment.js
@@ -48,7 +48,9 @@ module.exports = function(environment) {
         multipleExportFileTypes: ['pdf', 'png', 'gsheet'],
         enabledNotifyIfData: true,
         enableContains: true,
-        enableTableEditing: true
+        enableRequestPreview: false,
+        enableTableEditing: true,
+        enableFiliTotals: true
       }
     }
   };

--- a/packages/reports/tests/integration/components/navi-column-config/base-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config/base-test.js
@@ -3,14 +3,16 @@ import { setupRenderingTest } from 'ember-qunit';
 import { helper as buildHelper } from '@ember/component/helper';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import config from 'ember-get-config';
 
 const TEMPLATE = hbs`
-<NaviColumnConfig::Base 
-  @column={{this.column}} 
+<NaviColumnConfig::Base
+  @column={{this.column}}
   @metadata={{this.metadata}}
   @cloneColumn={{this.cloneColumn}}
   @toggleColumnFilter={{this.toggleColumnFilter}}
   @onUpdateColumnName={{this.onUpdateColumnName}}
+  @toggleRollup={{this.toggleRollup}}
 />`;
 
 module('Integration | Component | navi-column-config/base', function(hooks) {
@@ -27,6 +29,7 @@ module('Integration | Component | navi-column-config/base', function(hooks) {
     this.cloneColumn = () => undefined;
     this.toggleColumnFilter = () => undefined;
     this.onUpdateColumnName = () => undefined;
+    this.toggleRollup = () => undefined;
   });
 
   test('it renders ', async function(assert) {
@@ -127,5 +130,34 @@ module('Integration | Component | navi-column-config/base', function(hooks) {
     assert
       .dom('.navi-column-config-base__filter-icon')
       .hasClass('navi-column-config-base__filter-icon--active', 'The filter is active when the column is filtered');
+  });
+
+  test('it renders rollup button', async function(assert) {
+    const OG = config.navi.FEATURES.enableFiliTotals;
+    config.navi.FEATURES.enableFiliTotals = true;
+
+    this.column = {
+      name: 'property',
+      type: 'dimension',
+      displayName: 'Property',
+      isFiltered: false,
+      isRollup: false,
+      fragment: { dimension: { name: 'Property' } }
+    };
+
+    this.toggleRollup = () => {
+      this.set('column.isRollup', !this.column.isRollup);
+    };
+
+    await render(TEMPLATE);
+
+    assert.dom('.navi-column-config-base__rollup-icon').exists('Rollup toggle button exists');
+    assert.dom('.navi-column-config-base__rollup-icon--active').doesNotExist('Rollup is not active on this column');
+
+    await click('.navi-column-config-base__rollup-icon');
+
+    assert.dom('.navi-column-config-base__rollup-icon--active').exists('Rollup is active when button is clicked');
+
+    config.navi.FEATURES.enableFiliTotals = OG;
   });
 });

--- a/packages/reports/tests/integration/components/navi-column-config/metric-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config/metric-test.js
@@ -7,6 +7,7 @@ import { selectChoose } from 'ember-power-select/test-support/helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { assertTooltipContent } from 'ember-tooltips/test-support/dom';
+import config from 'ember-get-config';
 
 let MetadataService;
 
@@ -57,7 +58,8 @@ module('Integration | Component | navi-column-config/metric', function(hooks) {
       name: metricFragment.canonicalName,
       displayName: metric,
       fragment: metricFragment,
-      isFiltered: false
+      isFiltered: false,
+      isRollup: false
     };
   }
 
@@ -201,5 +203,18 @@ module('Integration | Component | navi-column-config/metric', function(hooks) {
     // await fillIn('.navi-column-config-base__column-name-input', 'Money');
 
     // await triggerKeyEvent('.navi-column-config-base__column-name-input', 'keyup', 13);
+  });
+
+  test('metrics do not render rollup button', async function(assert) {
+    const OG = config.navi.FEATURES.enableFiliTotals;
+    config.navi.FEATURES.enableFiliTotals = true;
+
+    this.column = await getMetricColumn('multipleParamMetric', {});
+
+    await render(TEMPLATE);
+
+    assert.dom('.navi-column-config-base__rollup-icon').doesNotExist('Rollup is not available on a metric column');
+
+    config.navi.FEATURES.enableFiliTotals = OG;
   });
 });


### PR DESCRIPTION
## Description

Adds UI to column config on dimension/datetime columns in order to toggle rollup (aka subtotal).

## Proposed Changes

- Other than obviously setting up and wiring up the buttons, Made dimension fragment copyable, since those fragments can only have one owner it became necessary to clone them in order to add them to the rollup part of the request.

## Screenshots
![Screen Shot 2021-07-28 at 10 01 27 AM](https://user-images.githubusercontent.com/99422/127347876-da674be4-310f-4c2e-bd3a-531ef4bc070f.png)

![Screen Shot 2021-07-28 at 10 01 09 AM](https://user-images.githubusercontent.com/99422/127347893-d15cb8e4-315d-4f68-8de3-cea5e27f4e1a.png)


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
