### PR TITLE
 Rollup.columns -> Rollup.columnCids

### DIFF
--- a/packages/core/addon/components/navi-visualizations/table.ts
+++ b/packages/core/addon/components/navi-visualizations/table.ts
@@ -162,7 +162,7 @@ export default class Table extends Component<Args> {
    * Adds meta into rows for serverside data rollups
    */
   _mapRollups(tableData: ResponseRow[], request: RequestFragment) {
-    if (request?.rollup?.columns?.length <= 0 && !request?.rollup?.grandTotal) {
+    if (request?.rollup?.columnCids?.length <= 0 && !request?.rollup?.grandTotal) {
       return tableData;
     }
     const dimensionCount = new Set(request?.columns.filter((col) => col.type !== 'metric')).size;

--- a/packages/core/addon/models/bard-request-v2/fragments/rollup.ts
+++ b/packages/core/addon/models/bard-request-v2/fragments/rollup.ts
@@ -8,13 +8,13 @@ import { Rollup } from 'navi-data/adapters/facts/interface';
 import { validator, buildValidations } from 'ember-cp-validations';
 
 const Validations = buildValidations({
-  columns: [validator('has-many')],
+  columnCids: [validator('has-many')],
   grandTotal: validator('presence', true),
 });
 
 export default class RollupFragment extends Fragment.extend(Validations) implements Rollup {
   @attr({ defaultValue: () => [] })
-  declare columns: Rollup['columns'];
+  declare columnCids: Rollup['columnCids'];
 
   @attr('boolean', { defaultValue: false })
   declare grandTotal: Rollup['grandTotal'];

--- a/packages/core/addon/models/bard-request-v2/request.ts
+++ b/packages/core/addon/models/bard-request-v2/request.ts
@@ -80,7 +80,7 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
   @fragmentArray('bard-request-v2/fragments/sort', { defaultValue: () => [] })
   declare sorts: FragmentArray<SortFragment>;
 
-  @fragment('bard-request-v2/fragments/rollup', { defaultValue: () => ({ columns: [], grandTotal: false }) })
+  @fragment('bard-request-v2/fragments/rollup', { defaultValue: () => ({ columnCids: [], grandTotal: false }) })
   declare rollup: Rollup;
 
   @attr('number')
@@ -359,7 +359,7 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
     const columnExists = this.columns.toArray().some((requestColumn) => requestColumn.cid === column.cid);
     assert(`Rollup column with cid: ${column.cid} must exist in request`, columnExists);
     this.removeRollupColumn(column); //remove duplicate
-    this.rollup.columns.push(column.cid);
+    this.rollup.columnCids.push(column.cid);
   }
 
   /**
@@ -367,7 +367,7 @@ export default class RequestFragment extends Fragment.extend(Validations) implem
    * @param column - dimension column to remove
    */
   removeRollupColumn(column: ColumnFragment) {
-    this.rollup.columns = this.rollup.columns.filter((rollupCid) => rollupCid !== column.cid);
+    this.rollup.columnCids = this.rollup.columnCids.filter((rollupCid) => rollupCid !== column.cid);
   }
 
   /**

--- a/packages/core/tests/unit/components/navi-visualizations/table-test.js
+++ b/packages/core/tests/unit/components/navi-visualizations/table-test.js
@@ -425,7 +425,7 @@ module('Unit | Component | table', function (hooks) {
           ],
           sorts: [{ type: 'metric', field: 'uniqueIdentifier', parameters: {}, direction: 'asc', source: 'bardOne' }],
           rollup: {
-            columns: ['cid_osId'],
+            columnCids: ['cid_osId'],
             grandTotal: true,
           },
         },

--- a/packages/core/tests/unit/models/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/models/bard-request-v2/request-test.js
@@ -426,7 +426,7 @@ module('Unit | Model | Fragment | BardRequest  - Request', function (hooks) {
           },
         ],
         rollup: {
-          columns: [],
+          columnCids: [],
           grandTotal: false,
         },
         table: 'network',
@@ -469,7 +469,7 @@ module('Unit | Model | Fragment | BardRequest  - Request', function (hooks) {
     assert.deepEqual(
       request.rollup.toJSON(),
       {
-        columns: ['2222222222'],
+        columnCids: ['2222222222'],
         grandTotal: false,
       },
       'Adding a dimension column works as expected'
@@ -479,7 +479,7 @@ module('Unit | Model | Fragment | BardRequest  - Request', function (hooks) {
     assert.deepEqual(
       request.rollup.toJSON(),
       {
-        columns: ['2222222222', '3333333333'],
+        columnCids: ['2222222222', '3333333333'],
         grandTotal: false,
       },
       'Adding another dimension pushes it to end of columns array'
@@ -489,7 +489,7 @@ module('Unit | Model | Fragment | BardRequest  - Request', function (hooks) {
     assert.deepEqual(
       request.rollup.toJSON(),
       {
-        columns: ['3333333333'],
+        columnCids: ['3333333333'],
         grandTotal: false,
       },
       'Correct column was removed'
@@ -499,7 +499,7 @@ module('Unit | Model | Fragment | BardRequest  - Request', function (hooks) {
     assert.deepEqual(
       request.rollup.toJSON(),
       {
-        columns: ['3333333333'],
+        columnCids: ['3333333333'],
         grandTotal: true,
       },
       'Grand Total is toggled'
@@ -512,7 +512,7 @@ module('Unit | Model | Fragment | BardRequest  - Request', function (hooks) {
     assert.deepEqual(
       clonedRequest.rollup.toJSON(),
       {
-        columns: ['3333333333', '1111111111'],
+        columnCids: ['3333333333', '1111111111'],
         grandTotal: true,
       },
       'Rollup was cloned correctly'

--- a/packages/core/tests/unit/models/dashboard-widget-test.js
+++ b/packages/core/tests/unit/models/dashboard-widget-test.js
@@ -106,7 +106,7 @@ module('Unit | Model | dashboard widget', function (hooks) {
                 },
               ],
               rollup: {
-                columns: [],
+                columnCids: [],
                 grandTotal: false,
               },
               limit: null,

--- a/packages/core/tests/unit/models/report-test.js
+++ b/packages/core/tests/unit/models/report-test.js
@@ -62,7 +62,7 @@ const ExpectedRequest = {
       },
     ],
     rollup: {
-      columns: [],
+      columnCids: [],
       grandTotal: false,
     },
     limit: null,

--- a/packages/dashboards/tests/unit/routes/dashboards/dashboard/widgets/new-test.js
+++ b/packages/dashboards/tests/unit/routes/dashboards/dashboard/widgets/new-test.js
@@ -12,7 +12,7 @@ const NEW_MODEL = {
       columns: [],
       sorts: [],
       rollup: {
-        columns: [],
+        columnCids: [],
         grandTotal: false,
       },
       limit: null,

--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -273,7 +273,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
    */
   _buildRollupParam(request: RequestV2): string {
     const columns = request.columns;
-    const rollupColumnCids = request.rollup?.columns || [];
+    const rollupColumnCids = request.rollup?.columnCids || [];
     return [
       ...columns.reduce((colSet, requestColumn) => {
         if (rollupColumnCids.includes(requestColumn.cid ?? '')) {
@@ -303,7 +303,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
     timeGrain = 'isoWeek' === timeGrain ? 'week' : timeGrain;
     let dimensions = this._buildDimensionsPath(request);
 
-    if ((request.rollup?.columns?.length ?? -1) > 0 || request?.rollup?.grandTotal) {
+    if ((request.rollup?.columnCids?.length ?? -1) > 0 || request?.rollup?.grandTotal) {
       dimensions = `${dimensions}/__rollupMask`;
     }
 

--- a/packages/data/addon/adapters/facts/interface.ts
+++ b/packages/data/addon/adapters/facts/interface.ts
@@ -65,7 +65,7 @@ export type Sort = {
 };
 
 export type Rollup = {
-  columns: string[];
+  columnCids: string[];
   grandTotal: boolean;
 };
 

--- a/packages/data/tests/unit/adapters/facts/bard-test.ts
+++ b/packages/data/tests/unit/adapters/facts/bard-test.ts
@@ -108,7 +108,7 @@ const TestRequest: RequestV2 = {
     ],
     sorts: [],
     rollup: {
-      columns: [],
+      columnCids: [],
       grandTotal: false,
     },
   },
@@ -124,7 +124,7 @@ const TestRequest: RequestV2 = {
     },
   },
   TestRequestWithRollup: RequestV2 = Object.assign(cloneDeep(TestRequest), {
-    rollup: { columns: ['znmxcv', 'ipuhozxvc', 'dt1'], grandTotal: true },
+    rollup: { columnCids: ['znmxcv', 'ipuhozxvc', 'dt1'], grandTotal: true },
   }),
   MockBardResponse: ResponseData = [200, { 'Content-Type': 'application/json' }, JSON.stringify(Response)];
 

--- a/packages/reports/addon/components/navi-column-config.ts
+++ b/packages/reports/addon/components/navi-column-config.ts
@@ -45,7 +45,7 @@ export default class NaviColumnConfig extends Component<NaviColumnConfigArgs> {
   /**
    * Dimension and metric columns from the request
    */
-  @computed('args.report.request.{columns.[],columns.@each.parameters,filters.[],sorts.[],rollup.columns.[]}')
+  @computed('args.report.request.{columns.[],columns.@each.parameters,filters.[],sorts.[],rollup.columnCids.[]}')
   get columns(): ConfigColumn[] {
     const { request } = this.args.report;
     const requiredColumns = this.requestConstrainer.getConstrainedProperties(request).columns || new Set();

--- a/packages/reports/addon/components/navi-column-config.ts
+++ b/packages/reports/addon/components/navi-column-config.ts
@@ -58,7 +58,7 @@ export default class NaviColumnConfig extends Component<NaviColumnConfigArgs> {
         return {
           isFiltered: filteredColumns.includes(column.canonicalName),
           isRequired: requiredColumns.has(column),
-          isRollup: rollup.columns.includes(column.cid),
+          isRollup: rollup.columnCids.includes(column.cid),
           fragment: column,
         };
       });

--- a/packages/reports/tests/unit/consumers/request/rollup-test.ts
+++ b/packages/reports/tests/unit/consumers/request/rollup-test.ts
@@ -74,14 +74,18 @@ module('Unit | Consumer | request rollup', function (hooks) {
       Consumer.send(RequestActions.PUSH_ROLLUP_COLUMN, Route, OS);
     });
 
-    assert.deepEqual(CurrentModel.request?.rollup?.columns[0], 'c1', 'pushes requested column to rollup on request');
+    assert.deepEqual(CurrentModel.request?.rollup?.columnCids[0], 'c1', 'pushes requested column to rollup on request');
 
     run(() => {
       Consumer.send(RequestActions.PUSH_ROLLUP_COLUMN, Route, AGE);
       Consumer.send(RequestActions.PUSH_ROLLUP_COLUMN, Route, DEVICE_TYPE);
     });
 
-    assert.deepEqual(CurrentModel.request.rollup?.columns, ['c1', 'c2', 'c3'], 'Columns are added in the right order');
+    assert.deepEqual(
+      CurrentModel.request.rollup?.columnCids,
+      ['c1', 'c2', 'c3'],
+      'Columns are added in the right order'
+    );
   });
 
   test('REMOVE_ROLLUP_COLUMN', function (assert) {
@@ -93,7 +97,7 @@ module('Unit | Consumer | request rollup', function (hooks) {
       Consumer.send(RequestActions.REMOVE_ROLLUP_COLUMN, Route, AGE);
     });
 
-    assert.deepEqual(CurrentModel.request.rollup?.columns, ['c1', 'c3'], 'The correct columns is removed');
+    assert.deepEqual(CurrentModel.request.rollup?.columnCids, ['c1', 'c3'], 'The correct columns is removed');
   });
 
   test('UPDATE_GRAND_TOTAL', function (assert) {
@@ -119,7 +123,7 @@ module('Unit | Consumer | request rollup', function (hooks) {
       Consumer.send(RequestActions.PUSH_ROLLUP_COLUMN, Route, DEVICE_TYPE);
       Consumer.send(RequestActions.REMOVE_COLUMN_FRAGMENT, Route, AGE);
     });
-    assert.deepEqual(CurrentModel.request.rollup?.columns, ['c1', 'c3'], 'The correct columns is removed');
+    assert.deepEqual(CurrentModel.request.rollup?.columnCids, ['c1', 'c3'], 'The correct columns is removed');
   });
 
   test('Column not in request assertion', function (assert) {

--- a/packages/reports/tests/unit/routes/reports/new-test.ts
+++ b/packages/reports/tests/unit/routes/reports/new-test.ts
@@ -16,7 +16,7 @@ const NEW_MODEL = {
     filters: [],
     limit: null,
     rollup: {
-      columns: [],
+      columnCids: [],
       grandTotal: false,
     },
     requestVersion: '2.0',

--- a/packages/reports/tests/unit/serializers/report-test.js
+++ b/packages/reports/tests/unit/serializers/report-test.js
@@ -60,7 +60,7 @@ module('Unit | Serializer | Report', function (hooks) {
               },
             ],
             rollup: {
-              columns: [],
+              columnCids: [],
               grandTotal: false,
             },
             limit: null,
@@ -162,7 +162,7 @@ module('Unit | Serializer | Report', function (hooks) {
               },
             ],
             rollup: {
-              columns: [],
+              columnCids: [],
               grandTotal: false,
             },
             limit: null,

--- a/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/ReportTest.kt
+++ b/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/ReportTest.kt
@@ -99,7 +99,7 @@ class ReportTest : IntegrationTest() {
             |"filters":[{"field":"id", "values":["-1", "102", "103"], "type":"dimension", "parameters":{}, "operator":"include"}], 
             |"requestVersion":"2.0", 
             |"sorts":[], 
-            |"rollup": {"columns":[], "grandTotal":false},
+            |"rollup": {"columnCids":[], "grandTotal":false},
             |"dataSource":"", 
             |"table":"base"
             |}

--- a/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/RequestV2Test.kt
+++ b/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/RequestV2Test.kt
@@ -221,7 +221,7 @@ class RequestV2Test : IntegrationTest() {
                             "title": "A Report With Rollup",
                             "request": {
                                 "rollup": {
-                                    "columns": ["cid1", "cid3"],
+                                    "columnCids": ["cid1", "cid3"],
                                     "grandTotal": true
                                 },
                                 "requestVersion": "2.0"
@@ -249,7 +249,7 @@ class RequestV2Test : IntegrationTest() {
             .then()
             .assertThat()
             .statusCode(HttpStatus.SC_OK)
-            .body("data.attributes.request.rollup.columns", hasItems("cid1", "cid3"))
+            .body("data.attributes.request.rollup.columnCids", hasItems("cid1", "cid3"))
             .body("data.attributes.request.rollup.grandTotal", equalTo(true))
 
         given()
@@ -264,7 +264,7 @@ class RequestV2Test : IntegrationTest() {
                             "title": "A Report With Rollup",
                             "request": {
                                 "rollup": {
-                                    "columns": [],
+                                    "columnCids": [],
                                     "grandTotal": false
                                 },
                                 "requestVersion": "2.0"
@@ -294,7 +294,7 @@ class RequestV2Test : IntegrationTest() {
             .then()
             .assertThat()
             .statusCode(HttpStatus.SC_OK)
-            .body("data.attributes.request.rollup.columns", equalTo(emptyStringList))
+            .body("data.attributes.request.rollup.columnCids", equalTo(emptyStringList))
             .body("data.attributes.request.rollup.grandTotal", equalTo(false))
     }
 

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Rollup.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/Rollup.kt
@@ -5,6 +5,6 @@
 package com.yahoo.navi.ws.models.beans.fragments.request
 
 data class Rollup(
-    var columns: List<String> = emptyList(), // cid list
+    var columnCids: List<String> = emptyList(), // cid list
     var grandTotal: Boolean = false
 )


### PR DESCRIPTION
## Description

Changes rollup contract from rollup.columns to rollup.columnCids

## Proposed Changes

- rename the prop everywhere

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
