### PR TITLE
Update: Allow admin to create/modify/delete entities

### DIFF
--- a/packages/webservice/app/build.gradle.kts
+++ b/packages/webservice/app/build.gradle.kts
@@ -92,7 +92,7 @@ tasks.register<NpmTask>("buildUI") {
 }
 
 tasks.register<Copy>("copyNaviApp") {
-    //dependsOn("buildUI")
+    dependsOn("buildUI")
     from("../../app/dist")
     into("$buildDir/resources/main/META-INF/resources/ui")
 }

--- a/packages/webservice/app/build.gradle.kts
+++ b/packages/webservice/app/build.gradle.kts
@@ -30,7 +30,7 @@ repositories {
 dependencies {
     implementation(project(":models"))
     implementation("org.springframework.boot:spring-boot-starter-security")
-    implementation("com.yahoo.elide", "elide-spring-boot-starter", "5.0.9")
+    implementation("com.yahoo.elide", "elide-spring-boot-starter", "5.0.12")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.h2database", "h2", "1.3.176")
     // drivers for models
@@ -49,7 +49,7 @@ dependencies {
     implementation("org.liquibase", "liquibase-core", "3.8.1")
 
     //Enables access logs.
-    implementation("net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1")
+    implementation("net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.9.0")
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
@@ -92,7 +92,7 @@ tasks.register<NpmTask>("buildUI") {
 }
 
 tasks.register<Copy>("copyNaviApp") {
-    dependsOn("buildUI")
+    //dependsOn("buildUI")
     from("../../app/dist")
     into("$buildDir/resources/main/META-INF/resources/ui")
 }

--- a/packages/webservice/app/src/main/kotlin/com/yahoo/navi/ws/filters/AuthFilter.kt
+++ b/packages/webservice/app/src/main/kotlin/com/yahoo/navi/ws/filters/AuthFilter.kt
@@ -22,16 +22,11 @@ import javax.servlet.http.HttpServletRequestWrapper
 class AuthFilter(private val userDetailsService: UserDetailsService) : Filter {
     override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
         val user = (request as HttpServletRequest).getHeader("User") ?: "admin"
-        var authorities: Collection<GrantedAuthority>
-        if (user !== null) {
-            authorities = try {
-                val userDetails = userDetailsService.loadUserByUsername(user)
-                userDetails.authorities
-            } catch (e: UsernameNotFoundException) {
-                ArrayList<GrantedAuthority>()
-            }
-        } else {
-            authorities = ArrayList<GrantedAuthority>()
+        val authorities: Collection<GrantedAuthority> = try {
+            val userDetails = userDetailsService.loadUserByUsername(user)
+            userDetails.authorities
+        } catch (e: UsernameNotFoundException) {
+            emptyList()
         }
 
         chain.run {

--- a/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/framework/IntegrationTest.kt
+++ b/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/framework/IntegrationTest.kt
@@ -44,9 +44,9 @@ abstract class IntegrationTest : RestAssuredSupport {
     /**
      * Registers a test user
      */
-    fun registerUser(user: String) {
+    fun registerUser(user: String, submitter: String? = user) {
         given()
-            .header("User", user)
+            .header("User", submitter)
             .contentType("application/vnd.api+json")
             .body(
                 """
@@ -91,9 +91,9 @@ abstract class IntegrationTest : RestAssuredSupport {
     /**
      * Registers user-role relationship
      */
-    fun registerUserRole(role: String, user: String) {
+    fun registerUserRole(role: String, user: String, submitter: String? = user) {
         given()
-            .header("User", user)
+            .header("User", submitter)
             .contentType("application/vnd.api+json")
             .body(
                 """
@@ -117,7 +117,7 @@ abstract class IntegrationTest : RestAssuredSupport {
      * @return number returned by COUNT query
      */
     fun getCountForSelectQuery(query: String): Int {
-        var numberOfRows: Int
+        val numberOfRows: Int
         try {
             val rs = this.entityManager.createQuery(query)
             numberOfRows = rs.resultList.size

--- a/packages/webservice/models/build.gradle.kts
+++ b/packages/webservice/models/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     `maven-publish`
     kotlin("plugin.allopen") version "1.3.72"
     kotlin("plugin.jpa") version "1.3.72"
-    `signing`
+    signing
 }
 
 java {
@@ -23,7 +23,7 @@ allOpen {
 }
 
 dependencies {
-    implementation("com.yahoo.elide", "elide-core", "5.0.9")
+    implementation("com.yahoo.elide", "elide-core", "5.0.12")
     implementation("javax.persistence", "javax.persistence-api", "2.2")
     implementation("org.hibernate", "hibernate-core", "5.4.15.Final")
     implementation("jakarta.mail:jakarta.mail-api:1.6.7")
@@ -59,7 +59,7 @@ publishing {
                 licenses {
                     license {
                         name.set("MIT License")
-                        url.set("http://www.opensource.org/licenses/mit-license.php")
+                        url.set("https://www.opensource.org/licenses/mit-license.php")
                         distribution.set("repo")
                     }
                 }
@@ -71,7 +71,7 @@ publishing {
                 scm {
                     connection.set("scm:git:https://github.com/yavin-dev/framework.git")
                     developerConnection.set("scm:git:ssh:git@github.com:yavin-dev/framework.git")
-                    url.set("http://yavin.dev")
+                    url.set("https://yavin.dev")
                 }
             }
         }
@@ -82,10 +82,10 @@ publishing {
             val snapshotsRepoUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
             // This line is evaluated before gradle.taskGraph.whenReady so the version did not contain "SNAPSHOT" in name,
             // so it was using releaseUrl instead of snapshotUrl. isSnapshot is passed in as project property in maven-publish.sh.
-            url = if (project.hasProperty("isSnapshot") && project.property("isSnapshot").toString().equals("true")) snapshotsRepoUrl else releasesRepoUrl
+            url = if (project.hasProperty("isSnapshot") && project.property("isSnapshot").toString() == "true") snapshotsRepoUrl else releasesRepoUrl
             credentials {
-                username = System.getenv("OSSRH_USER") as String?
-                password = System.getenv("OSSRH_TOKEN") as String?
+                username = System.getenv("OSSRH_USER")
+                password = System.getenv("OSSRH_TOKEN")
 
             }
         }
@@ -105,7 +105,7 @@ gradle.taskGraph.whenReady {
             tag = "-${project.property("publishTag")}"
         }
         var snapshot = ""
-        if(project.hasProperty("isSnapshot") && project.property("isSnapshot").toString().equals("true")) {
+        if(project.hasProperty("isSnapshot") && project.property("isSnapshot").toString() == "true") {
             snapshot = "-SNAPSHOT"
         }
         version = "${version}${tag}${snapshot}"

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Dashboard.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Dashboard.kt
@@ -12,6 +12,7 @@ import com.yahoo.elide.annotation.LifeCycleHookBinding
 import com.yahoo.elide.annotation.UpdatePermission
 import com.yahoo.navi.ws.models.beans.fragments.DashboardPresentation
 import com.yahoo.navi.ws.models.beans.fragments.request.DashboardFilter
+import com.yahoo.navi.ws.models.checks.DefaultAdminCheck.Companion.IS_ADMIN
 import com.yahoo.navi.ws.models.checks.DefaultEditorsCheck.Companion.IS_EDITOR
 import com.yahoo.navi.ws.models.checks.DefaultOwnerCheck.Companion.IS_OWNER
 import com.yahoo.navi.ws.models.hooks.DashboardDeletionHook
@@ -28,9 +29,9 @@ import javax.persistence.OneToMany
 @Entity
 @Include(name = "dashboards")
 @DiscriminatorValue("dashboard")
-@CreatePermission(expression = IS_OWNER)
-@UpdatePermission(expression = "$IS_OWNER OR $IS_EDITOR")
-@DeletePermission(expression = IS_OWNER)
+@CreatePermission(expression = "$IS_OWNER OR $IS_ADMIN")
+@UpdatePermission(expression = "$IS_OWNER OR $IS_EDITOR OR $IS_ADMIN")
+@DeletePermission(expression = "$IS_OWNER OR $IS_ADMIN")
 @LifeCycleHookBinding(
     phase = LifeCycleHookBinding.TransactionPhase.PREFLUSH,
     operation = LifeCycleHookBinding.Operation.DELETE,

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/DashboardWidget.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/DashboardWidget.kt
@@ -13,6 +13,7 @@ import com.yahoo.elide.core.exceptions.InvalidValueException
 import com.yahoo.navi.ws.models.beans.fragments.DashboardWidgetVisualization
 import com.yahoo.navi.ws.models.beans.fragments.Request
 import com.yahoo.navi.ws.models.beans.fragments.RequestList
+import com.yahoo.navi.ws.models.checks.DefaultAdminCheck.Companion.IS_ADMIN
 import com.yahoo.navi.ws.models.checks.DefaultEditorsCheck.Companion.IS_EDITOR
 import com.yahoo.navi.ws.models.checks.DefaultNobodyCheck.Companion.NOBODY
 import com.yahoo.navi.ws.models.checks.DefaultOwnerCheck.Companion.IS_OWNER
@@ -34,9 +35,9 @@ import javax.persistence.Transient
 
 @Entity
 @Include(rootLevel = false, name = "dashboardWidgets")
-@CreatePermission(expression = "$IS_OWNER OR $IS_EDITOR")
-@UpdatePermission(expression = "$IS_OWNER OR $IS_EDITOR")
-@DeletePermission(expression = "$IS_OWNER OR $IS_EDITOR")
+@CreatePermission(expression = "$IS_OWNER OR $IS_EDITOR OR $IS_ADMIN")
+@UpdatePermission(expression = "$IS_OWNER OR $IS_EDITOR OR $IS_ADMIN")
+@DeletePermission(expression = "$IS_OWNER OR $IS_EDITOR OR $IS_ADMIN")
 class DashboardWidget : HasOwner, HasEditors {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/DeliveryRule.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/DeliveryRule.kt
@@ -14,9 +14,10 @@ import com.yahoo.navi.ws.models.beans.enums.DeliveryFrequency
 import com.yahoo.navi.ws.models.beans.fragments.DeliveryFormat
 import com.yahoo.navi.ws.models.beans.fragments.SchedulingRules
 import com.yahoo.navi.ws.models.checks.DefaultAdminCheck
+import com.yahoo.navi.ws.models.checks.DefaultAdminCheck.Companion.IS_ADMIN
 import com.yahoo.navi.ws.models.checks.DefaultJobRunnerCheck
 import com.yahoo.navi.ws.models.checks.DefaultNobodyCheck
-import com.yahoo.navi.ws.models.checks.DefaultOwnerCheck
+import com.yahoo.navi.ws.models.checks.DefaultOwnerCheck.Companion.IS_OWNER
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.Parameter
 import org.hibernate.annotations.Type
@@ -40,9 +41,9 @@ import javax.validation.constraints.Size
 @Entity
 @Include(name = "deliveryRules")
 @DiscriminatorValue("deliveryRule")
-@CreatePermission(expression = "${DefaultOwnerCheck.IS_OWNER} OR ${DefaultAdminCheck.IS_ADMIN}")
-@UpdatePermission(expression = "${DefaultOwnerCheck.IS_OWNER} OR ${DefaultAdminCheck.IS_ADMIN}")
-@DeletePermission(expression = "${DefaultOwnerCheck.IS_OWNER} OR ${DefaultAdminCheck.IS_ADMIN}")
+@CreatePermission(expression = "$IS_OWNER OR $IS_ADMIN")
+@UpdatePermission(expression = "$IS_OWNER OR $IS_ADMIN")
+@DeletePermission(expression = "$IS_OWNER OR $IS_ADMIN")
 class DeliveryRule : HasOwner {
 
     @Id

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Report.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/Report.kt
@@ -12,6 +12,7 @@ import com.yahoo.elide.annotation.LifeCycleHookBinding
 import com.yahoo.elide.annotation.UpdatePermission
 import com.yahoo.navi.ws.models.beans.fragments.Request
 import com.yahoo.navi.ws.models.beans.fragments.Visualization
+import com.yahoo.navi.ws.models.checks.DefaultAdminCheck.Companion.IS_ADMIN
 import com.yahoo.navi.ws.models.checks.DefaultOwnerCheck.Companion.IS_OWNER
 import com.yahoo.navi.ws.models.hooks.ReportDeletionHook
 import org.hibernate.annotations.Parameter
@@ -27,9 +28,9 @@ import javax.persistence.OneToMany
 @Entity
 @DiscriminatorValue("report")
 @Include(name = "reports")
-@CreatePermission(expression = IS_OWNER)
-@UpdatePermission(expression = IS_OWNER)
-@DeletePermission(expression = IS_OWNER)
+@CreatePermission(expression = "$IS_OWNER OR $IS_ADMIN")
+@UpdatePermission(expression = "$IS_OWNER OR $IS_ADMIN")
+@DeletePermission(expression = "$IS_OWNER OR $IS_ADMIN")
 @LifeCycleHookBinding(
     phase = LifeCycleHookBinding.TransactionPhase.PREFLUSH,
     operation = LifeCycleHookBinding.Operation.DELETE,

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/User.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/User.kt
@@ -8,6 +8,7 @@ import com.yahoo.elide.annotation.DeletePermission
 import com.yahoo.elide.annotation.Include
 import com.yahoo.elide.annotation.LifeCycleHookBinding
 import com.yahoo.elide.annotation.UpdatePermission
+import com.yahoo.navi.ws.models.checks.DefaultAdminCheck.Companion.IS_ADMIN
 import com.yahoo.navi.ws.models.checks.DefaultDashboardOwnerCheck.Companion.IS_DASHBOARD_OWNER
 import com.yahoo.navi.ws.models.checks.DefaultNobodyCheck.Companion.NOBODY
 import com.yahoo.navi.ws.models.checks.DefaultSameUserCheck.Companion.IS_SAME_USER
@@ -29,8 +30,8 @@ import javax.validation.constraints.NotBlank
 
 @Entity
 @Include(name = "users")
-@DeletePermission(expression = NOBODY)
-@UpdatePermission(expression = IS_SAME_USER)
+@DeletePermission(expression = "$NOBODY OR $IS_ADMIN")
+@UpdatePermission(expression = "$IS_SAME_USER OR $IS_ADMIN")
 @LifeCycleHookBinding(
     operation = LifeCycleHookBinding.Operation.CREATE,
     phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT,

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/DashboardDeletionHook.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/DashboardDeletionHook.kt
@@ -23,11 +23,11 @@ class DashboardDeletionHook : LifeCycleHook<Dashboard> {
         requestScope: RequestScope?,
         changes: Optional<ChangeSpec>?
     ) {
-        var favoriteUsers = dashboard?.favoritedBy
+        val favoriteUsers = dashboard?.favoritedBy
 
         if (favoriteUsers != null) {
             for (user in favoriteUsers) {
-                user?.favoriteDashboards?.remove(dashboard)
+                user.favoriteDashboards.remove(dashboard)
             }
         }
     }

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/ReportDeletionHook.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/ReportDeletionHook.kt
@@ -17,17 +17,17 @@ import java.util.Optional
  */
 class ReportDeletionHook : LifeCycleHook<Report> {
     override fun execute(
-        operation: LifeCycleHookBinding.Operation?,
-        phase: LifeCycleHookBinding.TransactionPhase?,
-        report: Report?,
-        requestScope: RequestScope?,
-        changes: Optional<ChangeSpec>?
+        operation: LifeCycleHookBinding.Operation,
+        phase: LifeCycleHookBinding.TransactionPhase,
+        report: Report,
+        requestScope: RequestScope,
+        changes: Optional<ChangeSpec>
     ) {
-        var favoriteUsers = report?.favoritedBy
+        val favoriteUsers = report.favoritedBy
 
         if (favoriteUsers != null) {
             for (user in favoriteUsers) {
-                user?.favoriteReports?.remove(report)
+                user.favoriteReports.remove(report)
             }
         }
     }

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/UserValidationHook.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/hooks/UserValidationHook.kt
@@ -6,30 +6,37 @@
 package com.yahoo.navi.ws.models.hooks
 
 import com.yahoo.elide.annotation.LifeCycleHookBinding
+import com.yahoo.elide.core.dictionary.EntityDictionary
 import com.yahoo.elide.core.exceptions.BadRequestException
 import com.yahoo.elide.core.lifecycle.LifeCycleHook
 import com.yahoo.elide.core.security.ChangeSpec
 import com.yahoo.elide.core.security.RequestScope
 import com.yahoo.navi.ws.models.beans.User
+import com.yahoo.navi.ws.models.checks.DefaultAdminCheck
+import com.yahoo.navi.ws.models.checks.DefaultAdminCheck.Companion.IS_ADMIN
 import java.util.Optional
+import javax.inject.Inject
 
 /**
  * Validates a User model on creation.  Elide 5 does not support CreatePermission checks
  * on ID fields - and so this logic is implemented as a hook.  Longer term, Navi should
  * not overload the ID field - it should be a simple surrogate key.
  */
-class UserValidationHook : LifeCycleHook<User> {
-    override fun execute(
-        operation: LifeCycleHookBinding.Operation?,
-        phase: LifeCycleHookBinding.TransactionPhase?,
-        user: User?,
-        requestScope: RequestScope?,
-        changes: Optional<ChangeSpec>?
-    ) {
-        val principalName = requestScope?.user?.name
-        val userName = user?.id
+class UserValidationHook() : LifeCycleHook<User> {
+    @Inject
+    private lateinit var dictionary: EntityDictionary
 
-        if (principalName.isNullOrEmpty() || userName != principalName) {
+    /**
+     * Validates that the current requesting user is an admin or the same user that is being created
+     */
+    override fun execute(operation: LifeCycleHookBinding.Operation, phase: LifeCycleHookBinding.TransactionPhase, user: User, requestScope: RequestScope, changes: Optional<ChangeSpec>) {
+        val adminCheck = dictionary.injector.instantiate(dictionary.getCheck(IS_ADMIN)) as DefaultAdminCheck?
+        val isRequestingUserAdmin = adminCheck?.ok(requestScope.user) ?: false
+
+        val principalName = requestScope.user?.name
+        val userName = user.id
+
+        if (principalName.isNullOrEmpty() || userName != principalName && !isRequestingUserAdmin) {
             throw BadRequestException("Forbidden User Identity")
         }
     }


### PR DESCRIPTION
## Description
Currently admins do not have the ability to create/update/delete any users/reports/dashboards/widgets/deliveryRules/etc 

## Proposed Changes
allow admins to create/update/delete entities

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
