### PR TITLE
Fix: ModelForHelper empty route, notifications width

### DIFF
--- a/packages/core/addon/helpers/current-route.ts
+++ b/packages/core/addon/helpers/current-route.ts
@@ -20,7 +20,7 @@ export default class CurrentRouteHelper extends Helper {
   /**
    * @returns name of currently visited route
    */
-  compute(_args?: unknown): string {
+  compute(_args?: unknown): string | null {
     return this.router.currentRouteName;
   }
 }

--- a/packages/core/addon/helpers/parent-route.ts
+++ b/packages/core/addon/helpers/parent-route.ts
@@ -10,12 +10,15 @@ export default class ParentRouteHelper extends CurrentRouteHelper {
   /**
    * @returns name of parent to currently visited route
    */
-  compute(_args?: unknown): string {
+  compute(_args?: unknown): string | null {
     const currentRoute = super.compute(...arguments);
-    const pathElements = currentRoute.split('.');
+    const pathElements = currentRoute?.split('.') ?? [];
 
     // Remove the leaf route
     pathElements.pop();
+    if (pathElements.length === 0) {
+      return null;
+    }
 
     return pathElements.join('.');
   }

--- a/packages/core/addon/mirage/serializers/base-json-serializer.js
+++ b/packages/core/addon/mirage/serializers/base-json-serializer.js
@@ -10,7 +10,7 @@ export default class extends JSONAPISerializer {
 
   keyForRelationship = (attr) => camelize(attr);
 
-  serializeIds: 'always';
+  serializeIds = 'always';
 
   getCoalescedIds(request) {
     const { filter } = request.queryParams ?? {};

--- a/packages/notifications/app/styles/navi-notifications.scss
+++ b/packages/notifications/app/styles/navi-notifications.scss
@@ -1,12 +1,12 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
 .navi-notifications {
-  display: flex;
-  justify-content: center;
+  // Only cover width of notification contents https://stackoverflow.com/a/23384995
+  left: 50%;
   position: absolute;
-  width: 100%;
+  transform: translate(-50%, 0);
   z-index: 1000;
 }

--- a/packages/reports/addon/helpers/model-for.ts
+++ b/packages/reports/addon/helpers/model-for.ts
@@ -4,6 +4,7 @@
  */
 import Helper from '@ember/component/helper';
 import { getOwner } from '@ember/application';
+import { isEmpty } from '@ember/utils';
 import type Route from '@ember/routing/route';
 
 export default class ModelForHelper extends Helper {
@@ -13,7 +14,10 @@ export default class ModelForHelper extends Helper {
    * in a route hierarchy. If the ancestor route's model was a promise,
    * its resolved result is returned.
    */
-  compute([name]: [string]) {
+  compute([name]: [string | null | undefined]) {
+    if (isEmpty(name)) {
+      return;
+    }
     const route = getOwner(this).lookup(`route:${name}`) as Route | undefined;
     if (!route) {
       return;

--- a/packages/reports/tests/integration/helpers/model-for-test.ts
+++ b/packages/reports/tests/integration/helpers/model-for-test.ts
@@ -39,4 +39,15 @@ module('Integration | Helper | model for', function (hooks) {
     await render(hbs`<span>{{model-for 'missing-route'}}</span>`);
     assert.dom('span').hasText('', 'model-for helper returns undefined when route does not exist');
   });
+
+  test('modelFor - empty parameter', async function (assert) {
+    await render(hbs`<span>{{model-for ''}}</span>`);
+    assert.dom('span').hasText('', 'model-for helper returns undefined when route is empty string');
+
+    await render(hbs`<span>{{model-for null}}</span>`);
+    assert.dom('span').hasText('', 'model-for helper returns undefined when route is null');
+
+    await render(hbs`<span>{{model-for undefined}}</span>`);
+    assert.dom('span').hasText('', 'model-for helper returns undefined when route is undefined');
+  });
 });


### PR DESCRIPTION
## Description
- model-for checks for empty route name to prevent container lookup assertion error
- notification bar only takes up the width of it's content now (caused some issues click on content near notifications)
- fixup for base-json-serializer

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
