### PR TITLE
New: Add subtotal and grandtotal support to table

### DIFF
--- a/packages/core/addon/components/navi-cell-renderers/dimension.ts
+++ b/packages/core/addon/components/navi-cell-renderers/dimension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -19,9 +19,18 @@ export default class DimensionCellRenderer extends BaseCellRenderer {
    */
   get displayValue() {
     const { columnValue } = this;
+    const { isRollup, isGrandTotal } = this.args;
 
     if (!isEmpty(columnValue)) {
       return columnValue;
+    }
+
+    if (isGrandTotal) {
+      return '';
+    }
+
+    if (isRollup) {
+      return '\xa0'; //non-breaking space.
     }
 
     return '--';

--- a/packages/core/addon/components/navi-cell-renderers/time-dimension.ts
+++ b/packages/core/addon/components/navi-cell-renderers/time-dimension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -26,6 +26,13 @@ export default class TimeDimensionCellRenderer extends BaseCellRenderer {
 
   get displayValue() {
     const { columnValue, timeGrain } = this;
-    return formatDateForGranularity(`${columnValue}`, timeGrain);
+    const { isRollup, isGrandTotal } = this.args;
+    let blankValue = '--';
+    if (isGrandTotal) {
+      blankValue = '';
+    } else if (isRollup) {
+      blankValue = '\xa0'; //non-breaking space
+    }
+    return formatDateForGranularity(`${columnValue}`, timeGrain, blankValue);
   }
 }

--- a/packages/core/addon/components/navi-table-cell-renderer.hbs
+++ b/packages/core/addon/components/navi-table-cell-renderer.hbs
@@ -1,9 +1,11 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#let (component this.cellRenderer) as |CellRenderer|}}
   <CellRenderer
     @data={{@data}}
     @column={{@column}}
     @request={{@request}}
+    @isRollup={{@isRollup}}
+    @isGrandTotal={{@isGrandTotal}}
     ...attributes
   />
 {{/let}}

--- a/packages/core/addon/components/navi-table-cell-renderer.ts
+++ b/packages/core/addon/components/navi-table-cell-renderer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Picks the correct cell renderer to use. Allows for extension in apps.
@@ -22,6 +22,8 @@ export type CellRendererArgs = {
   data: ResponseRow;
   column: TableColumn;
   request: RequestFragment;
+  isRollup: boolean;
+  isGrandTotal: boolean;
 };
 
 export default class NaviTableCellRenderer extends Component<CellRendererArgs> {

--- a/packages/core/addon/helpers/format-date-for-granularity.ts
+++ b/packages/core/addon/helpers/format-date-for-granularity.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { helper as buildHelper } from '@ember/component/helper';
@@ -37,9 +37,9 @@ function formatWeek(startDate: string): string {
 /**
  * Returns a date in a human readable format based on granularity
  */
-export function formatDateForGranularity(date: string, grain: Grain) {
+export function formatDateForGranularity(date: string, grain: Grain, blankValue = '--') {
   if (!isValidMoment(date)) {
-    return '--';
+    return blankValue;
   }
 
   const period = getPeriodForGrain(grain);

--- a/packages/core/addon/templates/components/table-renderer-vertical-collection.hbs
+++ b/packages/core/addon/templates/components/table-renderer-vertical-collection.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class={{this.tableHeadersClass}}>
   {{#unless @isEditingMode}}
     {{#let "table-renderer-vc" as |groupName|}}
@@ -87,10 +87,10 @@
         @bufferSize={{@bufferSize}}
         as |row idx|
       >
-        <tr class="table-row-vc {{if row.__meta__.isTotalRow "table-row__total-row"}} {{if (eq idx (sub @tableData.length 1)) "table-row__last-row"}}">
-          {{#each @columns as |column|}}
+        <tr class="table-row-vc {{if row.__meta__.isTotalRow "table-row__total-row"}} {{if row.__meta__.isRollup "table-row__rollup-row"}} {{if row.__meta__.isGrandTotal "table-row__grand-total-row"}}  {{if (eq idx (sub @tableData.length 1)) "table-row__last-row"}}">
+          {{#each @columns as |column index|}}
             <td class="table-cell {{column.fragment.type}}">
-              {{#if (and (eq column.fragment.type "timeDimension") row.__meta__.isTotalRow)}}
+              {{#if (and (eq index 0) row.__meta__.isTotalRow)}}
                 {{#let (component (concat @cellRendererPrefix "total")) as |TotalRenderer|}}
                   <TotalRenderer
                     @data={{row}}
@@ -99,10 +99,17 @@
                   />
                 {{/let}}
               {{else}}
+                {{#if (and (eq index 0) row.__meta__.isGrandTotal)}}
+                  <div class="table-row-grandtotal">Grand Total</div>
+                {{else if (and (eq index 0) row.__meta__.isRollup)}}
+                  <div class="table-row-subtotal">Subtotal</div>
+                {{/if}}
                 <NaviTableCellRenderer
                   @data={{row}}
                   @column={{column}}
                   @request={{@request}}
+                  @isRollup={{row.__meta__.isRollup}}
+                  @isGrandTotal={{row.__meta__.isGrandTotal}}
                 />
               {{/if}}
             </td>

--- a/packages/core/addon/templates/components/table-renderer.hbs
+++ b/packages/core/addon/templates/components/table-renderer.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div class="table-widget__horizontal-scroll-container" ...attributes>
   <div class= "table-widget-container">
     {{#if @isEditingMode}}
@@ -67,7 +67,7 @@
           @bufferSize={{@bufferSize}}
           as |row idx|
         >
-          <div class="table-row {{if row.__meta__.isTotalRow "table-row__total-row"}} {{if (eq idx (sub @tableData.length 1)) "table-row__last-row"}}">
+          <div class="table-row {{if row.__meta__.isTotalRow "table-row__total-row"}} {{if row.__meta__.isRollup "table-row__rollup-row"}} {{if row.__meta__.isGrandTotal "table-row__grand-total-row"}} {{if (eq idx (sub @tableData.length 1)) "table-row__last-row"}}">
             {{#each @columns as |column|}}
               <div class="table-cell {{column.fragment.type}}">
                 {{#if (and (eq column.fragment.type "timeDimension") row.__meta__.isTotalRow)}}
@@ -83,6 +83,8 @@
                     @data={{row}}
                     @column={{column}}
                     @request={{@request}}
+                    @isRollup={{row.__meta__.isRollup}}
+                    @isGrandTotal={{row.__meta__.isGrandTotal}}
                   />
                 {{/if}}
               </div>

--- a/packages/core/app/styles/navi-core/components/navi-visualizations/table.scss
+++ b/packages/core/app/styles/navi-core/components/navi-visualizations/table.scss
@@ -286,8 +286,42 @@ $font-family-strong: 'HelveticaNeueW01-55Roma', Helvetica, Arial, sans-serif;
         font-weight: 600;
       }
 
+      &.table-row__rollup-row {
+        background-color: map-get($denali-grey-colors, '200');
+
+        .table-cell {
+          vertical-align: bottom;
+        }
+
+        .table-row-subtotal {
+          font-size: 11px;
+          font-weight: 600;
+        }
+      }
+
+      &.table-row__grand-total-row {
+        background-color: map-get($denali-grey-colors, '700');
+        color: map-get($denali-grey-colors, '100');
+
+        .table-cell {
+          vertical-align: bottom;
+        }
+
+        .table-row-grandtotal {
+          font-weight: 600;
+        }
+
+        &:hover {
+          background-color: map-get($denali-grey-colors, '800');
+        }
+      }
+
       &.table-row__total-row.table-row__last-row {
         background-color: rgba(150, 150, 150, 0.1);
+      }
+
+      .metric {
+        text-align: right;
       }
 
       .table-cell {

--- a/packages/core/tests/integration/components/navi-cell-renderers/dimension-test.ts
+++ b/packages/core/tests/integration/components/navi-cell-renderers/dimension-test.ts
@@ -92,4 +92,35 @@ module('Integration | Component | cell renderers/dimension', function (hooks) {
       .dom('.table-cell-content')
       .hasText('--', 'The dimension cell renders correctly when present description field is not present');
   });
+
+  test('dimension rollup render', async function (this: TestContext, assert) {
+    assert.expect(4);
+    this.set('data', { ...this.data, 'os(field=id)': null, 'os(field=desc)': null });
+    this.set('rollup', true);
+    this.set('grandTotal', false);
+
+    await render(hbs`
+      <NaviCellRenderers::Dimension
+        @data={{this.data}}
+        @column={{this.column}}
+        @request={{this.request}}
+        @isRollup={{this.rollup}}
+        @isGrandTotal={{this.grandTotal}}
+      />
+    `);
+
+    assert.dom('.table-cell-content').hasText('\xa0', 'renders non breaking space when rollup is true');
+
+    this.set('rollup', false);
+
+    assert.dom('.table-cell-content').hasText('--', 'renders dash when rollup is false');
+
+    this.set('grandTotal', true);
+
+    assert.dom('.table-cell-content').hasText('', 'renders blank when grandTotal is true');
+
+    this.set('rollup', true);
+
+    assert.dom('.table-cell-content').hasText('', 'renders blank when grandTotal and rollup is true');
+  });
 });

--- a/packages/core/tests/integration/components/navi-cell-renderers/time-dimension-test.ts
+++ b/packages/core/tests/integration/components/navi-cell-renderers/time-dimension-test.ts
@@ -175,4 +175,36 @@ module('Integration | Component | cell renderers/time-dimension', function (hook
 
     assert.dom('.table-cell-content').hasText('2016', 'The time-dimension cell renders the year value correctly');
   });
+
+  test('Rollup null field', async function (this: TestContext, assert) {
+    assert.expect(4);
+    _setRequestForTimeGrain(this, 'day');
+    this.set('data', { ...this.data, 'network.dateTime(grain=day)': null });
+    this.set('rollup', true);
+    this.set('grandTotal', false);
+
+    await render(hbs`
+      <NaviCellRenderers::TimeDimension
+        @data={{this.data}}
+        @column={{this.column}}
+        @request={{this.request}}
+        @isRollup={{this.rollup}}
+        @isGrandTotal={{this.grandTotal}}
+      />
+    `);
+
+    assert.dom('.table-cell-content').hasText('\xa0', 'renders non breaking space if rollup');
+
+    this.set('rollup', false);
+
+    assert.dom('.table-cell-content').hasText('--', 'renders double dash when non rollup');
+
+    this.set('grandTotal', true);
+
+    assert.dom('.table-cell-content').hasText('', 'renders empty when grandTotal');
+
+    this.set('rollup', true);
+
+    assert.dom('.table-cell-content').hasText('', 'renders empty when grandTotal and rollup are both set');
+  });
 });

--- a/packages/core/tests/integration/components/navi-visualizations/metric-label-test.ts
+++ b/packages/core/tests/integration/components/navi-visualizations/metric-label-test.ts
@@ -11,6 +11,7 @@ import RequestFragment from 'navi-core/models/bard-request-v2/request';
 import NaviFactResponse from 'navi-data/models/navi-fact-response';
 //@ts-ignore
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import type { RowValue } from 'navi-data/addon/serializers/facts/interface';
 
 const TEMPLATE = hbs`
 <NaviVisualizations::MetricLabel
@@ -27,7 +28,7 @@ interface TestContext extends Context, ComponentArgs {}
  * @param context - test context
  * @param row - object containing row of data
  */
-function _setModel(row: Record<string, unknown>): void {
+function _setModel(row: Record<string, RowValue>): void {
   const test = getContext() as TestContext;
   set(test.model.firstObject!.response, 'rows', [row]);
 }

--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -33,7 +33,7 @@ import type { GrainWithAll } from 'navi-data/serializers/metadata/bard';
 import type { TaskGenerator } from 'ember-concurrency';
 import Interval from 'navi-data/utils/classes/interval';
 
-export type Query = RequestOptions & Record<string, string | number | boolean>;
+export type Query = Record<string, string | number | boolean>;
 
 /**
  * @param column - dimension column

--- a/packages/data/addon/serializers/facts/bard.ts
+++ b/packages/data/addon/serializers/facts/bard.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Description: A serializer for the bard response
@@ -65,6 +65,9 @@ export default class BardFactsSerializer extends EmberObject implements NaviFact
       let f = totalFields;
       while (f--) {
         newRow[normalizedFields[f]] = rawRow[filiFields[f]];
+      }
+      if (rawRow.__rollupMask) {
+        newRow.__rollupMask = rawRow.__rollupMask;
       }
     }
 

--- a/packages/data/addon/serializers/facts/interface.ts
+++ b/packages/data/addon/serializers/facts/interface.ts
@@ -8,7 +8,12 @@ import type NaviAdapterError from 'navi-data/errors/navi-adapter-error';
 
 export type MetricValue = number | undefined | null;
 export type DimensionValue = string | number | boolean | undefined | null;
-export type RowMetadata = unknown;
+export type RowMetadata = {
+  isTotalRow?: boolean;
+  hasPartialData?: boolean;
+  isRollup?: boolean;
+  isGrandTotal?: boolean;
+};
 export type RowValue = MetricValue | DimensionValue | RowMetadata;
 
 export interface ResponseV1 {

--- a/packages/reports/addon/consumers/request/column.ts
+++ b/packages/reports/addon/consumers/request/column.ts
@@ -59,6 +59,7 @@ export default class ColumnConsumer extends ActionConsumer {
       const { routeName } = route;
       const { request } = route.modelFor(routeName) as ReportModel;
       request.removeColumn(column);
+      this.requestActionDispatcher.dispatch(RequestActions.REMOVE_ROLLUP_COLUMN, route, column);
     },
 
     /**

--- a/packages/reports/addon/consumers/request/column.ts
+++ b/packages/reports/addon/consumers/request/column.ts
@@ -59,7 +59,6 @@ export default class ColumnConsumer extends ActionConsumer {
       const { routeName } = route;
       const { request } = route.modelFor(routeName) as ReportModel;
       request.removeColumn(column);
-      this.requestActionDispatcher.dispatch(RequestActions.REMOVE_ROLLUP_COLUMN, route, column);
     },
 
     /**

--- a/packages/reports/tests/acceptance/column-config-test.ts
+++ b/packages/reports/tests/acceptance/column-config-test.ts
@@ -1,5 +1,5 @@
 import { module, test, skip } from 'qunit';
-import { findAll, visit, click, fillIn, blur, currentURL, find, settled } from '@ember/test-helpers';
+import { findAll, visit, click, fillIn, blur, currentURL, find } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 //@ts-ignore
 import { setupMirage } from 'ember-cli-mirage/test-support';

--- a/packages/reports/tests/acceptance/column-config-test.ts
+++ b/packages/reports/tests/acceptance/column-config-test.ts
@@ -1356,8 +1356,6 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
 
     assert.dom('.table-row__rollup-row').exists('Table visualization has rollup styled rows');
 
-    //await this.pauseTest();
-
     await click('.navi-column-config-base__rollup-icon');
     await click('span[title="Property (id)"]');
     await click('span[title="Date Time (day)"]');

--- a/packages/reports/tests/acceptance/column-config-test.ts
+++ b/packages/reports/tests/acceptance/column-config-test.ts
@@ -1,5 +1,5 @@
 import { module, test, skip } from 'qunit';
-import { findAll, visit, click, fillIn, blur, currentURL, find } from '@ember/test-helpers';
+import { findAll, visit, click, fillIn, blur, currentURL, find, settled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 //@ts-ignore
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -1308,7 +1308,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   });
 
   test('Rollup test', async function (assert) {
-    assert.expect(5);
+    assert.expect(11);
     await visit('/reports/1/view');
     let apiURL = await getRequestURL();
     assert.equal(
@@ -1338,6 +1338,14 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
       'Property rollup added to query'
     );
 
+    await click('.navi-report__run-btn');
+    find('.table-widget .scroll-container > div > div')?.scrollTo(0, 9999);
+    await settled();
+
+    await click('.visualization-toggle__option-icon[title="Data Table"]');
+    assert.dom('.table-row__rollup-row').exists('Table visualization has rollup styled rows');
+    assert.dom('.table-row__grand-total-row').doesNotExist('Table visualization does not have grandtotal styled rows');
+
     await click('.navi-column-config__grandtotal-icon');
 
     apiURL = await getRequestURL();
@@ -1346,6 +1354,15 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
       'https://data.naviapp.io/v1/data/network/day/property;show=id/__rollupMask/?dateTime=2015-11-09T00%3A00%3A00.000%2F2015-11-16T00%3A00%3A00.000&metrics=adClicks%2CnavClicks&sort=navClicks%7Casc&rollupTo=dateTime%2Cproperty&rollupGrandTotal=true&format=json',
       'grandTotal added to query'
     );
+
+    await click('.navi-report__run-btn');
+    find('.table-widget .scroll-container > div > div')?.scrollTo(0, 9999);
+    await settled();
+
+    assert.dom('.table-row__rollup-row').exists('Table visualization has rollup styled rows');
+    assert.dom('.table-row__grand-total-row').exists('Table visualization has grandtotal styled rows');
+
+    //await this.pauseTest();
 
     await click('.navi-column-config-base__rollup-icon');
     await click('span[title="Property (id)"]');
@@ -1359,5 +1376,17 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
       'https://data.naviapp.io/v1/data/network/day/property;show=id/?dateTime=2015-11-09T00%3A00%3A00.000%2F2015-11-16T00%3A00%3A00.000&metrics=adClicks%2CnavClicks&sort=navClicks%7Casc&format=json',
       'Rollup removed from query after toggling off both dimensions'
     );
+
+    await click('.navi-report__run-btn');
+    find('.table-widget .scroll-container > div > div')?.scrollTo(0, 9999);
+    await settled();
+
+    assert
+      .dom('.table-row__rollup-row')
+      .doesNotExist('Table visualization has all rollup styled rows removed after toggling off both dimensions');
+
+    assert
+      .dom('.table-row__grand-total-row')
+      .doesNotExist('Table visualization grand total is gone when grand total is toggled off');
   });
 });

--- a/packages/reports/tests/acceptance/column-config-test.ts
+++ b/packages/reports/tests/acceptance/column-config-test.ts
@@ -1308,7 +1308,7 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   });
 
   test('Rollup test', async function (assert) {
-    assert.expect(11);
+    assert.expect(8);
     await visit('/reports/1/view');
     let apiURL = await getRequestURL();
     assert.equal(
@@ -1339,12 +1339,9 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
     );
 
     await click('.navi-report__run-btn');
-    find('.table-widget .scroll-container > div > div')?.scrollTo(0, 9999);
-    await settled();
 
     await click('.visualization-toggle__option-icon[title="Data Table"]');
     assert.dom('.table-row__rollup-row').exists('Table visualization has rollup styled rows');
-    assert.dom('.table-row__grand-total-row').doesNotExist('Table visualization does not have grandtotal styled rows');
 
     await click('.navi-column-config__grandtotal-icon');
 
@@ -1356,11 +1353,8 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
     );
 
     await click('.navi-report__run-btn');
-    find('.table-widget .scroll-container > div > div')?.scrollTo(0, 9999);
-    await settled();
 
     assert.dom('.table-row__rollup-row').exists('Table visualization has rollup styled rows');
-    assert.dom('.table-row__grand-total-row').exists('Table visualization has grandtotal styled rows');
 
     //await this.pauseTest();
 
@@ -1378,15 +1372,9 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
     );
 
     await click('.navi-report__run-btn');
-    find('.table-widget .scroll-container > div > div')?.scrollTo(0, 9999);
-    await settled();
 
     assert
       .dom('.table-row__rollup-row')
       .doesNotExist('Table visualization has all rollup styled rows removed after toggling off both dimensions');
-
-    assert
-      .dom('.table-row__grand-total-row')
-      .doesNotExist('Table visualization grand total is gone when grand total is toggled off');
   });
 });


### PR DESCRIPTION
## Description

Adds sub total and grand total rendering support to table

## Proposed Changes

- More flexible "blank values" rendering in cell selectors, sub total needs nbsp in order to render the subtotal label as a superscript and grand total needs blank in order to display more flat and inline.
- subtotal/grand total styles added
- table component maps subtotal, grandtotal in row meta.

## Screenshots
![Screen Shot 2021-09-10 at 4 12 49 PM](https://user-images.githubusercontent.com/99422/132918294-6bbb0d9f-45c7-4e83-a238-420ec0bce9fe.png)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.