### PR TITLE
Subtotal table support

### DIFF
--- a/packages/core/addon/components/navi-cell-renderers/dimension.ts
+++ b/packages/core/addon/components/navi-cell-renderers/dimension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -19,9 +19,18 @@ export default class DimensionCellRenderer extends BaseCellRenderer {
    */
   get displayValue() {
     const { columnValue } = this;
+    const { isRollup, isGrandTotal } = this.args;
 
     if (!isEmpty(columnValue)) {
       return columnValue;
+    }
+
+    if (isGrandTotal) {
+      return '';
+    }
+
+    if (isRollup) {
+      return '\xa0'; //non-breaking space.
     }
 
     return '--';

--- a/packages/core/addon/components/navi-cell-renderers/time-dimension.ts
+++ b/packages/core/addon/components/navi-cell-renderers/time-dimension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -26,6 +26,13 @@ export default class TimeDimensionCellRenderer extends BaseCellRenderer {
 
   get displayValue() {
     const { columnValue, timeGrain } = this;
-    return formatDateForGranularity(`${columnValue}`, timeGrain);
+    const { isRollup, isGrandTotal } = this.args;
+    let blankValue = '--';
+    if (isGrandTotal) {
+      blankValue = '';
+    } else if (isRollup) {
+      blankValue = '\xa0'; //non-breaking space
+    }
+    return formatDateForGranularity(`${columnValue}`, timeGrain, blankValue);
   }
 }

--- a/packages/core/addon/components/navi-table-cell-renderer.hbs
+++ b/packages/core/addon/components/navi-table-cell-renderer.hbs
@@ -1,9 +1,11 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#let (component this.cellRenderer) as |CellRenderer|}}
   <CellRenderer
     @data={{@data}}
     @column={{@column}}
     @request={{@request}}
+    @isRollup={{@isRollup}}
+    @isGrandTotal={{@isGrandTotal}}
     ...attributes
   />
 {{/let}}

--- a/packages/core/addon/components/navi-table-cell-renderer.ts
+++ b/packages/core/addon/components/navi-table-cell-renderer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Picks the correct cell renderer to use. Allows for extension in apps.
@@ -22,6 +22,8 @@ export type CellRendererArgs = {
   data: ResponseRow;
   column: TableColumn;
   request: RequestFragment;
+  isRollup: boolean;
+  isGrandTotal: boolean;
 };
 
 export default class NaviTableCellRenderer extends Component<CellRendererArgs> {

--- a/packages/core/addon/helpers/format-date-for-granularity.ts
+++ b/packages/core/addon/helpers/format-date-for-granularity.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { helper as buildHelper } from '@ember/component/helper';
@@ -37,9 +37,9 @@ function formatWeek(startDate: string): string {
 /**
  * Returns a date in a human readable format based on granularity
  */
-export function formatDateForGranularity(date: string, grain: Grain) {
+export function formatDateForGranularity(date: string, grain: Grain, blankValue = '--') {
   if (!isValidMoment(date)) {
-    return '--';
+    return blankValue;
   }
 
   const period = getPeriodForGrain(grain);

--- a/packages/core/addon/templates/components/table-renderer-vertical-collection.hbs
+++ b/packages/core/addon/templates/components/table-renderer-vertical-collection.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class={{this.tableHeadersClass}}>
   {{#unless @isEditingMode}}
     {{#let "table-renderer-vc" as |groupName|}}
@@ -87,10 +87,10 @@
         @bufferSize={{@bufferSize}}
         as |row idx|
       >
-        <tr class="table-row-vc {{if row.__meta__.isTotalRow "table-row__total-row"}} {{if (eq idx (sub @tableData.length 1)) "table-row__last-row"}}">
-          {{#each @columns as |column|}}
+        <tr class="table-row-vc {{if row.__meta__.isTotalRow "table-row__total-row"}} {{if row.__meta__.isRollup "table-row__rollup-row"}} {{if row.__meta__.isGrandTotal "table-row__grand-total-row"}}  {{if (eq idx (sub @tableData.length 1)) "table-row__last-row"}}">
+          {{#each @columns as |column index|}}
             <td class="table-cell {{column.fragment.type}}">
-              {{#if (and (eq column.fragment.type "timeDimension") row.__meta__.isTotalRow)}}
+              {{#if (and (eq index 0) row.__meta__.isTotalRow)}}
                 {{#let (component (concat @cellRendererPrefix "total")) as |TotalRenderer|}}
                   <TotalRenderer
                     @data={{row}}
@@ -99,10 +99,17 @@
                   />
                 {{/let}}
               {{else}}
+                {{#if (and (eq index 0) row.__meta__.isGrandTotal)}}
+                  <div class="table-row-grandtotal">Grand Total</div>
+                {{else if (and (eq index 0) row.__meta__.isRollup)}}
+                  <div class="table-row-subtotal">Subtotal</div>
+                {{/if}}
                 <NaviTableCellRenderer
                   @data={{row}}
                   @column={{column}}
                   @request={{@request}}
+                  @isRollup={{row.__meta__.isRollup}}
+                  @isGrandTotal={{row.__meta__.isGrandTotal}}
                 />
               {{/if}}
             </td>

--- a/packages/core/addon/templates/components/table-renderer.hbs
+++ b/packages/core/addon/templates/components/table-renderer.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class="table-widget__horizontal-scroll-container" ...attributes>
   <div class= "table-widget-container">
     {{#if @isEditingMode}}
@@ -67,7 +67,7 @@
           @bufferSize={{@bufferSize}}
           as |row idx|
         >
-          <div class="table-row {{if row.__meta__.isTotalRow "table-row__total-row"}} {{if (eq idx (sub @tableData.length 1)) "table-row__last-row"}}">
+          <div class="table-row {{if row.__meta__.isTotalRow "table-row__total-row"}} {{if row.__meta__.isRollup "table-row__rollup-row"}} {{if row.__meta__.isGrandTotal "table-row__grand-total-row"}} {{if (eq idx (sub @tableData.length 1)) "table-row__last-row"}}">
             {{#each @columns as |column|}}
               <div class="table-cell {{column.fragment.type}}">
                 {{#if (and (eq column.fragment.type "timeDimension") row.__meta__.isTotalRow)}}
@@ -83,6 +83,8 @@
                     @data={{row}}
                     @column={{column}}
                     @request={{@request}}
+                    @isRollup={{row.__meta__.isRollup}}
+                    @isGrandTotal={{row.__meta__.isGrandTotal}}
                   />
                 {{/if}}
               </div>

--- a/packages/core/app/styles/navi-core/components/navi-visualizations/table.scss
+++ b/packages/core/app/styles/navi-core/components/navi-visualizations/table.scss
@@ -286,8 +286,42 @@ $font-family-strong: 'HelveticaNeueW01-55Roma', Helvetica, Arial, sans-serif;
         font-weight: 600;
       }
 
+      &.table-row__rollup-row {
+        background-color: map-get($denali-grey-colors, '200');
+
+        .table-cell {
+          vertical-align: bottom;
+        }
+
+        .table-row-subtotal {
+          font-size: 11px;
+          font-weight: 600;
+        }
+      }
+
+      &.table-row__grand-total-row {
+        background-color: map-get($denali-grey-colors, '700');
+        color: map-get($denali-grey-colors, '100');
+
+        .table-cell {
+          vertical-align: bottom;
+        }
+
+        .table-row-grandtotal {
+          font-weight: 600;
+        }
+
+        &:hover {
+          background-color: map-get($denali-grey-colors, '800');
+        }
+      }
+
       &.table-row__total-row.table-row__last-row {
         background-color: rgba(150, 150, 150, 0.1);
+      }
+
+      .metric {
+        text-align: right;
       }
 
       .table-cell {

--- a/packages/core/tests/integration/components/navi-cell-renderers/dimension-test.ts
+++ b/packages/core/tests/integration/components/navi-cell-renderers/dimension-test.ts
@@ -92,4 +92,35 @@ module('Integration | Component | cell renderers/dimension', function (hooks) {
       .dom('.table-cell-content')
       .hasText('--', 'The dimension cell renders correctly when present description field is not present');
   });
+
+  test('dimension rollup render', async function (this: TestContext, assert) {
+    assert.expect(4);
+    this.set('data', { ...this.data, 'os(field=id)': null, 'os(field=desc)': null });
+    this.set('rollup', true);
+    this.set('grandTotal', false);
+
+    await render(hbs`
+      <NaviCellRenderers::Dimension
+        @data={{this.data}}
+        @column={{this.column}}
+        @request={{this.request}}
+        @isRollup={{this.rollup}}
+        @isGrandTotal={{this.grandTotal}}
+      />
+    `);
+
+    assert.dom('.table-cell-content').hasText('\xa0', 'renders non breaking space when rollup is true');
+
+    this.set('rollup', false);
+
+    assert.dom('.table-cell-content').hasText('--', 'renders dash when rollup is false');
+
+    this.set('grandTotal', true);
+
+    assert.dom('.table-cell-content').hasText('', 'renders blank when grandTotal is true');
+
+    this.set('rollup', true);
+
+    assert.dom('.table-cell-content').hasText('', 'renders blank when grandTotal and rollup is true');
+  });
 });

--- a/packages/core/tests/integration/components/navi-cell-renderers/time-dimension-test.ts
+++ b/packages/core/tests/integration/components/navi-cell-renderers/time-dimension-test.ts
@@ -175,4 +175,36 @@ module('Integration | Component | cell renderers/time-dimension', function (hook
 
     assert.dom('.table-cell-content').hasText('2016', 'The time-dimension cell renders the year value correctly');
   });
+
+  test('Rollup null field', async function (this: TestContext, assert) {
+    assert.expect(4);
+    _setRequestForTimeGrain(this, 'day');
+    this.set('data', { ...this.data, 'network.dateTime(grain=day)': null });
+    this.set('rollup', true);
+    this.set('grandTotal', false);
+
+    await render(hbs`
+      <NaviCellRenderers::TimeDimension
+        @data={{this.data}}
+        @column={{this.column}}
+        @request={{this.request}}
+        @isRollup={{this.rollup}}
+        @isGrandTotal={{this.grandTotal}}
+      />
+    `);
+
+    assert.dom('.table-cell-content').hasText('\xa0', 'renders non breaking space if rollup');
+
+    this.set('rollup', false);
+
+    assert.dom('.table-cell-content').hasText('--', 'renders double dash when non rollup');
+
+    this.set('grandTotal', true);
+
+    assert.dom('.table-cell-content').hasText('', 'renders empty when grandTotal');
+
+    this.set('rollup', true);
+
+    assert.dom('.table-cell-content').hasText('', 'renders empty when grandTotal and rollup are both set');
+  });
 });

--- a/packages/dashboards/tests/dummy/config/environment.js
+++ b/packages/dashboards/tests/dummy/config/environment.js
@@ -34,6 +34,7 @@ module.exports = function (environment) {
           type: 'bard',
           options: {
             enableDimensionSearch: true,
+            enableSubtotals: true,
           },
         },
         {

--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -273,16 +273,15 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
    */
   _buildRollupParam(request: RequestV2): string {
     const columns = request.columns;
-    const rollupColumns = request.rollup?.columns || [];
+    const rollupColumnCids = request.rollup?.columns || [];
+    const rollupColumns = columns.filter((col) => rollupColumnCids.includes(col.cid || ''));
     return rollupColumns.length
       ? array(
           rollupColumns.map((rollupColumn) => {
-            const column = columns.find((col) => rollupColumn === col.cid);
-            return column && isDateTime(column) ? 'dateTime' : column?.field;
+            return rollupColumn && isDateTime(rollupColumn) ? 'dateTime' : rollupColumn?.field;
           })
         )
           .uniq()
-          .filter((x) => !!x)
           .join(',')
       : '';
   }

--- a/packages/data/addon/serializers/facts/bard.ts
+++ b/packages/data/addon/serializers/facts/bard.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Description: A serializer for the bard response
@@ -65,6 +65,9 @@ export default class BardFactsSerializer extends EmberObject implements NaviFact
       let f = totalFields;
       while (f--) {
         newRow[normalizedFields[f]] = rawRow[filiFields[f]];
+      }
+      if (rawRow.__rollupMask) {
+        newRow.__rollupMask = rawRow.__rollupMask;
       }
     }
 

--- a/packages/data/addon/serializers/facts/interface.ts
+++ b/packages/data/addon/serializers/facts/interface.ts
@@ -8,7 +8,12 @@ import type NaviAdapterError from 'navi-data/errors/navi-adapter-error';
 
 export type MetricValue = number | undefined | null;
 export type DimensionValue = string | number | boolean | undefined | null;
-export type RowMetadata = unknown;
+export type RowMetadata = {
+  isTotalRow?: boolean;
+  hasPartialData?: boolean;
+  isRollup?: boolean;
+  isGrandTotal?: boolean;
+};
 export type RowValue = MetricValue | DimensionValue | RowMetadata;
 
 export interface ResponseV1 {

--- a/packages/data/config/navi-config.d.ts
+++ b/packages/data/config/navi-config.d.ts
@@ -11,6 +11,7 @@ declare module 'navi-config' {
 
   export interface FiliConfigOptions {
     enableDimensionSearch?: boolean;
+    enableSubtotals?: boolean;
   }
   export type FiliDataSource = BaseDataSource<'bard', FiliConfigOptions>;
 

--- a/packages/data/tests/unit/adapters/facts/bard-test.ts
+++ b/packages/data/tests/unit/adapters/facts/bard-test.ts
@@ -124,7 +124,7 @@ const TestRequest: RequestV2 = {
     },
   },
   TestRequestWithRollup: RequestV2 = Object.assign(cloneDeep(TestRequest), {
-    rollup: { columns: ['dt1', 'znmxcv', 'ipuhozxvc'], grandTotal: true },
+    rollup: { columns: ['znmxcv', 'ipuhozxvc', 'dt1'], grandTotal: true },
   }),
   MockBardResponse: ResponseData = [200, { 'Content-Type': 'application/json' }, JSON.stringify(Response)];
 

--- a/packages/reports/addon/components/navi-column-config.hbs
+++ b/packages/reports/addon/components/navi-column-config.hbs
@@ -1,7 +1,21 @@
 {{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class="navi-column-config" ...attributes>
   <div class="navi-column-config__panel">
-    <h4 class="navi-column-config__title">Columns</h4>
+    <div class="navi-column-config__panel-header">
+      <h4 class="navi-column-config__title">Columns</h4>
+      <div class="navi-column-config__panel-buttons">
+        {{#if this.supportsSubtotal}}
+           <DenaliIcon
+              class="navi-column-config__grandtotal-icon {{if @report.request.rollup.grandTotal "navi-column-config__grandtotal-icon--active"}}"
+              role="button"
+              @icon="hash-solid"
+              @size="small"
+              title="{{if @report.request.rollup.grandTotal 'Remove' 'Add'}} grand total display."
+              {{on "click" this.toggleGrandTotal}}
+            />
+        {{/if}}
+      </div>
+    </div>
     <ol class="navi-column-config__columns" {{sortable-group groupName="navi-column-config" onChange=this.reorderColumns direction="y"}}>
       {{#each this.columns key="fragment" as |column|}}
         <NaviColumnConfig::Item
@@ -16,6 +30,8 @@
           @onRemoveSort={{fn @onRemoveSort column.fragment}}
           @onRenameColumn={{fn @onRenameColumn column.fragment}}
           @onUpdateColumnParam={{fn @onUpdateColumnParam column.fragment}}
+          @toggleRollup={{fn this.toggleRollup column}}
+          @supportsSubtotal={{this.supportsSubtotal}}
         />
       {{/each}}
     </ol>

--- a/packages/reports/addon/components/navi-column-config.ts
+++ b/packages/reports/addon/components/navi-column-config.ts
@@ -6,6 +6,7 @@ import Component from '@glimmer/component';
 import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { getDataSource } from 'navi-data/utils/adapter';
 import type ReportModel from 'navi-core/models/report';
 import type ColumnFragment from 'navi-core/models/bard-request-v2/fragments/column';
 import type { Parameters, SortDirection } from 'navi-data/adapters/facts/interface';
@@ -22,11 +23,15 @@ interface NaviColumnConfigArgs {
   onRemoveSort(column: ColumnFragment): void;
   onRenameColumn(column: ColumnFragment, alias: string): void;
   onReorderColumn(column: ColumnFragment, index: number): void;
+  onPushRollup(column: ColumnFragment): void;
+  onRemoveRollup(column: ColumnFragment): void;
+  onUpdateGrandTotal(grandTotal: boolean): void;
 }
 
 export type ConfigColumn = {
   isFiltered: boolean;
   isRequired: boolean;
+  isRollup: boolean;
   fragment: ColumnFragment;
 };
 
@@ -40,12 +45,12 @@ export default class NaviColumnConfig extends Component<NaviColumnConfigArgs> {
   /**
    * Dimension and metric columns from the request
    */
-  @computed('args.report.request.{columns.[],columns.@each.parameters,filters.[],sorts.[]}')
+  @computed('args.report.request.{columns.[],columns.@each.parameters,filters.[],sorts.[],rollup.columns.[]}')
   get columns(): ConfigColumn[] {
     const { request } = this.args.report;
     const requiredColumns = this.requestConstrainer.getConstrainedProperties(request).columns || new Set();
     if (request.table !== undefined) {
-      const { columns, filters } = request;
+      const { columns, filters, rollup } = request;
 
       const filteredColumns = filters.map(({ canonicalName }) => canonicalName);
 
@@ -53,11 +58,21 @@ export default class NaviColumnConfig extends Component<NaviColumnConfigArgs> {
         return {
           isFiltered: filteredColumns.includes(column.canonicalName),
           isRequired: requiredColumns.has(column),
+          isRollup: rollup.columns.includes(column.cid),
           fragment: column,
         };
       });
     }
     return [];
+  }
+
+  @computed('args.report.request.dataSource')
+  get supportsSubtotal(): boolean {
+    if (!this.args.report.request.dataSource) {
+      return false;
+    }
+    const dataSource = getDataSource<'bard'>(this.args.report.request.dataSource).options;
+    return dataSource?.enableSubtotals ?? false;
   }
 
   /**
@@ -68,6 +83,27 @@ export default class NaviColumnConfig extends Component<NaviColumnConfigArgs> {
   cloneColumn(column: ConfigColumn) {
     const { columnMetadata, parameters } = column.fragment;
     this.args.onAddColumn(columnMetadata, { ...parameters });
+  }
+
+  /**
+   * Toggles adding column to rollup list.
+   * @param column - column to toggle rollup on
+   */
+  @action
+  toggleRollup(column: ConfigColumn) {
+    if (column.isRollup) {
+      this.args.onRemoveRollup(column.fragment);
+    } else {
+      this.args.onPushRollup(column.fragment);
+    }
+  }
+
+  /**
+   * Toggles grandTotal on rollup
+   */
+  @action
+  toggleGrandTotal() {
+    this.args.onUpdateGrandTotal(!this.args.report.request.rollup.grandTotal);
   }
 
   /**

--- a/packages/reports/addon/components/navi-column-config/base.hbs
+++ b/packages/reports/addon/components/navi-column-config/base.hbs
@@ -38,6 +38,16 @@
             title="Add Filter"
             {{on "click" @onAddFilter}}
           />
+          {{#if (and @supportsSubtotal (not-eq @column.fragment.type "metric"))}}
+            <DenaliIcon
+              class="navi-column-config-base__rollup-icon {{if @column.isRollup "navi-column-config-base__rollup-icon--active"}}"
+              role="button"
+              @icon="hash-solid"
+              @size="small"
+              title="{{if @column.isRollup 'Remove' 'Add'}} subtotal rows based on this column."
+              {{on "click" @toggleRollup}}
+            />
+          {{/if}}
         </span>
       </div>
     </div>

--- a/packages/reports/addon/components/navi-column-config/base.ts
+++ b/packages/reports/addon/components/navi-column-config/base.ts
@@ -20,6 +20,8 @@ interface NaviColumnConfigBaseArgs {
   onRemoveSort(): void;
   onRenameColumn(newColumnName?: string): void;
   onUpdateColumnParam(param: string, paramValue: string): void;
+  toggleRollup(): void;
+  supportsSubtotal: boolean;
 }
 
 type AllDirectionSort = SortDirection | 'none';

--- a/packages/reports/addon/components/navi-column-config/item.hbs
+++ b/packages/reports/addon/components/navi-column-config/item.hbs
@@ -49,6 +49,8 @@
       @onUpsertSort={{@onUpsertSort}}
       @onRemoveSort={{@onRemoveSort}}
       @onRenameColumn={{@onRenameColumn}}
+      @toggleRollup={{@toggleRollup}}
+      @supportsSubtotal={{@supportsSubtotal}}
       @onUpdateColumnParam={{@onUpdateColumnParam}}
     />
   {{/if}}

--- a/packages/reports/addon/components/navi-column-config/item.ts
+++ b/packages/reports/addon/components/navi-column-config/item.ts
@@ -24,6 +24,8 @@ interface Args {
   onUpsertSort(direction: SortDirection): void;
   onRemoveSort(): void;
   onRenameColumn(alias?: string): void;
+  toggleRollup(): void;
+  supportsSubtotal: boolean;
   onUpdateColumnParam(paramId: string, paramValue: ColumnFragment['parameters'][string]): void;
 }
 

--- a/packages/reports/addon/components/report-builder/sidebar.hbs
+++ b/packages/reports/addon/components/report-builder/sidebar.hbs
@@ -94,6 +94,9 @@
                 @onRenameColumn={{update-report-action "RENAME_COLUMN_FRAGMENT"}}
                 @onReorderColumn={{update-report-action "REORDER_COLUMN_FRAGMENT"}}
                 @onUpdateColumnParam={{update-report-action "UPDATE_COLUMN_FRAGMENT_WITH_PARAMS"}}
+                @onPushRollup={{update-report-action "PUSH_ROLLUP_COLUMN"}}
+                @onRemoveRollup={{update-report-action "REMOVE_ROLLUP_COLUMN"}}
+                @onUpdateGrandTotal={{update-report-action "UPDATE_GRAND_TOTAL"}}
               />
             </div>
           {{/if}}

--- a/packages/reports/addon/consumers/request/column.ts
+++ b/packages/reports/addon/consumers/request/column.ts
@@ -59,6 +59,7 @@ export default class ColumnConsumer extends ActionConsumer {
       const { routeName } = route;
       const { request } = route.modelFor(routeName) as ReportModel;
       request.removeColumn(column);
+      this.requestActionDispatcher.dispatch(RequestActions.REMOVE_ROLLUP_COLUMN, route, column);
     },
 
     /**

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config.scss
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config.scss
@@ -19,6 +19,29 @@
   }
 }
 
+@mixin navi-subtotal-button {
+  background-color: transparent;
+  border-radius: 5px;
+  color: $links-text-color;
+  cursor: pointer;
+  margin: 0 1px;
+  padding: 3px;
+
+  &:hover {
+    color: $links-hover-text-color;
+  }
+
+  &--active {
+    background-color: $links-text-color;
+    color: map-get($denali-grey-colors, '100');
+
+    &:hover {
+      background-color: $links-hover-text-color;
+      color: map-get($denali-grey-colors, '100');
+    }
+  }
+}
+
 .navi-column-config {
   display: flex;
   height: 100%;
@@ -37,6 +60,21 @@
     flex-flow: column;
     max-width: 250px;
     width: 250px;
+
+    &-header {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+    }
+
+    &-buttons {
+      margin-right: 4px;
+      padding: 8px 0;
+    }
+  }
+
+  &__grandtotal-icon {
+    @include navi-subtotal-button;
   }
 
   &__columns {

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config/base.scss
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config/base.scss
@@ -35,8 +35,13 @@
   &__clone-icon,
   &__filter-icon,
   &__sort-icon,
-  &__star-icon {
+  &__star-icon,
+  &__rollup-icon {
     @include navi-column-config-icon;
     margin: 0 4px;
+  }
+
+  &__rollup-icon {
+    @include navi-subtotal-button;
   }
 }

--- a/packages/reports/tests/acceptance/column-config-test.ts
+++ b/packages/reports/tests/acceptance/column-config-test.ts
@@ -17,7 +17,7 @@ function getColumns() {
 
 async function getRequestURL() {
   await click('.get-api__action-btn');
-  const url = (find('.get-api__api-input input') as HTMLInputElement).value;
+  const url = (find('.get-api__api-input') as HTMLInputElement).value;
   await click('.get-api__cancel-btn');
   return new URL(url);
 }
@@ -1305,5 +1305,59 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
     apiURL = await getRequestURL();
     assert.notOk(apiURL.searchParams.has('sort'), 'Sort is removed from request when metric params changed');
+  });
+
+  test('Rollup test', async function (assert) {
+    assert.expect(5);
+    await visit('/reports/1/view');
+    let apiURL = await getRequestURL();
+    assert.equal(
+      apiURL.href,
+      'https://data.naviapp.io/v1/data/network/day/property;show=id/?dateTime=2015-11-09T00%3A00%3A00.000%2F2015-11-16T00%3A00%3A00.000&metrics=adClicks%2CnavClicks&sort=navClicks%7Casc&format=json',
+      'Default query with no rollup'
+    );
+
+    await click('span[title="Date Time (day)"]');
+    await click('.navi-column-config-base__rollup-icon');
+
+    apiURL = await getRequestURL();
+    assert.equal(
+      apiURL.href,
+      'https://data.naviapp.io/v1/data/network/day/property;show=id/__rollupMask/?dateTime=2015-11-09T00%3A00%3A00.000%2F2015-11-16T00%3A00%3A00.000&metrics=adClicks%2CnavClicks&sort=navClicks%7Casc&rollupTo=dateTime&format=json',
+      'Datetime rollup added to query'
+    );
+
+    await click('span[title="Date Time (day)"]');
+    await click('span[title="Property (id)"]');
+    await click('.navi-column-config-base__rollup-icon');
+
+    apiURL = await getRequestURL();
+    assert.equal(
+      apiURL.href,
+      'https://data.naviapp.io/v1/data/network/day/property;show=id/__rollupMask/?dateTime=2015-11-09T00%3A00%3A00.000%2F2015-11-16T00%3A00%3A00.000&metrics=adClicks%2CnavClicks&sort=navClicks%7Casc&rollupTo=dateTime%2Cproperty&format=json',
+      'Property rollup added to query'
+    );
+
+    await click('.navi-column-config__grandtotal-icon');
+
+    apiURL = await getRequestURL();
+    assert.equal(
+      apiURL.href,
+      'https://data.naviapp.io/v1/data/network/day/property;show=id/__rollupMask/?dateTime=2015-11-09T00%3A00%3A00.000%2F2015-11-16T00%3A00%3A00.000&metrics=adClicks%2CnavClicks&sort=navClicks%7Casc&rollupTo=dateTime%2Cproperty&rollupGrandTotal=true&format=json',
+      'grandTotal added to query'
+    );
+
+    await click('.navi-column-config-base__rollup-icon');
+    await click('span[title="Property (id)"]');
+    await click('span[title="Date Time (day)"]');
+    await click('.navi-column-config-base__rollup-icon');
+    await click('.navi-column-config__grandtotal-icon');
+
+    apiURL = await getRequestURL();
+    assert.equal(
+      apiURL.href,
+      'https://data.naviapp.io/v1/data/network/day/property;show=id/?dateTime=2015-11-09T00%3A00%3A00.000%2F2015-11-16T00%3A00%3A00.000&metrics=adClicks%2CnavClicks&sort=navClicks%7Casc&format=json',
+      'Rollup removed from query after toggling off both dimensions'
+    );
   });
 });

--- a/packages/reports/tests/acceptance/column-config-test.ts
+++ b/packages/reports/tests/acceptance/column-config-test.ts
@@ -1,5 +1,5 @@
 import { module, test, skip } from 'qunit';
-import { findAll, visit, click, fillIn, blur, currentURL, find } from '@ember/test-helpers';
+import { findAll, visit, click, fillIn, blur, currentURL, find, settled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 //@ts-ignore
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -1308,7 +1308,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   });
 
   test('Rollup test', async function (assert) {
-    assert.expect(5);
+    assert.expect(11);
     await visit('/reports/1/view');
     let apiURL = await getRequestURL();
     assert.equal(
@@ -1338,6 +1338,14 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
       'Property rollup added to query'
     );
 
+    await click('.navi-report__run-btn');
+    find('.table-widget .scroll-container > div > div')?.scrollTo(0, 9999);
+    await settled();
+
+    await click('.visualization-toggle__option-icon[title="Data Table"]');
+    assert.dom('.table-row__rollup-row').exists('Table visualization has rollup styled rows');
+    assert.dom('.table-row__grand-total-row').doesNotExist('Table visualization does not have grandtotal styled rows');
+
     await click('.navi-column-config__grandtotal-icon');
 
     apiURL = await getRequestURL();
@@ -1346,6 +1354,15 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
       'https://data.naviapp.io/v1/data/network/day/property;show=id/__rollupMask/?dateTime=2015-11-09T00%3A00%3A00.000%2F2015-11-16T00%3A00%3A00.000&metrics=adClicks%2CnavClicks&sort=navClicks%7Casc&rollupTo=dateTime%2Cproperty&rollupGrandTotal=true&format=json',
       'grandTotal added to query'
     );
+
+    await click('.navi-report__run-btn');
+    find('.table-widget .scroll-container > div > div')?.scrollTo(0, 9999);
+    await settled();
+
+    assert.dom('.table-row__rollup-row').exists('Table visualization has rollup styled rows');
+    assert.dom('.table-row__grand-total-row').exists('Table visualization has grandtotal styled rows');
+
+    //await this.pauseTest();
 
     await click('.navi-column-config-base__rollup-icon');
     await click('span[title="Property (id)"]');
@@ -1359,5 +1376,17 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
       'https://data.naviapp.io/v1/data/network/day/property;show=id/?dateTime=2015-11-09T00%3A00%3A00.000%2F2015-11-16T00%3A00%3A00.000&metrics=adClicks%2CnavClicks&sort=navClicks%7Casc&format=json',
       'Rollup removed from query after toggling off both dimensions'
     );
+
+    await click('.navi-report__run-btn');
+    find('.table-widget .scroll-container > div > div')?.scrollTo(0, 9999);
+    await settled();
+
+    assert
+      .dom('.table-row__rollup-row')
+      .doesNotExist('Table visualization has all rollup styled rows removed after toggling off both dimensions');
+
+    assert
+      .dom('.table-row__grand-total-row')
+      .doesNotExist('Table visualization grand total is gone when grand total is toggled off');
   });
 });

--- a/packages/reports/tests/dummy/config/environment.js
+++ b/packages/reports/tests/dummy/config/environment.js
@@ -42,6 +42,7 @@ module.exports = function (environment) {
           type: 'bard',
           options: {
             enableDimensionSearch: true,
+            enableSubtotals: true,
           },
         },
         {

--- a/packages/reports/tests/integration/components/navi-column-config/metric-test.js
+++ b/packages/reports/tests/integration/components/navi-column-config/metric-test.js
@@ -17,6 +17,8 @@ const TEMPLATE = hbs`
   @onRemoveSort={{optional this.onRemoveSort}}
   @onRenameColumn={{optional this.onRenameColumn}}
   @onUpdateColumnParam={{this.onUpdateColumnParam}}
+  @toggleRollup={{optional this.toggleRollup}}
+  @supportsSubtotal={{this.supportsSubtotal}}
 />
 `;
 module('Integration | Component | navi-column-config/metric', function (hooks) {
@@ -26,6 +28,8 @@ module('Integration | Component | navi-column-config/metric', function (hooks) {
   hooks.beforeEach(async function () {
     MetadataService = this.owner.lookup('service:navi-metadata');
     await MetadataService.loadMetadata();
+
+    this.set('supportsSubtotal', false);
 
     this.onUpdateColumnParam = (paramId, paramKey) => {
       this.set('column.fragment.parameters', {
@@ -186,5 +190,14 @@ module('Integration | Component | navi-column-config/metric', function (hooks) {
 
     await fillIn(columnNameInput, 'Money');
     await triggerKeyEvent(columnNameInput, 'keyup', 13);
+  });
+
+  test('metrics do not render rollup button', async function (assert) {
+    this.set('supportsSubtotal', true);
+    this.column = await getMetricColumn('multipleParamMetric', {});
+
+    await render(TEMPLATE);
+
+    assert.dom('.navi-column-config-base__rollup-icon').doesNotExist('Rollup is not available on a metric column');
   });
 });


### PR DESCRIPTION
## Description

Adds sub total and grand total rendering support to table

## Proposed Changes

- More flexible "blank values" rendering in cell selectors, sub total needs nbsp in order to render the subtotal label as a superscript and grand total needs blank in order to display more flat and inline.
- subtotal/grand total styles added
- table component maps subtotal, grandtotal in row meta.

## Screenshots
![Screen Shot 2021-09-10 at 4 12 49 PM](https://user-images.githubusercontent.com/99422/132918294-6bbb0d9f-45c7-4e83-a238-420ec0bce9fe.png)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
