### PR TITLE
Fix: Support new elide error message format.

### DIFF
--- a/packages/core/addon/utils/persistence-error.js
+++ b/packages/core/addon/utils/persistence-error.js
@@ -2,7 +2,7 @@
  * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
-import { capitalize, last } from 'lodash-es';
+import { capitalize, tail } from 'lodash-es';
 
 /**
  * Returns formatted message based on error object
@@ -16,7 +16,9 @@ export function getApiErrMsg(error = {}, defaultMsg) {
   if (detail) {
     let message = detail[0];
     message = message.detail ?? message;
-    return capitalize(last(message.split(':')).trim());
+    const messages = message.split(':');
+    message = messages.length > 1 ? tail(messages).join(':') : messages[0];
+    return capitalize(message.trim());
   }
 
   return defaultMsg;

--- a/packages/core/addon/utils/persistence-error.js
+++ b/packages/core/addon/utils/persistence-error.js
@@ -14,7 +14,9 @@ export function getApiErrMsg(error = {}, defaultMsg) {
   const { detail } = error;
 
   if (detail) {
-    return capitalize(last(detail[0].split(':')).trim());
+    let message = detail[0];
+    message = message.detail ?? message;
+    return capitalize(last(message.split(':')).trim());
   }
 
   return defaultMsg;

--- a/packages/core/tests/unit/utils/persistence-error-test.js
+++ b/packages/core/tests/unit/utils/persistence-error-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Utility | persistence error', function () {
   test('getApiErrMsg', function (assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     assert.equal(getApiErrMsg({}, 'default'), 'default', 'getApiErrMsg returns the default message if no detail');
 
@@ -19,6 +19,13 @@ module('Unit | Utility | persistence error', function () {
       getApiErrMsg({ detail }),
       'Object details',
       'getApiErrMsg returns the first formated detail element if detail is present'
+    );
+
+    detail = [{ detail: 'Error: Object details' }];
+    assert.equal(
+      getApiErrMsg({ detail }),
+      'Object details',
+      'getApiErrMsg returns the detail object if array contains detail objects'
     );
   });
 });

--- a/packages/core/tests/unit/utils/persistence-error-test.js
+++ b/packages/core/tests/unit/utils/persistence-error-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Utility | persistence error', function () {
   test('getApiErrMsg', function (assert) {
-    assert.expect(4);
+    assert.expect(5);
 
     assert.equal(getApiErrMsg({}, 'default'), 'default', 'getApiErrMsg returns the default message if no detail');
 
@@ -26,6 +26,13 @@ module('Unit | Utility | persistence error', function () {
       getApiErrMsg({ detail }),
       'Object details',
       'getApiErrMsg returns the detail object if array contains detail objects'
+    );
+
+    detail = [{ detail: 'Error: Object details: a, list, of things' }];
+    assert.equal(
+      getApiErrMsg({ detail }),
+      'Object details: a, list, of things',
+      'getApiErrMsg returns correct message if message contains additional colons'
     );
   });
 });

--- a/packages/reports/tests/acceptance/schedule-modal-test.js
+++ b/packages/reports/tests/acceptance/schedule-modal-test.js
@@ -499,7 +499,7 @@ module('Acceptance | Navi Report Schedule Modal', function (hooks) {
 
     assert.equal(
       find('.alert p').innerText.trim(),
-      'Invalid email: Must be a valid oath.com or yahoo-inc.com email',
+      'Invalid email: must be a valid oath.com or yahoo-inc.com email',
       'failing notification is shown if server returns 400'
     );
 

--- a/packages/reports/tests/acceptance/schedule-modal-test.js
+++ b/packages/reports/tests/acceptance/schedule-modal-test.js
@@ -481,9 +481,7 @@ module('Acceptance | Navi Report Schedule Modal', function (hooks) {
         400,
         {},
         {
-          errors: [
-            'InvalidValueException: Invalid value: Invalid Email: must be a valid oath.com or yahoo-inc.com email',
-          ],
+          errors: ['InvalidValueException: Invalid Email: must be a valid oath.com or yahoo-inc.com email'],
         }
       );
     });
@@ -501,7 +499,7 @@ module('Acceptance | Navi Report Schedule Modal', function (hooks) {
 
     assert.equal(
       find('.alert p').innerText.trim(),
-      'Must be a valid oath.com or yahoo-inc.com email',
+      'Invalid email: Must be a valid oath.com or yahoo-inc.com email',
       'failing notification is shown if server returns 400'
     );
 


### PR DESCRIPTION
## Description

Persistence error messages coming in as `{ errors: [{detail: 'msg'}] }` so we need to support this format

## Proposed Changes

- Make sure we can pull error messages from this format.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
