### PR TITLE
Fix: Request v2 normalizer adds dimensions with id field, table normalizer updates to use show fields/desc

### DIFF
--- a/packages/core/addon/mirage/fixtures/reports.ts
+++ b/packages/core/addon/mirage/fixtures/reports.ts
@@ -356,9 +356,14 @@ export default [
             displayName: 'Date',
           },
           {
-            field: 'property',
             type: 'dimension',
-            displayName: 'Property',
+            attributes: { name: 'multiSystemId', field: 'desc' },
+            displayName: 'Multi System Id (desc)',
+          },
+          {
+            type: 'dimension',
+            attributes: { name: 'multiSystemId', field: 'other' },
+            displayName: 'Multi System Id (other)',
           },
           {
             field: 'revenue(currency=USD)',
@@ -371,6 +376,10 @@ export default [
             displayName: 'Revenue (EUR)',
           },
         ],
+        showTotals: {
+          subtotal: 'multiSystemId',
+          grandTotal: true,
+        },
       },
     },
     request: {
@@ -395,7 +404,7 @@ export default [
       ],
       dimensions: [
         {
-          dimension: 'property',
+          dimension: 'multiSystemId',
         },
       ],
       filters: [],

--- a/packages/core/addon/serializers/dashboard-widget.ts
+++ b/packages/core/addon/serializers/dashboard-widget.ts
@@ -4,10 +4,14 @@
  */
 //@ts-ignore
 import AssetSerializer from './asset';
-import type Model from '@ember-data/model';
+import { inject as service } from '@ember/service';
 import { normalizeVisualization } from './report';
+import type Model from '@ember-data/model';
+import type NaviMetadataService from 'navi-data/services/navi-metadata';
 
 export default class DashboardWidgetSerializer extends AssetSerializer {
+  @service declare naviMetadata: NaviMetadataService;
+
   /**
    * Normalizes payload so that it can be applied to models correctly
    * @param type - class type as a DS model
@@ -18,7 +22,7 @@ export default class DashboardWidgetSerializer extends AssetSerializer {
     const normalized = super.normalize(type, dashboardWidget) as TODO;
 
     const { requests, visualization } = normalized.data?.attributes;
-    normalized.data.attributes.visualization = normalizeVisualization(requests[0], visualization);
+    normalized.data.attributes.visualization = normalizeVisualization(requests[0], visualization, this.naviMetadata);
 
     return normalized;
   }

--- a/packages/core/addon/serializers/report.ts
+++ b/packages/core/addon/serializers/report.ts
@@ -4,19 +4,21 @@
  */
 //@ts-ignore
 import AssetSerializer from './asset';
-import type Model from '@ember-data/model';
-import type RequestFragment from 'navi-core/models/bard-request-v2/request';
+import { inject as service } from '@ember/service';
 import { normalizeTableV2 } from './table';
 import { normalizeMetricLabelV2 } from './metric-label';
 import { normalizeLineChartV2 } from './line-chart';
 import { normalizeBarChartV2 } from './bar-chart';
 import { normalizeGoalGaugeV2 } from './goal-gauge';
 import { normalizePieChartV2 } from './pie-chart';
+import type Model from '@ember-data/model';
+import type RequestFragment from 'navi-core/models/bard-request-v2/request';
+import type NaviMetadataService from 'navi-data/services/navi-metadata';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function normalizeVisualization(request: RequestFragment, visualization?: any) {
+export function normalizeVisualization(request: RequestFragment, visualization: any, metadata: NaviMetadataService) {
   if (visualization?.type === 'table') {
-    return normalizeTableV2(request, visualization);
+    return normalizeTableV2(request, visualization, metadata);
   } else if (visualization?.type === 'metric-label') {
     return normalizeMetricLabelV2(request, visualization);
   } else if (visualization?.type === 'line-chart') {
@@ -32,6 +34,8 @@ export function normalizeVisualization(request: RequestFragment, visualization?:
 }
 
 export default class ReportSerializer extends AssetSerializer {
+  @service declare naviMetadata: NaviMetadataService;
+
   /**
    * Normalizes payload so that it can be applied to models correctly
    * @param type - class type as a DS model
@@ -42,7 +46,7 @@ export default class ReportSerializer extends AssetSerializer {
     const normalized = super.normalize(type, report) as TODO;
 
     const { request, visualization } = normalized.data?.attributes;
-    normalized.data.attributes.visualization = normalizeVisualization(request, visualization);
+    normalized.data.attributes.visualization = normalizeVisualization(request, visualization, this.naviMetadata);
 
     return normalized;
   }

--- a/packages/core/addon/utils/request.ts
+++ b/packages/core/addon/utils/request.ts
@@ -6,10 +6,8 @@ import { hasParameters, getAliasedMetrics, canonicalizeMetric } from 'navi-data/
 import { nanoid } from 'nanoid';
 import moment from 'moment';
 import { getPeriodForGrain } from 'navi-data/utils/date';
-import { assert } from '@ember/debug';
 import type { Parameters, SortDirection, RequestV2, FilterOperator } from 'navi-data/adapters/facts/interface';
 import type { GrainWithAll } from 'navi-data/serializers/metadata/bard';
-import type NaviMetadataService from 'navi-data/services/navi-metadata';
 
 type LogicalTable = {
   table: string;
@@ -152,11 +150,7 @@ export function normalizeV1(request: RequestV1<string>, namespace?: string): Req
  * @param namespace - request datasource
  * @returns request normalized into v2
  */
-export function normalizeV1toV2(
-  request: RequestV1<string>,
-  dataSource: string,
-  metadata?: NaviMetadataService
-): RequestV2 {
+export function normalizeV1toV2(request: RequestV1<string>, dataSource: string): RequestV2 {
   //normalize v1 request
   const normalized = Object.assign({}, normalizeV1(request, dataSource));
 
@@ -190,29 +184,12 @@ export function normalizeV1toV2(
   normalized.dimensions.forEach(({ dimension }) => {
     // skip if dimension is null or empty
     if (dimension) {
-      const dimMeta = metadata?.getById('dimension', dimension, dataSource);
-      // get all show fields
-      const showFields = dimMeta?.getFieldsForTag('show').map((f) => f.name) ?? [];
-
-      const allFields = dimMeta?.fields?.map((field) => field.name) ?? [];
-      // default to id/desc from available fields
-      const idOrDescFields = allFields.filter((field) => ['id', 'desc'].includes(field));
-
-      let fields = ['id'];
-      if (showFields.length) {
-        fields = showFields;
-      } else if (idOrDescFields.length) {
-        fields = idOrDescFields;
-      }
-      assert(`At least one dimension field must exist for ${dimension}`, fields.length > 0);
-      fields.forEach((field) =>
-        requestV2.columns.push({
-          cid: nanoid(10),
-          type: 'dimension',
-          field: removeNamespace(dimension, dataSource),
-          parameters: { field },
-        })
-      );
+      requestV2.columns.push({
+        cid: nanoid(10),
+        type: 'dimension',
+        field: removeNamespace(dimension, dataSource),
+        parameters: { field: 'id' }, // By default only request id
+      });
     }
   });
 

--- a/packages/core/tests/unit/models/report-test.js
+++ b/packages/core/tests/unit/models/report-test.js
@@ -41,14 +41,6 @@ const ExpectedRequest = {
       },
       {
         alias: null,
-        field: 'property',
-        parameters: {
-          field: 'desc',
-        },
-        type: 'dimension',
-      },
-      {
-        alias: null,
         field: 'adClicks',
         parameters: {},
         type: 'metric',
@@ -127,7 +119,7 @@ module('Unit | Model | report', function (hooks) {
   });
 
   test('Retrieving records', async function (assert) {
-    assert.expect(7);
+    assert.expect(6);
 
     await run(async () => {
       const report = await Store.findRecord('report', 1);

--- a/packages/core/tests/unit/serializers/bard-request-v2/request-test.js
+++ b/packages/core/tests/unit/serializers/bard-request-v2/request-test.js
@@ -109,7 +109,7 @@ module('Unit | Serializer | Request', function (hooks) {
 
     assert.equal(requestVersion, '2.0', 'request version is set correctly');
 
-    assert.equal(columns.length, 8, 'request has correct number of columns');
+    assert.equal(columns.length, 6, 'request has correct number of columns');
 
     assert.equal(columns.objectAt(0).columnMetadata.id, 'network.dateTime', 'dateTime column is normalized correctly');
     assert.equal(columns.objectAt(0).type, 'timeDimension', 'dateTime column type is set correctly');
@@ -118,8 +118,8 @@ module('Unit | Serializer | Request', function (hooks) {
     assert.equal(columns.objectAt(1).columnMetadata.id, 'age', 'dimension columns are normalized correctly');
     assert.deepEqual(columns.objectAt(1).parameters, { field: 'id' }, 'dimension columns have a field parameter');
 
-    assert.equal(columns.objectAt(5).columnMetadata.id, 'revenue', 'metric columns are normalized correctly');
-    assert.deepEqual(columns.objectAt(5).parameters, { currency: 'USD' }, 'metric columns have correct parameters');
+    assert.equal(columns.objectAt(3).columnMetadata.id, 'revenue', 'metric columns are normalized correctly');
+    assert.deepEqual(columns.objectAt(3).parameters, { currency: 'USD' }, 'metric columns have correct parameters');
 
     assert.equal(filters.length, 5, 'request has correct number of filter fragments');
 

--- a/packages/core/tests/unit/utils/request-test.ts
+++ b/packages/core/tests/unit/utils/request-test.ts
@@ -255,9 +255,9 @@ module('Unit | Utils | Request', function (hooks) {
   });
 
   test('normalize v1 to v2', function (assert) {
-    assert.expect(14);
+    assert.expect(12);
 
-    const normalized = normalizeV1toV2(request, 'bardOne', naviMetadata);
+    const normalized = normalizeV1toV2(request, 'bardOne');
 
     assert.equal(normalized.requestVersion, '2.0', 'requestVersion is set correctly');
 
@@ -290,24 +290,10 @@ module('Unit | Utils | Request', function (hooks) {
           },
         },
         {
-          field: 'age',
-          type: 'dimension',
-          parameters: {
-            field: 'desc',
-          },
-        },
-        {
           field: 'platform',
           type: 'dimension',
           parameters: {
             field: 'id',
-          },
-        },
-        {
-          field: 'platform',
-          type: 'dimension',
-          parameters: {
-            field: 'desc',
           },
         },
         {
@@ -441,7 +427,7 @@ module('Unit | Utils | Request', function (hooks) {
     request.intervals[0] = { start: '2021-01-01', end: '2021-01-03' };
 
     assert.deepEqual(
-      normalizeV1toV2(request, 'bardOne', naviMetadata).filters[0],
+      normalizeV1toV2(request, 'bardOne').filters[0],
       {
         type: 'timeDimension',
         field: 'network.dateTime',
@@ -458,7 +444,7 @@ module('Unit | Utils | Request', function (hooks) {
     request.intervals[0] = { start: '2021-02-01', end: '2021-02-08' };
 
     assert.deepEqual(
-      normalizeV1toV2(request, 'bardOne', naviMetadata).filters[0],
+      normalizeV1toV2(request, 'bardOne').filters[0],
       {
         type: 'timeDimension',
         field: 'network.dateTime',
@@ -475,7 +461,7 @@ module('Unit | Utils | Request', function (hooks) {
     request.intervals[0] = { start: '2021-01-01', end: '2021-03-01' };
 
     assert.deepEqual(
-      normalizeV1toV2(request, 'bardOne', naviMetadata).filters[0],
+      normalizeV1toV2(request, 'bardOne').filters[0],
       {
         type: 'timeDimension',
         field: 'network.dateTime',
@@ -492,7 +478,7 @@ module('Unit | Utils | Request', function (hooks) {
     request.intervals[0] = { start: '2021-01-01', end: '2021-04-01' };
 
     assert.deepEqual(
-      normalizeV1toV2(request, 'bardOne', naviMetadata).filters[0],
+      normalizeV1toV2(request, 'bardOne').filters[0],
       {
         type: 'timeDimension',
         field: 'network.dateTime',
@@ -509,7 +495,7 @@ module('Unit | Utils | Request', function (hooks) {
     request.intervals[0] = { start: '2021-01-01', end: '2022-01-01' };
 
     assert.deepEqual(
-      normalizeV1toV2(request, 'bardOne', naviMetadata).filters[0],
+      normalizeV1toV2(request, 'bardOne').filters[0],
       {
         type: 'timeDimension',
         field: 'network.dateTime',
@@ -539,7 +525,7 @@ module('Unit | Utils | Request', function (hooks) {
     };
 
     assert.deepEqual(
-      normalizeV1toV2(request, 'bardOne', naviMetadata),
+      normalizeV1toV2(request, 'bardOne'),
       {
         columns: [],
         dataSource: 'bardOne',
@@ -564,7 +550,7 @@ module('Unit | Utils | Request', function (hooks) {
   });
 
   test('normalize v1 to v2 - show fields', function (assert) {
-    assert.expect(3);
+    assert.expect(2);
 
     const request: RequestV1<string> = {
       intervals: [],
@@ -578,7 +564,7 @@ module('Unit | Utils | Request', function (hooks) {
       requestVersion: 'v1',
     };
 
-    const normalized = normalizeV1toV2(request, 'bardOne', naviMetadata);
+    const normalized = normalizeV1toV2(request, 'bardOne');
 
     const cids = normalized.columns.map((c) => c.cid);
     cids.forEach((cid, idx) => {
@@ -590,10 +576,7 @@ module('Unit | Utils | Request', function (hooks) {
     assert.deepEqual(
       normalized,
       {
-        columns: [
-          { type: 'dimension', field: 'multiSystemId', parameters: { field: 'desc' } },
-          { type: 'dimension', field: 'multiSystemId', parameters: { field: 'other' } },
-        ],
+        columns: [{ type: 'dimension', field: 'multiSystemId', parameters: { field: 'id' } }],
         dataSource: 'bardOne',
         filters: [],
         limit: null,
@@ -606,7 +589,7 @@ module('Unit | Utils | Request', function (hooks) {
   });
 
   test('normalize v1 to v2 - default fields', function (assert) {
-    assert.expect(4);
+    assert.expect(3);
 
     const dimension = 'contextId';
 
@@ -622,7 +605,7 @@ module('Unit | Utils | Request', function (hooks) {
       requestVersion: 'v1',
     };
 
-    const normalized = normalizeV1toV2(request, 'bardOne', naviMetadata);
+    const normalized = normalizeV1toV2(request, 'bardOne');
 
     const cids = normalized.columns.map((c) => c.cid);
     cids.forEach((cid, idx) => {
@@ -640,10 +623,7 @@ module('Unit | Utils | Request', function (hooks) {
     assert.deepEqual(
       normalized,
       {
-        columns: [
-          { type: 'dimension', field: dimension, parameters: { field: 'id' } },
-          { type: 'dimension', field: dimension, parameters: { field: 'desc' } },
-        ],
+        columns: [{ type: 'dimension', field: dimension, parameters: { field: 'id' } }],
         dataSource: 'bardOne',
         filters: [],
         limit: null,

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -597,7 +597,7 @@ module('Acceptance | Dashboards', function (hooks) {
     assert.expect(2);
 
     server.urlPrefix = `${config.navi.dataSources[0].uri}/v1`;
-    server.get('/data/network/day/os;show=id', function () {
+    server.get('/data/network/day/os;show=desc', function () {
       return new Response(403);
     });
     await visit('/dashboards/2/view');

--- a/packages/data/addon/mirage/routes/bard-lite.ts
+++ b/packages/data/addon/mirage/routes/bard-lite.ts
@@ -125,15 +125,15 @@ function _fakeDimensionValues(dimension: FiliDimension, count: number): Dimensio
   let fakeValues: DimensionRow[] = [];
 
   for (let i = 0; i < count; i++) {
-    let key = null;
+    let extraKeys = {};
     // used to generate alternative primary keys for dimensions that don't use `id` as their primaryKey (in this case uses `key` instead)
     if (dimension.name === 'multiSystemId') {
-      key = `k${i + 1}`;
+      extraKeys = { key: `k${i + 1}`, other: `o${i + 1}` };
     }
     fakeValues.push({
       id: `${i + 1}`,
       description: faker.commerce.productName(),
-      ...(key ? { key } : {}),
+      ...extraKeys,
     });
   }
 

--- a/packages/reports/tests/acceptance/multi-datasource-test.js
+++ b/packages/reports/tests/acceptance/multi-datasource-test.js
@@ -161,25 +161,25 @@ module('Acceptance | multi-datasource report builder', function (hooks) {
     //check visualizations are showing up correctly
     assert.deepEqual(
       findAll('.table-widget__table-headers .table-header-cell__title').map((el) => el.textContent.trim()),
-      ['Date Time (day)', 'Container (id)', 'Display Currency (id)', 'Used Amount', 'Revenue (GIL)'],
+      ['Date Time (day)', 'Container (desc)', 'Display Currency (desc)', 'Used Amount', 'Revenue (GIL)'],
       'Table displays correct header titles'
     );
     assert.dom('.table-widget__table .table-row-vc').exists('Table rows exist');
 
     await click('.visualization-toggle__option-icon[title="Bar Chart"]');
     assert.dom('.c3-axis-y-label').hasText('Used Amount', 'Bar chart has right Y axis label');
-    assert.dom('.c3-legend-item').containsText('2,ANG', 'Bar chart legend has right value');
+    assert.dom('.c3-legend-item').containsText('Bank,UNKNOWN', 'Bar chart legend has right value');
 
     await click('.visualization-toggle__option-icon[title="Line Chart"]');
     assert.dom('.c3-axis-y-label').hasText('Used Amount', 'Line chart has right Y Axis label');
-    assert.dom('.c3-legend-item').containsText('2,ANG', 'Line chart has right legend value');
+    assert.dom('.c3-legend-item').containsText('Bank,UNKNOWN', 'Line chart has right legend value');
 
     //check api url
     await click('.get-api__action-btn');
     assert
       .dom('.get-api__modal input')
       .hasValue(
-        'https://data2.naviapp.io/v1/data/inventory/day/container;show=id/displayCurrency;show=id/?dateTime=P3D%2Fcurrent&metrics=usedAmount%2Crevenue(currency%3DGIL)&filters=container%7Cid-in%5B%222%22%5D&having=usedAmount-gt%5B50%5D&format=json',
+        'https://data2.naviapp.io/v1/data/inventory/day/container;show=desc/displayCurrency;show=desc/?dateTime=P3D%2Fcurrent&metrics=usedAmount%2Crevenue(currency%3DGIL)&filters=container%7Cid-in%5B%222%22%5D&having=usedAmount-gt%5B50%5D&format=json',
         'shows api url from bardTwo datasource'
       );
 
@@ -190,7 +190,7 @@ module('Acceptance | multi-datasource report builder', function (hooks) {
       .dom('.export__download-link')
       .hasAttribute(
         'href',
-        'https://data2.naviapp.io/v1/data/inventory/day/container;show=id/displayCurrency;show=id/?dateTime=P3D%2Fcurrent&metrics=usedAmount%2Crevenue(currency%3DGIL)&filters=container%7Cid-in%5B%222%22%5D&having=usedAmount-gt%5B50%5D&format=csv',
+        'https://data2.naviapp.io/v1/data/inventory/day/container;show=desc/displayCurrency;show=desc/?dateTime=P3D%2Fcurrent&metrics=usedAmount%2Crevenue(currency%3DGIL)&filters=container%7Cid-in%5B%222%22%5D&having=usedAmount-gt%5B50%5D&format=csv',
         'uses csv export from right datasource'
       );
 

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -1278,7 +1278,7 @@ module('Acceptance | Navi Report', function (hooks) {
     assert.deepEqual(
       seriesLabels,
       ['Property 1', 'Property 2', 'Property 3', 'Property 4'],
-      '3 series are initially present'
+      '4 series are initially present'
     );
     assert.deepEqual(hiddenLabels, [], 'No series are initially hidden from chart');
 
@@ -1792,14 +1792,14 @@ module('Acceptance | Navi Report', function (hooks) {
       'mouse',
       '.table-header-row-vc--view .table-header-cell',
       '.table-header-cell[data-name="navClicks"]',
-      '.table-header-cell[data-name="property(field=id)"]',
+      '.table-header-cell[data-name="property(field=desc)"]',
       '.table-header-cell[data-name="adClicks"]',
       '.table-header-cell[data-name="network.dateTime(grain=day)"]'
     );
 
     assert.deepEqual(
       findAll('.table-header-row-vc--view .table-header-cell__title').map((el) => el.innerText.trim()),
-      ['Nav Link Clicks', 'Property (id)', 'Ad Clicks', 'Date Time (day)'],
+      ['Nav Link Clicks', 'Property (desc)', 'Ad Clicks', 'Date Time (day)'],
       'The headers are reordered as specified by the reorder'
     );
   });
@@ -1810,7 +1810,7 @@ module('Acceptance | Navi Report', function (hooks) {
 
     assert.deepEqual(
       findAll('.table-header-row-vc--view .table-header-cell__title').map((el) => el.innerText.trim()),
-      ['Date Time (day)', 'Property (id)', 'Ad Clicks', 'Nav Link Clicks'],
+      ['Date Time (day)', 'Property (desc)', 'Ad Clicks', 'Nav Link Clicks'],
       'The headers are ordered correctly'
     );
 
@@ -1818,14 +1818,14 @@ module('Acceptance | Navi Report', function (hooks) {
       'mouse',
       '.table-header-row-vc--view .table-header-cell',
       '.table-header-cell[data-name="navClicks"]',
-      '.table-header-cell[data-name="property(field=id)"]',
+      '.table-header-cell[data-name="property(field=desc)"]',
       '.table-header-cell[data-name="adClicks"]',
       '.table-header-cell[data-name="network.dateTime(grain=day)"]'
     );
 
     assert.deepEqual(
       findAll('.table-header-row-vc--view .table-header-cell__title').map((el) => el.innerText.trim()),
-      ['Nav Link Clicks', 'Property (id)', 'Ad Clicks', 'Date Time (day)'],
+      ['Nav Link Clicks', 'Property (desc)', 'Ad Clicks', 'Date Time (day)'],
       'The headers are reordered as specified by the reorder'
     );
 
@@ -1834,7 +1834,7 @@ module('Acceptance | Navi Report', function (hooks) {
 
     assert.deepEqual(
       findAll('.table-header-row-vc--view .table-header-cell__title').map((el) => el.textContent.trim()),
-      ['Nav Link Clicks', 'Property (id)', 'Ad Clicks', 'Date Time (day)', 'Total Clicks'],
+      ['Nav Link Clicks', 'Property (desc)', 'Ad Clicks', 'Date Time (day)', 'Total Clicks'],
       'The headers are reordered as specified by the reorder'
     );
   });
@@ -1935,7 +1935,7 @@ module('Acceptance | Navi Report', function (hooks) {
     const columns = () => findAll('.table-widget__table-headers .table-header-cell').map((el) => el.textContent.trim());
     assert.deepEqual(
       columns(),
-      ['Date Time (day)', 'Property (id)', 'Ad Clicks', 'Nav Link Clicks'],
+      ['Date Time (day)', 'Property (desc)', 'Ad Clicks', 'Nav Link Clicks'],
       'Report loads with expected columns'
     );
 
@@ -1943,14 +1943,14 @@ module('Acceptance | Navi Report', function (hooks) {
     await click('.navi-report__run-btn');
     assert.deepEqual(
       columns(),
-      ['Date Time (day)', 'Property (id)', 'Ad Clicks', 'Nav Link Clicks', 'Page Views'],
+      ['Date Time (day)', 'Property (desc)', 'Ad Clicks', 'Nav Link Clicks', 'Page Views'],
       'Report changed and ran successfully'
     );
 
     await click('.navi-report__revert-btn');
     assert.deepEqual(
       columns(),
-      ['Date Time (day)', 'Property (id)', 'Ad Clicks', 'Nav Link Clicks'],
+      ['Date Time (day)', 'Property (desc)', 'Ad Clicks', 'Nav Link Clicks'],
       'Report revertted successfully'
     );
 
@@ -1959,7 +1959,7 @@ module('Acceptance | Navi Report', function (hooks) {
     await click('.navi-report__run-btn');
     assert.deepEqual(
       columns(),
-      ['Date Time (day)', 'Property (id)', 'Ad Clicks', 'Nav Link Clicks', 'Page Views'],
+      ['Date Time (day)', 'Property (desc)', 'Ad Clicks', 'Nav Link Clicks', 'Page Views'],
       'Report changed and ran successfully'
     );
   });
@@ -1974,7 +1974,7 @@ module('Acceptance | Navi Report', function (hooks) {
     await click(findAll('.number-format-dropdown__trigger')[1]); // open nav clicks dropdown
 
     const navClicksCell = () => find('.table-row-vc').querySelectorAll('.table-cell-content.metric')[1];
-    assert.dom(navClicksCell()).hasText('880.41', 'The original metric value has no formatting');
+    assert.dom(navClicksCell()).hasText('305.99', 'The original metric value has no formatting');
     assert.dom('.number-format-selector__radio-custom input').isChecked('The custom input is selected');
 
     find('.number-format-selector__radio-money input').checked = true; // change format to money
@@ -1983,6 +1983,6 @@ module('Acceptance | Navi Report', function (hooks) {
     assert.dom('.number-format-selector__radio-money input').isChecked('The money input is selected');
 
     await click('.number-format-dropdown');
-    assert.dom(navClicksCell()).hasText('$880.41', 'The metric is re-rendered in the money format');
+    assert.dom(navClicksCell()).hasText('$305.99', 'The metric is re-rendered in the money format');
   });
 });

--- a/packages/reports/tests/acceptance/report-visualizations-test.js
+++ b/packages/reports/tests/acceptance/report-visualizations-test.js
@@ -18,7 +18,7 @@ module('Acceptance | navi-report - report visualizations', function (hooks) {
     assert.deepEqual(
       findAll('.c3-legend-item').map((el) => el.textContent.trim()),
       ['Property 1', 'Property 2', 'Property 3', 'Property 4'],
-      'Without filters, three series are shown in the chart'
+      'Without filters, four series are shown in the chart'
     );
 
     await clickItemFilter('dimension', 'Property');

--- a/packages/reports/tests/dummy/app/routes/application.ts
+++ b/packages/reports/tests/dummy/app/routes/application.ts
@@ -1,13 +1,18 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import UserModel from 'navi-core/models/user';
-import UserService from 'navi-core/services/user';
+import type UserModel from 'navi-core/models/user';
+import type UserService from 'navi-core/services/user';
+import type NaviMetadataService from 'navi-data/services/navi-metadata';
 
 export default class ApplicationRoute extends Route {
   @service
   private declare user: UserService;
 
-  model(): Promise<UserModel> {
-    return this.user.findOrRegister();
+  @service
+  private declare naviMetadata: NaviMetadataService;
+
+  async model(): Promise<UserModel> {
+    await this.naviMetadata.loadMetadata({ dataSourceName: 'bardOne' });
+    return await this.user.findOrRegister();
   }
 }


### PR DESCRIPTION
## Description
Reverts the request v2 normalizer to convert requested `dimension`s to `{ type: 'dimension', field: dimension, parameters: { field: 'id' }}` because only the table visualization requires different fields

## Proposed Changes
The table serializer will modify the request dimensions by
- checking if metadata is available and
  - injecting all `show` fields if present or
  - injecting `desc` or `id` if present or
  - fall back to first field available
- if not available, defaults to `desc` field

For chart series visualizations, the request must only ask for the `id` field to remain valid. If we request `id` and `desc` the visualization becomes out of date and must be rebuilt.

## Screenshots

For chart series, this is how it will appear if new series are added since the description is not available.

<img width="753" alt="Screen Shot 2021-10-02 at 12 37 18 PM" src="https://user-images.githubusercontent.com/12093492/135726763-eaa04b9e-e2fe-4da2-972d-8e7c66f3d8ba.png">

But after adding the desc field and rerunning, the chart series will have the proper labels

<img width="756" alt="Screen Shot 2021-10-02 at 12 39 23 PM" src="https://user-images.githubusercontent.com/12093492/135726821-20cf3f88-7077-4885-8056-8b3ab96815c3.png">


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
