### PR TITLE
New: Rollup support in webservice models

### DIFF
--- a/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/ReportTest.kt
+++ b/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/ReportTest.kt
@@ -99,6 +99,7 @@ class ReportTest : IntegrationTest() {
             |"filters":[{"field":"id", "values":["-1", "102", "103"], "type":"dimension", "parameters":{}, "operator":"include"}], 
             |"requestVersion":"2.0", 
             |"sorts":[], 
+            |"rollup": {"columns":[], "grandTotal":false},
             |"dataSource":"", 
             |"table":"base"
             |}

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/Request.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/Request.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans.fragments
@@ -7,6 +7,7 @@ package com.yahoo.navi.ws.models.beans.fragments
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.yahoo.navi.ws.models.beans.fragments.request.Column
 import com.yahoo.navi.ws.models.beans.fragments.request.Filter
+import com.yahoo.navi.ws.models.beans.fragments.request.Rollup
 import com.yahoo.navi.ws.models.beans.fragments.request.Sort
 import com.yahoo.navi.ws.models.types.JsonType
 import org.hibernate.annotations.TypeDef
@@ -18,6 +19,7 @@ data class Request(
     var columns: List<Column> = emptyList(),
     var table: String = "",
     var sorts: List<Sort> = emptyList(),
+    var rollup: Rollup = Rollup(),
     var limit: Int? = null,
     var dataSource: String? = null,
     val requestVersion: String = "2.0"

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Rollup.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Rollup.kt
@@ -1,0 +1,10 @@
+/**
+ * Copyright 2021, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+package com.yahoo.navi.ws.models.beans.fragments.request
+
+data class Rollup(
+    var columns: List<String> = emptyList(), // cid list
+    var grandTotal: Boolean = false
+)


### PR DESCRIPTION
## Description

Add rollup to v2 models

## Proposed Changes

- Adds the following shape to requests: 

```
{
    rollup: {
        columns: [
            'columnCID',
            'anotherColumnCID'
         ],
        grandTotal: true
    }
}
```

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
