### PR TITLE
Fix: Export tooltip

### DIFF
--- a/packages/dashboards/addon/components/dashboard-actions.hbs
+++ b/packages/dashboards/addon/components/dashboard-actions.hbs
@@ -13,10 +13,11 @@
       </EmberTooltip>
     </LinkTo>
 
-    {{#if (feature-flag "enableDashboardExport")}}
+    {{#if (and (feature-flag "enableDashboardExport") (not (is-empty (feature-flag "exportFileTypes"))))}}
       {{!-- Export action enabled if the dashboard is valid --}}
       <DashboardActions::Export
         class="dashboard-actions__export"
+        id="dashboard-actions__export-{{dashboard.id}}"
         @model={{dashboard}}
         @disabled={{not dashboard.validations.isTruelyValid}}
       >
@@ -26,10 +27,10 @@
           @icon="download"
           class="p-4 link m-r-4"
         />
-        <EmberTooltip @popperContainer="body">
-          {{if dashboard.validations.isTruelyValid "Export the dashboard" "Unable to export invalid dashboard"}}
-        </EmberTooltip>
       </DashboardActions::Export>
+      <EmberTooltip @targetId="dashboard-actions__export-{{dashboard.id}}" @popperContainer="body">
+        {{if dashboard.validations.isTruelyValid "Export the dashboard" "Unable to export invalid dashboard"}}
+      </EmberTooltip>
     {{/if}}
 
     <CommonActions::Share

--- a/packages/dashboards/addon/components/dashboard-header.hbs
+++ b/packages/dashboards/addon/components/dashboard-header.hbs
@@ -39,7 +39,7 @@
             Clone
           </LinkTo>
 
-          {{#if (feature-flag "enableDashboardExport")}}
+          {{#if (and (feature-flag "enableDashboardExport") (not (is-empty (feature-flag "exportFileTypes"))))}}
             {{!-- Export action enabled if the dashboard is valid --}}
             <DashboardActions::Export
               @model={{@dashboard}}

--- a/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
+++ b/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
@@ -72,7 +72,7 @@
                   Export
                 </DenaliButton>
               </ReportActions::MultipleFormatExport>
-            {{else if exportFileTypes}}
+            {{else if (not (is-empty exportFileTypes))}}
               <ReportActions::Export
                 @model={{@model}}
                 as |onClick|
@@ -91,7 +91,7 @@
                 </span>
               </ReportActions::Export>
             {{/if}}
-            {{#if exportFileTypes}}
+            {{#if (not (is-empty exportFileTypes))}}
               <EmberTooltip @targetId="navi-report-widget__action-export">
                 {{if @model.validations.isTruelyValid "Export the widget" "Unable to export invalid widget"}}
               </EmberTooltip>

--- a/packages/reports/addon/components/navi-action-list.hbs
+++ b/packages/reports/addon/components/navi-action-list.hbs
@@ -21,35 +21,32 @@
   {{#let (feature-flag "exportFileTypes") as |exportFileTypes|}}
     {{#if (gt exportFileTypes.length 1)}}
       <ReportActions::MultipleFormatExport
+        id="navi-report-actions__export-{{@index}}"
         class="navi-report-actions__export"
         @model={{@item}}
       >
         <DenaliIcon
-          id="navi-report-actions__export-{{@index}}"
           class="navi-report-actions__export-btn p-4 link m-r-4"
           @size="small"
           @icon="download"
         />
       </ReportActions::MultipleFormatExport>
-    {{else if exportFileTypes}}
+    {{else if (not (is-empty exportFileTypes))}}
       <ReportActions::Export
         @model={{@item}}
         as |onClick|
       >
         {{!-- this wrapper div exists because tooltip doesn't render for a disabled button --}}
-        <span id="navi-report-actions__export-{{@index}}">
-          <DenaliButton
-            @style="text"
-            @size="small"
-            @icon="download"
-            class="navi-report-actions__export-btn m-r-4"
-            {{on "click" onClick}}
-          >
-          </DenaliButton>
-        </span>
+        <DenaliIcon
+          id="navi-report-actions__export-{{@index}}"
+          class="navi-report-actions__export-btn p-4 link m-r-4"
+          @size="small"
+          @icon="download"
+          {{on "click" onClick}}
+        />
       </ReportActions::Export>
     {{/if}}
-    {{#if exportFileTypes}}
+    {{#if (not (is-empty exportFileTypes))}}
       <EmberTooltip @targetId="navi-report-actions__export-{{@index}}" @popperContainer="body">
         Export the report
       </EmberTooltip>

--- a/packages/reports/addon/templates/components/report-actions.hbs
+++ b/packages/reports/addon/templates/components/report-actions.hbs
@@ -72,7 +72,7 @@
         Export
       </DenaliButton>
     </ReportActions::MultipleFormatExport>
-  {{else if exportFileTypes}}
+  {{else if (not (is-empty exportFileTypes))}}
     <ReportActions::Export
       @model={{@model}}
       as |onClick|
@@ -91,7 +91,7 @@
       </span>
     </ReportActions::Export>
   {{/if}}
-  {{#if exportFileTypes}}
+  {{#if (not (is-empty exportFileTypes))}}
     <EmberTooltip @targetId="report-actions__export">
       {{if @model.validations.isTruelyValid "Export the report" "Unable to export invalid report"}}
     </EmberTooltip>

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -576,7 +576,7 @@ module('Acceptance | Navi Report', function (hooks) {
     assert.deepEqual(
       findAll('.report-header__header-actions .button').map((e) => e.textContent.trim()),
       ['API Query', 'Clone', 'Share', 'Schedule', 'Delete'],
-      'Export is disabled by default'
+      'Export button is not rendered'
     );
 
     config.navi.FEATURES.exportFileTypes = originalFlag;


### PR DESCRIPTION
## Description

Fixes the mysterious disappearance of the export tooltip in the directory view

## Screenshots

<img width="486" alt="Screen Shot 2021-09-02 at 1 20 53 PM" src="https://user-images.githubusercontent.com/13946669/131910778-087c3f5f-f2a1-4f27-8241-34c984497e38.png">

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
