### PR TITLE
New: Subtotal models and consumers.

### DIFF
--- a/packages/core/addon/models/bard-request-v2/fragments/rollup.ts
+++ b/packages/core/addon/models/bard-request-v2/fragments/rollup.ts
@@ -14,10 +14,10 @@ const Validations = buildValidations({
 
 export default class RollupFragment extends Fragment.extend(Validations) implements Rollup {
   @attr({ defaultValue: () => [] })
-  columns!: Rollup['columns'];
+  declare columns: Rollup['columns'];
 
   @attr('boolean', { defaultValue: false })
-  grandTotal!: Rollup['grandTotal'];
+  declare grandTotal: Rollup['grandTotal'];
 }
 
 declare module 'navi-core/models/registry' {

--- a/packages/core/addon/models/bard-request-v2/fragments/rollup.ts
+++ b/packages/core/addon/models/bard-request-v2/fragments/rollup.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2021, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import { attr } from '@ember-data/model';
+import Fragment from 'ember-data-model-fragments/fragment';
+import { Rollup } from 'navi-data/adapters/facts/interface';
+import { validator, buildValidations } from 'ember-cp-validations';
+
+const Validations = buildValidations({
+  columns: [validator('has-many')],
+  grandTotal: validator('presence', true),
+});
+
+export default class RollupFragment extends Fragment.extend(Validations) implements Rollup {
+  @attr({ defaultValue: () => [] })
+  columns!: Rollup['columns'];
+
+  @attr('boolean', { defaultValue: false })
+  grandTotal!: Rollup['grandTotal'];
+}
+
+declare module 'navi-core/models/registry' {
+  export interface FragmentRegistry {
+    'bard-request-v2/fragments/rollup': RollupFragment;
+  }
+}

--- a/packages/core/addon/models/bard-request-v2/request.ts
+++ b/packages/core/addon/models/bard-request-v2/request.ts
@@ -356,6 +356,8 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
    * @param column - dimension column to add a rollup
    */
   pushRollupColumn(column: ColumnFragment) {
+    const columnExists = this.columns.toArray().some((requestColumn) => requestColumn.cid === column.cid);
+    assert(`Rollup column with cid: ${column.cid} must exist in request`, columnExists);
     this.removeRollupColumn(column); //remove duplicate
     this.rollup.columns.push(column.cid);
   }

--- a/packages/core/addon/models/bard-request-v2/request.ts
+++ b/packages/core/addon/models/bard-request-v2/request.ts
@@ -7,7 +7,7 @@ import { inject as service } from '@ember/service';
 import { attr } from '@ember-data/model';
 import Fragment from 'ember-data-model-fragments/fragment';
 //@ts-ignore
-import { fragmentArray } from 'ember-data-model-fragments/attributes';
+import { fragmentArray, fragment } from 'ember-data-model-fragments/attributes';
 import { validator, buildValidations } from 'ember-cp-validations';
 //@ts-ignore
 import { isEqual } from 'lodash-es';
@@ -15,7 +15,7 @@ import { isEqual } from 'lodash-es';
 import Interval from 'navi-data/utils/classes/interval';
 import { assert } from '@ember/debug';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
-import type { RequestV2, SortDirection, Parameters } from 'navi-data/adapters/facts/interface';
+import type { RequestV2, SortDirection, Parameters, Rollup } from 'navi-data/adapters/facts/interface';
 import type FragmentFactory from 'navi-core/services/fragment-factory';
 import type NaviMetadataService from 'navi-data/services/navi-metadata';
 import type Store from '@ember-data/store';
@@ -80,6 +80,9 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
   @fragmentArray('bard-request-v2/fragments/sort', { defaultValue: () => [] })
   declare sorts: FragmentArray<SortFragment>;
 
+  @fragment('bard-request-v2/fragments/rollup', { defaultValue: () => ({ columns: [], grandTotal: false }) })
+  declare rollup: Rollup;
+
   @attr('number')
   declare limit: number | null;
 
@@ -142,6 +145,7 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
         });
         return newSort;
       }),
+      rollup: store.createFragment('bard-request-v2/fragments/rollup', clonedRequest.rollup),
       limit: clonedRequest.limit,
       requestVersion: clonedRequest.requestVersion,
       dataSource: clonedRequest.dataSource,
@@ -345,6 +349,31 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
     assert(`Metric: ${canonicalName} cannot have multiple sorts on it`, !sortExists);
 
     this.sorts.pushObject(this.fragmentFactory.createSort(type, source, field, parameters, direction));
+  }
+
+  /**
+   * Pushes column cid to end of rollup list, removing dupes.
+   * @param column - dimension column to add a rollup
+   */
+  pushRollupColumn(column: ColumnFragment) {
+    this.removeRollupColumn(column); //remove duplicate
+    this.rollup.columns.push(column.cid);
+  }
+
+  /**
+   * Removes column cid from rollup list
+   * @param column - dimension column to remove
+   */
+  removeRollupColumn(column: ColumnFragment) {
+    this.rollup.columns = this.rollup.columns.filter((rollupCid) => rollupCid !== column.cid);
+  }
+
+  /**
+   * Sets rollup grand total
+   * @param grandTotal - toggle grandTotal rollup
+   */
+  setGrandTotal(grandTotal: boolean) {
+    this.rollup.grandTotal = !!grandTotal;
   }
 
   /**

--- a/packages/core/addon/models/registry.ts
+++ b/packages/core/addon/models/registry.ts
@@ -15,6 +15,7 @@ export type VisualizationType = FilteredKeys<FragmentRegistry, VisualizationFrag
 // Forces global fragments to be augmented (e.g. for other addons) into the registry
 import 'navi-core/models/bard-request-v2/fragments/column';
 import 'navi-core/models/bard-request-v2/fragments/filter';
+import 'navi-core/models/bard-request-v2/fragments/rollup';
 import 'navi-core/models/bard-request-v2/fragments/sort';
 import 'navi-core/models/bard-request-v2/request';
 import 'navi-core/models/fragments/layout';

--- a/packages/core/app/models/bard-request-v2/fragments/rollup.js
+++ b/packages/core/app/models/bard-request-v2/fragments/rollup.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-core/models/bard-request-v2/fragments/rollup';

--- a/packages/core/tests/unit/models/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/request-test.js
@@ -464,34 +464,32 @@ module('Unit | Model | Fragment | BardRequest  - Request', function (hooks) {
     assert.expect(5);
     const request = mockModel.get('request');
 
-    request.addColumn({ cid: 'bar' });
-
-    request.pushRollupColumn({ cid: 'foo' });
-    request.pushRollupColumn({ cid: 'foo' }); //test duplicate push
+    request.pushRollupColumn({ cid: '2222222222' });
+    request.pushRollupColumn({ cid: '2222222222' }); //test duplicate push
     assert.deepEqual(
       request.rollup.toJSON(),
       {
-        columns: ['foo'],
+        columns: ['2222222222'],
         grandTotal: false,
       },
       'Adding a dimension column works as expected'
     );
 
-    request.pushRollupColumn({ cid: 'bar' });
+    request.pushRollupColumn({ cid: '3333333333' });
     assert.deepEqual(
       request.rollup.toJSON(),
       {
-        columns: ['foo', 'bar'],
+        columns: ['2222222222', '3333333333'],
         grandTotal: false,
       },
       'Adding another dimension pushes it to end of columns array'
     );
 
-    request.removeRollupColumn({ cid: 'foo' });
+    request.removeRollupColumn({ cid: '2222222222' });
     assert.deepEqual(
       request.rollup.toJSON(),
       {
-        columns: ['bar'],
+        columns: ['3333333333'],
         grandTotal: false,
       },
       'Correct column was removed'
@@ -501,20 +499,20 @@ module('Unit | Model | Fragment | BardRequest  - Request', function (hooks) {
     assert.deepEqual(
       request.rollup.toJSON(),
       {
-        columns: ['bar'],
+        columns: ['3333333333'],
         grandTotal: true,
       },
       'Grand Total is toggled'
     );
 
-    request.pushRollupColumn({ cid: 'dateTime' });
+    request.pushRollupColumn({ cid: '1111111111' });
 
     const clonedRequest = request.clone();
 
     assert.deepEqual(
       clonedRequest.rollup.toJSON(),
       {
-        columns: ['bar', 'dateTime'],
+        columns: ['3333333333', '1111111111'],
         grandTotal: true,
       },
       'Rollup was cloned correctly'

--- a/packages/core/tests/unit/models/dashboard-widget-test.js
+++ b/packages/core/tests/unit/models/dashboard-widget-test.js
@@ -105,6 +105,10 @@ module('Unit | Model | dashboard widget', function (hooks) {
                   values: ['P1D', 'current'],
                 },
               ],
+              rollup: {
+                columns: [],
+                grandTotal: false,
+              },
               limit: null,
               requestVersion: '2.0',
               sorts: [],

--- a/packages/core/tests/unit/models/report-test.js
+++ b/packages/core/tests/unit/models/report-test.js
@@ -61,6 +61,10 @@ const ExpectedRequest = {
         type: 'metric',
       },
     ],
+    rollup: {
+      columns: [],
+      grandTotal: false,
+    },
     limit: null,
     requestVersion: '2.0',
     dataSource: 'bardOne',

--- a/packages/core/tests/unit/services/compression-test.ts
+++ b/packages/core/tests/unit/services/compression-test.ts
@@ -28,8 +28,8 @@ module('Unit | Service | compression', function (hooks) {
     const compressedString = await Service.compress(object);
 
     assert.equal(
-      compressedString.replace(/[+/=]/g, ''),
-      encodeURIComponent(compressedString.replace(/[+/=]/g, '')),
+      compressedString,
+      encodeURI(compressedString),
       'The object compressed to a string safe for use in a URL without requiring an id'
     );
 
@@ -59,8 +59,8 @@ module('Unit | Service | compression', function (hooks) {
     const compressedString = await Service.compressModel(report);
 
     assert.equal(
-      compressedString.replace(/[+/=]/g, ''),
-      encodeURIComponent(compressedString.replace(/[+/=]/g, '')),
+      compressedString,
+      encodeURI(compressedString),
       'The model compresses to a string safe for use in a URL'
     );
 

--- a/packages/core/tests/unit/services/compression-test.ts
+++ b/packages/core/tests/unit/services/compression-test.ts
@@ -28,8 +28,8 @@ module('Unit | Service | compression', function (hooks) {
     const compressedString = await Service.compress(object);
 
     assert.equal(
-      compressedString,
-      encodeURIComponent(compressedString),
+      compressedString.replace(/[+/=]/g, ''),
+      encodeURIComponent(compressedString.replace(/[+/=]/g, '')),
       'The object compressed to a string safe for use in a URL without requiring an id'
     );
 
@@ -59,8 +59,8 @@ module('Unit | Service | compression', function (hooks) {
     const compressedString = await Service.compressModel(report);
 
     assert.equal(
-      compressedString,
-      encodeURIComponent(compressedString),
+      compressedString.replace(/[+/=]/g, ''),
+      encodeURIComponent(compressedString.replace(/[+/=]/g, '')),
       'The model compresses to a string safe for use in a URL'
     );
 

--- a/packages/dashboards/tests/unit/routes/dashboards/dashboard/widgets/new-test.js
+++ b/packages/dashboards/tests/unit/routes/dashboards/dashboard/widgets/new-test.js
@@ -11,6 +11,10 @@ const NEW_MODEL = {
       filters: [],
       columns: [],
       sorts: [],
+      rollup: {
+        columns: [],
+        grandTotal: false,
+      },
       limit: null,
       requestVersion: '2.0',
       dataSource: null,

--- a/packages/data/addon/adapters/facts/interface.ts
+++ b/packages/data/addon/adapters/facts/interface.ts
@@ -64,12 +64,18 @@ export type Sort = {
   direction: SortDirection;
 };
 
+export type Rollup = {
+  columns: string[];
+  grandTotal: boolean;
+};
+
 // TODO: Remove V2 once V1 is no longer in use
 export type RequestV2 = {
   filters: Filter[];
   columns: Column[];
   table: string;
   dataSource: string;
+  rollup?: Rollup;
   sorts: Sort[];
   limit?: number | null;
   requestVersion: '2.0';

--- a/packages/reports/addon/consumers/request/column.ts
+++ b/packages/reports/addon/consumers/request/column.ts
@@ -59,6 +59,7 @@ export default class ColumnConsumer extends ActionConsumer {
       const { routeName } = route;
       const { request } = route.modelFor(routeName) as ReportModel;
       request.removeColumn(column);
+      this.requestActionDispatcher.dispatch(RequestActions.REMOVE_ROLLUP_COLUMN, route, column);
     },
 
     /**

--- a/packages/reports/addon/consumers/request/column.ts
+++ b/packages/reports/addon/consumers/request/column.ts
@@ -59,7 +59,6 @@ export default class ColumnConsumer extends ActionConsumer {
       const { routeName } = route;
       const { request } = route.modelFor(routeName) as ReportModel;
       request.removeColumn(column);
-      this.requestActionDispatcher.dispatch(RequestActions.REMOVE_ROLLUP_COLUMN, route, column);
     },
 
     /**

--- a/packages/reports/addon/consumers/request/rollup.ts
+++ b/packages/reports/addon/consumers/request/rollup.ts
@@ -4,10 +4,10 @@
  */
 import { inject as service } from '@ember/service';
 import ActionConsumer from 'navi-core/consumers/action-consumer';
-import Route from '@ember/routing/route';
 import RequestActionDispatcher, { RequestActions } from 'navi-reports/services/request-action-dispatcher';
-import ColumnFragment from 'navi-core/addon/models/bard-request-v2/fragments/column';
-import ReportModel from 'navi-core/models/report';
+import type Route from '@ember/routing/route';
+import type ColumnFragment from 'navi-core/addon/models/bard-request-v2/fragments/column';
+import type ReportModel from 'navi-core/models/report';
 
 export default class RollupConsumer extends ActionConsumer {
   @service

--- a/packages/reports/addon/consumers/request/rollup.ts
+++ b/packages/reports/addon/consumers/request/rollup.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2021, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import { inject as service } from '@ember/service';
+import ActionConsumer from 'navi-core/consumers/action-consumer';
+import Route from '@ember/routing/route';
+import RequestActionDispatcher, { RequestActions } from 'navi-reports/services/request-action-dispatcher';
+import ColumnFragment from 'navi-core/addon/models/bard-request-v2/fragments/column';
+import ReportModel from 'navi-core/models/report';
+
+export default class RollupConsumer extends ActionConsumer {
+  @service
+  declare requestActionDispatcher: RequestActionDispatcher;
+
+  actions = {
+    /**
+     * @action PUSH_ROLLUP_COLUMN
+     * @param route - route that has a model that contains a request property
+     * @param columnFragment - data model fragment of the column
+     */
+    [RequestActions.PUSH_ROLLUP_COLUMN](this: RollupConsumer, route: Route, columnFragment: ColumnFragment) {
+      const { routeName } = route;
+      const { request } = route.modelFor(routeName) as ReportModel;
+      request.pushRollupColumn(columnFragment);
+    },
+
+    /**
+     * @action REMOVE_ROLLUP_COLUMN
+     * @param route - route that has a model that contains a request property
+     * @param columnFragment - data model fragment of the column
+     */
+    [RequestActions.REMOVE_ROLLUP_COLUMN](this: RollupConsumer, route: Route, columnFragment: ColumnFragment) {
+      const { routeName } = route;
+      const { request } = route.modelFor(routeName) as ReportModel;
+      request.removeRollupColumn(columnFragment);
+    },
+
+    /**
+     * @action UPDATE_GRAND_TOTAL
+     * @param route - route that has a model that contains a request property
+     * @param isGrandTotal - boolean grand total flag
+     */
+    [RequestActions.UPDATE_GRAND_TOTAL](this: RollupConsumer, route: Route, isGrandTotal: boolean) {
+      const { routeName } = route;
+      const { request } = route.modelFor(routeName) as ReportModel;
+      request.setGrandTotal(isGrandTotal);
+    },
+  };
+}

--- a/packages/reports/addon/consumers/request/rollup.ts
+++ b/packages/reports/addon/consumers/request/rollup.ts
@@ -46,5 +46,14 @@ export default class RollupConsumer extends ActionConsumer {
       const { request } = route.modelFor(routeName) as ReportModel;
       request.setGrandTotal(isGrandTotal);
     },
+
+    /**
+     * @action REMOVE_COLUMN_FRAGMENT
+     * @param route - removes column from rollup when column fragment is removed.
+     * @param columnFragment - data model fragment of the column
+     */
+    [RequestActions.REMOVE_COLUMN_FRAGMENT](this: RollupConsumer, route: Route, columnFragment: ColumnFragment) {
+      this.requestActionDispatcher.dispatch(RequestActions.REMOVE_ROLLUP_COLUMN, route, columnFragment);
+    },
   };
 }

--- a/packages/reports/addon/consumers/request/rollup.ts
+++ b/packages/reports/addon/consumers/request/rollup.ts
@@ -6,7 +6,7 @@ import { inject as service } from '@ember/service';
 import ActionConsumer from 'navi-core/consumers/action-consumer';
 import RequestActionDispatcher, { RequestActions } from 'navi-reports/services/request-action-dispatcher';
 import type Route from '@ember/routing/route';
-import type ColumnFragment from 'navi-core/addon/models/bard-request-v2/fragments/column';
+import type ColumnFragment from 'navi-core/models/bard-request-v2/fragments/column';
 import type ReportModel from 'navi-core/models/report';
 
 export default class RollupConsumer extends ActionConsumer {

--- a/packages/reports/addon/services/request-action-dispatcher.ts
+++ b/packages/reports/addon/services/request-action-dispatcher.ts
@@ -24,6 +24,10 @@ export const RequestActions = <const>{
 
   UPSERT_SORT: 'upsertSort',
   REMOVE_SORT: 'removeSort',
+
+  PUSH_ROLLUP_COLUMN: 'pushRollupColumn',
+  REMOVE_ROLLUP_COLUMN: 'removeRollupColumn',
+  UPDATE_GRAND_TOTAL: 'updateGrandTotal',
 };
 
 export default class RequestActionDispatcher extends ActionDispatcher {
@@ -36,6 +40,7 @@ export default class RequestActionDispatcher extends ActionDispatcher {
       'request/sort',
       'request/fili',
       'request/constraint',
+      'request/rollup',
     ];
   }
 }

--- a/packages/reports/app/consumers/request/rollup.js
+++ b/packages/reports/app/consumers/request/rollup.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/consumers/request/rollup';

--- a/packages/reports/tests/unit/consumers/request/rollup-test.ts
+++ b/packages/reports/tests/unit/consumers/request/rollup-test.ts
@@ -1,0 +1,113 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+// @ts-ignore
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { RequestActions } from 'navi-reports/services/request-action-dispatcher';
+import { run } from '@ember/runloop';
+import StoreService from '@ember-data/store';
+import RollupConsumer from 'navi-reports/consumers/request/rollup';
+import RequestFragment from 'navi-core/models/bard-request-v2/request';
+import { Column } from 'navi-data/adapters/facts/interface';
+
+let Store: StoreService;
+let Consumer: RollupConsumer;
+let CurrentModel: { request: RequestFragment };
+let OS: Column;
+let AGE: Column;
+let DEVICE_TYPE: Column;
+let Route: { modelFor: () => { request: RequestFragment } };
+const routeFor = (request: RequestFragment) => ({ modelFor: () => ({ request }) });
+
+module('Unit | Consumer | request rollup', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    Store = this.owner.lookup('service:store');
+
+    Consumer = this.owner.lookup('consumer:request/rollup');
+
+    OS = {
+      cid: 'c1',
+      type: 'dimension',
+      field: 'os',
+      parameters: { field: 'id' },
+    };
+
+    AGE = {
+      cid: 'c2',
+      type: 'dimension',
+      field: 'age',
+      parameters: { field: 'id' },
+    };
+
+    DEVICE_TYPE = {
+      cid: 'c3',
+      type: 'dimension',
+      field: 'deviceType',
+      parameters: { field: 'id' },
+    };
+
+    CurrentModel = {
+      request: Store.createFragment('bard-request-v2/request', {
+        table: 'network',
+        limit: null,
+        dataSource: 'bardOne',
+        requestVersion: '2.0',
+        columns: [OS, AGE, DEVICE_TYPE],
+        filters: [],
+        sorts: [],
+      }),
+    };
+
+    Route = routeFor(CurrentModel.request);
+
+    // Isolate test to focus on only this consumer
+    let requestActionDispatcher = this.owner.lookup('service:request-action-dispatcher');
+    requestActionDispatcher._registeredConsumers = [];
+    requestActionDispatcher.registerConsumer('request/rollup');
+  });
+
+  test('PUSH_ROLLUP_COLUMN', function (assert) {
+    assert.expect(2);
+    run(() => {
+      Consumer.send(RequestActions.PUSH_ROLLUP_COLUMN, Route, OS);
+    });
+
+    assert.deepEqual(CurrentModel.request?.rollup?.columns[0], 'c1', 'pushes requested column to rollup on request');
+
+    run(() => {
+      Consumer.send(RequestActions.PUSH_ROLLUP_COLUMN, Route, AGE);
+      Consumer.send(RequestActions.PUSH_ROLLUP_COLUMN, Route, DEVICE_TYPE);
+    });
+
+    assert.deepEqual(CurrentModel.request.rollup?.columns, ['c1', 'c2', 'c3'], 'Columns are added in the right order');
+  });
+
+  test('REMOVE_ROLLUP_COLUMN', function (assert) {
+    assert.expect(1);
+    run(() => {
+      Consumer.send(RequestActions.PUSH_ROLLUP_COLUMN, Route, OS);
+      Consumer.send(RequestActions.PUSH_ROLLUP_COLUMN, Route, AGE);
+      Consumer.send(RequestActions.PUSH_ROLLUP_COLUMN, Route, DEVICE_TYPE);
+      Consumer.send(RequestActions.REMOVE_ROLLUP_COLUMN, Route, AGE);
+    });
+
+    assert.deepEqual(CurrentModel.request.rollup?.columns, ['c1', 'c3'], 'The correct columns is removed');
+  });
+
+  test('UPDATE_GRAND_TOTAL', function (assert) {
+    assert.expect(2);
+    run(() => {
+      Consumer.send(RequestActions.UPDATE_GRAND_TOTAL, Route, true);
+    });
+
+    assert.ok(CurrentModel.request.rollup.grandTotal, 'Grand total is updated to true');
+
+    run(() => {
+      Consumer.send(RequestActions.UPDATE_GRAND_TOTAL, Route, false);
+    });
+
+    assert.notOk(CurrentModel.request.rollup.grandTotal, 'Grand total is back to false');
+  });
+});

--- a/packages/reports/tests/unit/consumers/request/rollup-test.ts
+++ b/packages/reports/tests/unit/consumers/request/rollup-test.ts
@@ -4,10 +4,10 @@ import { setupTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { RequestActions } from 'navi-reports/services/request-action-dispatcher';
 import { run } from '@ember/runloop';
-import StoreService from '@ember-data/store';
-import RollupConsumer from 'navi-reports/consumers/request/rollup';
-import RequestFragment from 'navi-core/models/bard-request-v2/request';
-import { Column } from 'navi-data/adapters/facts/interface';
+import type StoreService from '@ember-data/store';
+import type RollupConsumer from 'navi-reports/consumers/request/rollup';
+import type RequestFragment from 'navi-core/models/bard-request-v2/request';
+import type { Column } from 'navi-data/adapters/facts/interface';
 
 let Store: StoreService;
 let Consumer: RollupConsumer;

--- a/packages/reports/tests/unit/consumers/request/rollup-test.ts
+++ b/packages/reports/tests/unit/consumers/request/rollup-test.ts
@@ -110,4 +110,28 @@ module('Unit | Consumer | request rollup', function (hooks) {
 
     assert.notOk(CurrentModel.request.rollup.grandTotal, 'Grand total is back to false');
   });
+
+  test('REMOVE_COLUMN_FRAGMENT', function (assert) {
+    assert.expect(1);
+    run(() => {
+      Consumer.send(RequestActions.PUSH_ROLLUP_COLUMN, Route, OS);
+      Consumer.send(RequestActions.PUSH_ROLLUP_COLUMN, Route, AGE);
+      Consumer.send(RequestActions.PUSH_ROLLUP_COLUMN, Route, DEVICE_TYPE);
+      Consumer.send(RequestActions.REMOVE_COLUMN_FRAGMENT, Route, AGE);
+    });
+    assert.deepEqual(CurrentModel.request.rollup?.columns, ['c1', 'c3'], 'The correct columns is removed');
+  });
+
+  test('Column not in request assertion', function (assert) {
+    assert.throws(() => {
+      run(() => {
+        Consumer.send(RequestActions.PUSH_ROLLUP_COLUMN, Route, {
+          cid: 'c7',
+          type: 'dimension',
+          field: 'os',
+          parameters: { field: 'id' },
+        });
+      });
+    }, 'Assertion is thrown when column is added that is not in the request');
+  });
 });

--- a/packages/reports/tests/unit/routes/reports/new-test.ts
+++ b/packages/reports/tests/unit/routes/reports/new-test.ts
@@ -15,6 +15,10 @@ const NEW_MODEL = {
     dataSource: null,
     filters: [],
     limit: null,
+    rollup: {
+      columns: [],
+      grandTotal: false,
+    },
     requestVersion: '2.0',
     sorts: [],
     table: null,

--- a/packages/reports/tests/unit/serializers/report-test.js
+++ b/packages/reports/tests/unit/serializers/report-test.js
@@ -59,6 +59,10 @@ module('Unit | Serializer | Report', function (hooks) {
                 values: ['2015-10-02T00:00:00.000Z', '2015-10-14T00:00:00.000Z'],
               },
             ],
+            rollup: {
+              columns: [],
+              grandTotal: false,
+            },
             limit: null,
             requestVersion: '2.0',
             sorts: [],
@@ -157,6 +161,10 @@ module('Unit | Serializer | Report', function (hooks) {
                 values: ['2015-10-02T00:00:00.000Z', '2015-10-14T00:00:00.000Z'],
               },
             ],
+            rollup: {
+              columns: [],
+              grandTotal: false,
+            },
             limit: null,
             requestVersion: '2.0',
             sorts: [],


### PR DESCRIPTION
## Description

Port of alpha branch but is simplified. Instead of holding dimension model copies in rollup columns, we simply just hold a reference cid.

## Proposed Changes

- add rollup to request model and add consumers to modify request.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
