### PR TITLE
Fix: Serializing __rollupMask is a dimension

### DIFF
--- a/packages/core/addon/components/navi-visualizations/table.js
+++ b/packages/core/addon/components/navi-visualizations/table.js
@@ -190,13 +190,14 @@ class Table extends Component {
       if (row.__rollupMask === undefined || row.__rollupMask === null) {
         return row;
       }
+      const rollupMask = Number(row.__rollupMask);
       if (!row.__meta__) {
         row.__meta__ = {};
       }
-      if (row.__rollupMask !== fullMask) {
+      if (rollupMask !== fullMask) {
         set(row, '__meta__.isRollup', true);
       }
-      if (row.__rollupMask === 0) {
+      if (rollupMask === 0) {
         set(row, '__meta__.isTotalRow', true);
       }
       return row;

--- a/packages/core/tests/unit/components/navi-visualizations/table-test.js
+++ b/packages/core/tests/unit/components/navi-visualizations/table-test.js
@@ -442,31 +442,31 @@ module('Unit | Component | table', function(hooks) {
               dateTime: '2021-01-01',
               'dimension|id': 'dim1',
               uniqueIdentifier: 123,
-              __rollupMask: 3
+              __rollupMask: '3'
             },
             {
               dateTime: null,
               'dimension|id': 'dim1',
               uniqueIdentifier: 123,
-              __rollupMask: 1
+              __rollupMask: '1'
             },
             {
               dateTime: '2021-01-01',
               'dimension|id': 'dim2',
               uniqueIdentifier: 321,
-              __rollupMask: 3
+              __rollupMask: '3'
             },
             {
               dateTime: null,
               'dimension|id': 'dim2',
               uniqueIdentifier: 321,
-              __rollupMask: 1
+              __rollupMask: '1'
             },
             {
               dateTime: null,
               'dimension|id': null,
               uniqueIdentifier: 321,
-              __rollupMask: 0
+              __rollupMask: '0'
             }
           ]
         }

--- a/packages/data/addon/mirage/routes/bard-lite.js
+++ b/packages/data/addon/mirage/routes/bard-lite.js
@@ -244,7 +244,7 @@ export default function(
       const getMask = rolledupDims => {
         const rollupDimensionMask = ['dateTime', ...dimensions];
         const flagMap = rollupDimensionMask.map(rolledDim => (rolledupDims.includes(rolledDim) ? 1 : 0));
-        return parseInt(flagMap.join(''), 2);
+        return String(parseInt(flagMap.join(''), 2));
       };
       const fullMask = getMask(['dateTime', ...dimensions]);
 
@@ -256,7 +256,7 @@ export default function(
             acc = {};
             Object.keys(row).forEach(key => (acc[key] = null));
             if (hasRollUpDim) {
-              acc.__rollupMask = 0;
+              acc.__rollupMask = '0';
             }
           }
 


### PR DESCRIPTION
## Description

Missed in spec. since __rollupMask  is a dimension, get serialized as a string

## Proposed Changes

- Handle _rollupMask as a string.

## Screenshots

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
