### PR TITLE
Issue1415

### DIFF
--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Dashboard.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Dashboard.kt
@@ -21,6 +21,7 @@ import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.DiscriminatorValue
 import javax.persistence.Entity
+import javax.persistence.FetchType
 import javax.persistence.ManyToMany
 import javax.persistence.OneToMany
 
@@ -65,6 +66,6 @@ class Dashboard : Asset(), HasOwner, HasEditors {
     var deliveryRules: MutableSet<DeliveryRule>? = null
 
     @Exclude
-    @ManyToMany(mappedBy = "favoriteDashboards")
+    @ManyToMany(mappedBy = "favoriteDashboards", fetch = FetchType.LAZY)
     var favoritedBy: MutableSet<User>? = null
 }

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Dashboard.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Dashboard.kt
@@ -6,12 +6,15 @@ package com.yahoo.navi.ws.models.beans
 
 import com.yahoo.elide.annotation.CreatePermission
 import com.yahoo.elide.annotation.DeletePermission
+import com.yahoo.elide.annotation.Exclude
 import com.yahoo.elide.annotation.Include
+import com.yahoo.elide.annotation.LifeCycleHookBinding
 import com.yahoo.elide.annotation.UpdatePermission
 import com.yahoo.navi.ws.models.beans.fragments.DashboardPresentation
 import com.yahoo.navi.ws.models.beans.fragments.request.Filter
 import com.yahoo.navi.ws.models.checks.DefaultEditorsCheck.Companion.IS_EDITOR
 import com.yahoo.navi.ws.models.checks.DefaultOwnerCheck.Companion.IS_OWNER
+import com.yahoo.navi.ws.models.hooks.DashboardDeletionHook
 import org.hibernate.annotations.Parameter
 import org.hibernate.annotations.Type
 import javax.persistence.CascadeType
@@ -27,6 +30,11 @@ import javax.persistence.OneToMany
 @CreatePermission(expression = IS_OWNER)
 @UpdatePermission(expression = "$IS_OWNER OR $IS_EDITOR")
 @DeletePermission(expression = IS_OWNER)
+@LifeCycleHookBinding(
+    phase = LifeCycleHookBinding.TransactionPhase.PRESECURITY, // TODO - change to PREFLUSH when Elide supports it.
+    operation = LifeCycleHookBinding.Operation.DELETE,
+    hook = DashboardDeletionHook::class
+)
 class Dashboard : Asset(), HasOwner, HasEditors {
 
     @ManyToMany(mappedBy = "editingDashboards")
@@ -55,4 +63,8 @@ class Dashboard : Asset(), HasOwner, HasEditors {
 
     @OneToMany(mappedBy = "deliveredItem", cascade = [CascadeType.REMOVE], orphanRemoval = true)
     var deliveryRules: MutableSet<DeliveryRule>? = null
+
+    @Exclude
+    @ManyToMany(mappedBy = "favoriteDashboards")
+    var favoritedBy: MutableSet<User>? = null
 }

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Report.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Report.kt
@@ -20,6 +20,7 @@ import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.DiscriminatorValue
 import javax.persistence.Entity
+import javax.persistence.FetchType
 import javax.persistence.ManyToMany
 import javax.persistence.OneToMany
 
@@ -58,6 +59,6 @@ class Report : Asset(), HasOwner {
     var deliveryRules: MutableSet<DeliveryRule>? = null
 
     @Exclude
-    @ManyToMany(mappedBy = "favoriteReports")
+    @ManyToMany(mappedBy = "favoriteReports", fetch = FetchType.LAZY)
     var favoritedBy: MutableSet<User>? = null
 }

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Report.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Report.kt
@@ -7,10 +7,12 @@ package com.yahoo.navi.ws.models.beans
 import com.yahoo.elide.annotation.CreatePermission
 import com.yahoo.elide.annotation.DeletePermission
 import com.yahoo.elide.annotation.Include
+import com.yahoo.elide.annotation.LifeCycleHookBinding
 import com.yahoo.elide.annotation.UpdatePermission
 import com.yahoo.navi.ws.models.beans.fragments.Request
 import com.yahoo.navi.ws.models.beans.fragments.Visualization
 import com.yahoo.navi.ws.models.checks.DefaultOwnerCheck.Companion.IS_OWNER
+import com.yahoo.navi.ws.models.hooks.ReportDeletionHook
 import org.hibernate.annotations.Parameter
 import org.hibernate.annotations.Type
 import javax.persistence.CascadeType
@@ -25,6 +27,11 @@ import javax.persistence.OneToMany
 @CreatePermission(expression = IS_OWNER)
 @UpdatePermission(expression = IS_OWNER)
 @DeletePermission(expression = IS_OWNER)
+@LifeCycleHookBinding(
+    phase = LifeCycleHookBinding.TransactionPhase.PRESECURITY, // TODO - change to PREFLUSH when Elide supports it.
+    operation = LifeCycleHookBinding.Operation.DELETE,
+    hook = ReportDeletionHook::class
+)
 class Report : Asset(), HasOwner {
 
     @Column(name = "request", columnDefinition = "MEDIUMTEXT")

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Report.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Report.kt
@@ -6,6 +6,7 @@ package com.yahoo.navi.ws.models.beans
 
 import com.yahoo.elide.annotation.CreatePermission
 import com.yahoo.elide.annotation.DeletePermission
+import com.yahoo.elide.annotation.Exclude
 import com.yahoo.elide.annotation.Include
 import com.yahoo.elide.annotation.LifeCycleHookBinding
 import com.yahoo.elide.annotation.UpdatePermission
@@ -19,6 +20,7 @@ import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.DiscriminatorValue
 import javax.persistence.Entity
+import javax.persistence.ManyToMany
 import javax.persistence.OneToMany
 
 @Entity
@@ -54,4 +56,8 @@ class Report : Asset(), HasOwner {
 
     @OneToMany(mappedBy = "deliveredItem", cascade = [CascadeType.REMOVE], orphanRemoval = true)
     var deliveryRules: MutableSet<DeliveryRule>? = null
+
+    @Exclude
+    @ManyToMany(mappedBy = "favoriteReports")
+    var favoritedBy: MutableSet<User>? = null
 }

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/DashboardDeletionHook.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/DashboardDeletionHook.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/DashboardDeletionHook.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/DashboardDeletionHook.kt
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+package com.yahoo.navi.ws.models.hooks
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding
+import com.yahoo.elide.core.lifecycle.LifeCycleHook
+import com.yahoo.elide.core.security.ChangeSpec
+import com.yahoo.elide.core.security.RequestScope
+import com.yahoo.navi.ws.models.beans.Dashboard
+import java.util.Optional
+
+/**
+ * Cleans up references to a dashboard so it can be safely deleted.
+ */
+class DashboardDeletionHook : LifeCycleHook<Dashboard> {
+    override fun execute(
+        operation: LifeCycleHookBinding.Operation?,
+        phase: LifeCycleHookBinding.TransactionPhase?,
+        dashboard: Dashboard?,
+        requestScope: RequestScope?,
+        changes: Optional<ChangeSpec>?
+    ) {
+        var favoriteUsers = dashboard?.favoritedBy
+
+        if (favoriteUsers != null) {
+            for (user in favoriteUsers) {
+                user?.favoriteReports?.remove(dashboard)
+            }
+        }
+    }
+}

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/DashboardDeletionHook.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/DashboardDeletionHook.kt
@@ -27,7 +27,7 @@ class DashboardDeletionHook : LifeCycleHook<Dashboard> {
 
         if (favoriteUsers != null) {
             for (user in favoriteUsers) {
-                user?.favoriteReports?.remove(dashboard)
+                user?.favoriteDashboards?.remove(dashboard)
             }
         }
     }

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/ReportDeletionHook.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/ReportDeletionHook.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/ReportDeletionHook.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/ReportDeletionHook.kt
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2020, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+package com.yahoo.navi.ws.models.hooks
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding
+import com.yahoo.elide.core.exceptions.BadRequestException
+import com.yahoo.elide.core.lifecycle.LifeCycleHook
+import com.yahoo.elide.core.security.ChangeSpec
+import com.yahoo.elide.core.security.RequestScope
+import com.yahoo.navi.ws.models.beans.User
+import java.util.Optional
+
+/**
+ * Validates a User model on creation.  Elide 5 does not support CreatePermission checks
+ * on ID fields - and so this logic is implemented as a hook.  Longer term, Navi should
+ * not overload the ID field - it should be a simple surrogate key.
+ */
+class UserValidationHook : LifeCycleHook<User> {
+    override fun execute(
+        operation: LifeCycleHookBinding.Operation?,
+        phase: LifeCycleHookBinding.TransactionPhase?,
+        user: User?,
+        requestScope: RequestScope?,
+        changes: Optional<ChangeSpec>?
+    ) {
+        val principalName = requestScope?.user?.name
+        val userName = user?.id
+
+        if (principalName.isNullOrEmpty() || userName != principalName) {
+            throw BadRequestException("Forbidden User Identity")
+        }
+    }
+}


### PR DESCRIPTION
Resolves #1415 

## Description
Cleans up references to dashboards and reports in new life cycle hooks so they can be safely deleted by the client.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
