### PR TITLE
Fix: Enable API Query button even if valid request hasn't been run

### DIFF
--- a/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
+++ b/packages/dashboards/addon/templates/dashboards/dashboard/widgets/widget.hbs
@@ -40,18 +40,18 @@
       </div>
       <div class="xs-col-10-10 sm-col-10-10 col-6-10 p-x-0">
         <div class="navi-report-widget__header-actions">
-          {{!-- Get API action is only enabled when request is valid --}}
+          {{!-- API query action is enabled only when the request is valid --}}
           <span id="navi-report-widget__action-copy-api">
             <CommonActions::GetApi
               @request={{@model.request}}
-              disabled={{not @model.validations.isTruelyValid}}
+              disabled={{not @model.request.validations.isTruelyValid}}
             >
               <DenaliIcon @icon="code" />
               API query
             </CommonActions::GetApi>
           </span>
           <EmberTooltip @targetId="navi-report-widget__action-copy-api">
-            {{if @model.validations.isTruelyValid "Get API Query" "Unable to get API query on invalid widget"}}
+            {{if @model.request.validations.isTruelyValid "Get API Query" "Unable to get API query on invalid widget"}}
           </EmberTooltip>
 
           {{!-- Export action is only enabled when request is valid --}}

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -397,7 +397,7 @@ module('Acceptance | Dashboards', function (hooks) {
   });
 
   test('New widget', async function (assert) {
-    assert.expect(15);
+    assert.expect(17);
 
     // Check original set of widgets
     await visit('/dashboards/1');
@@ -412,6 +412,7 @@ module('Acceptance | Dashboards', function (hooks) {
     // Create new widget
     await click('.dashboard-header__add-widget-btn');
     await click('.add-widget__new-btn');
+    assert.dom('.get-api__action-btn').isDisabled('API query action is disabled when a new widget is created');
     await click('.report-builder-source-selector__source-button[data-source-name="Bard One"]');
     await click('.report-builder-source-selector__source-button[data-source-name="Network"]');
     await animationsSettled();
@@ -421,6 +422,8 @@ module('Acceptance | Dashboards', function (hooks) {
     await clickItem('dimension', 'Date Time');
     await selectChoose('.navi-column-config-item__parameter-trigger', 'Day');
     await clickItem('metric', 'Total Clicks');
+
+    assert.dom('.get-api__action-btn').isEnabled('API query action is enabled when the request is valid');
 
     // Save without running
     await click('.navi-report-widget__save-btn');

--- a/packages/dashboards/tests/acceptance/explore-widget-test.js
+++ b/packages/dashboards/tests/acceptance/explore-widget-test.js
@@ -192,18 +192,18 @@ module('Acceptance | Exploring Widgets', function (hooks) {
       .hasAttribute('href', /export\?reportModel=/, 'Export url contains serialized report');
   });
 
-  test('Get API action - enabled/disabled', async function (assert) {
+  test('API query action - enabled/disabled', async function (assert) {
     assert.expect(2);
 
     await visit('/dashboards/1/widgets/2/view');
-    assert.dom('.get-api__action-btn').isEnabled('Get API action is enabled for a valid request');
+    assert.dom('.get-api__action-btn').isEnabled('API query action is enabled for a valid request');
 
     // Remove all columns to create an invalid request
     await click('.navi-column-config-item__remove-icon[aria-label="delete time-dimension Date Time (day)"]');
     await click('.navi-column-config-item__remove-icon[aria-label="delete metric Nav Link Clicks"]');
     await click('.navi-column-config-item__remove-icon[aria-label="delete metric Ad Clicks"]');
 
-    assert.dom('.get-api__action-btn').isDisabled('Get API action is disabled when request is not valid');
+    assert.dom('.get-api__action-btn').isDisabled('API query action is disabled when the request is not valid');
   });
 
   test('Share action', async function (assert) {

--- a/packages/reports/addon/templates/components/report-actions.hbs
+++ b/packages/reports/addon/templates/components/report-actions.hbs
@@ -26,17 +26,17 @@
   </EmberTooltip>
 {{/if}}
 
-{{!-- API Query Enabled only for a valid report --}}
+{{!-- API Query Enabled only for a valid request --}}
 <span id="report-actions__copy-api">
   <CommonActions::GetApi
     @request={{@model.request}}
-    @disabled={{not @model.validations.isTruelyValid}}
+    @disabled={{not @model.request.validations.isTruelyValid}}
   >
     <DenaliIcon @icon="code" />API Query
   </CommonActions::GetApi>
 </span>
 <EmberTooltip @targetId="report-actions__copy-api">
-  {{if @model.validations.isTruelyValid "Get API Query" "Unable to get API query on invalid report"}}
+  {{if @model.request.validations.isTruelyValid "Get API Query" "Unable to get API query on invalid report"}}
 </EmberTooltip>
 
 <LinkTo

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -160,10 +160,11 @@ module('Acceptance | Navi Report', function (hooks) {
     config.navi.FEATURES.exportFileTypes = originalFlag;
   });
 
-  test('New report - copy api', async function (assert) {
-    assert.expect(4);
+  test('New report - API query', async function (assert) {
+    assert.expect(5);
 
     await newReport();
+    assert.dom('.get-api__action-btn').isDisabled('API query button is disabled when a new report is created');
     await clickItem('metric', 'Ad Clicks');
 
     //add date-dimension
@@ -175,8 +176,7 @@ module('Acceptance | Navi Report', function (hooks) {
     await click($('button.ember-power-calendar-day--current-month:contains(5)')[0]);
     await clickTrigger('.filter-values--date-range-input__high-value');
     await click($('button.ember-power-calendar-day--current-month:contains(10)')[0]);
-    assert.dom('.get-api__action-btn').isDisabled('Copy api button is disabled before running');
-    await click('.navi-report__run-btn');
+    assert.dom('.get-api__action-btn').isEnabled('API query button is enabled even before running');
     await click('.get-api__action-btn');
 
     assert.dom('.get-api__modal').exists('Copy modal is open');
@@ -793,17 +793,17 @@ module('Acceptance | Navi Report', function (hooks) {
     config.navi.FEATURES.enableTotals = originalTotalsFlag;
   });
 
-  test('Get API action - enabled/disabled', async function (assert) {
+  test('API query action - enabled/disabled', async function (assert) {
     await visit('/reports/13/view');
 
-    assert.dom('.get-api__action-btn').isNotDisabled('Get API action is enabled for a valid report');
+    assert.dom('.get-api__action-btn').isEnabled('API query action is enabled for a valid request');
 
     // Remove all metrics
     await click('.navi-column-config-item__remove-icon[aria-label="delete metric Ad Clicks"]');
     await click('.navi-column-config-item__remove-icon[aria-label="delete dimension Property (id)"]');
     await click('.navi-column-config-item__remove-icon[aria-label="delete time-dimension Date Time (day)"]');
 
-    assert.dom('.get-api__action-btn').isDisabled('Get API action is disabled for an invalid report');
+    assert.dom('.get-api__action-btn').isDisabled('API query action is disabled for an invalid request');
   });
 
   test('Share report', async function (assert) {
@@ -1768,7 +1768,6 @@ module('Acceptance | Navi Report', function (hooks) {
       'The selected dimensions are shown even with a comma'
     );
 
-    await click('.navi-report__run-btn');
     await click('.get-api__action-btn');
 
     const url = find('.get-api__api-input').value;


### PR DESCRIPTION
## Proposed Changes

Check validity of the request and not the report (which also checks `title`, `visualization`)

## Screenshots

![Sep-29-2021 21-24-46](https://user-images.githubusercontent.com/13946669/135387107-aeb8660b-e4d3-42e2-b8fb-8602747a6184.gif)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
