### PR TITLE
Update: Configurable Fili end for since operator

### DIFF
--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -10,7 +10,7 @@ import { inject as service } from '@ember/service';
 import { A as array } from '@ember/array';
 import EmberObject from '@ember/object';
 import { canonicalizeMetric } from '../../utils/metric';
-import { configHost } from '../../utils/adapter';
+import { configHost, getDataSource } from '../../utils/adapter';
 import NaviFactAdapter, {
   Filter,
   RequestOptions,
@@ -32,6 +32,7 @@ import type BardTableMetadataModel from 'navi-data/models/metadata/bard/table';
 import type { GrainWithAll } from 'navi-data/serializers/metadata/bard';
 import type { TaskGenerator } from 'ember-concurrency';
 import Interval from 'navi-data/utils/classes/interval';
+import { FiliDataSource } from 'navi-config';
 
 export type Query = Record<string, string | number | boolean>;
 
@@ -180,7 +181,9 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
       if (!moment.utc(start).isValid()) {
         throw new FactAdapterError(`Since operator only supports datetimes, '${start}' is invalid`);
       }
-      end = moment.utc('9999-12-31').startOf(filterGrain).toISOString();
+      const dataSourceConfig = getDataSource(request.dataSource) as FiliDataSource;
+      const sinceOperatorEnd = dataSourceConfig.options?.sinceOperatorEndPeriod;
+      end = sinceOperatorEnd ?? moment.utc('9999-12-31').startOf(filterGrain).toISOString();
     } else if (timeFilter.operator === 'lte') {
       start = moment
         .utc(config.navi.dataEpoch || '0001-01-01')

--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -183,7 +183,9 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
       }
       const dataSourceConfig = getDataSource(request.dataSource) as FiliDataSource;
       const sinceOperatorEnd = dataSourceConfig.options?.sinceOperatorEndPeriod;
-      end = sinceOperatorEnd ?? moment.utc('9999-12-31').startOf(filterGrain).toISOString();
+      end = sinceOperatorEnd
+        ? moment.utc().add(moment.duration(sinceOperatorEnd)).startOf(filterGrain).toISOString()
+        : moment.utc('9999-12-31').startOf(filterGrain).toISOString();
     } else if (timeFilter.operator === 'lte') {
       start = moment
         .utc(config.navi.dataEpoch || '0001-01-01')

--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -184,7 +184,12 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
       const dataSourceConfig = getDataSource(request.dataSource) as FiliDataSource;
       const sinceOperatorEnd = dataSourceConfig.options?.sinceOperatorEndPeriod;
       end = sinceOperatorEnd
-        ? moment.utc().add(moment.duration(sinceOperatorEnd)).startOf(filterGrain).toISOString()
+        ? moment
+            .utc()
+            .add(moment.duration(sinceOperatorEnd))
+            .add(1, filterGrain === 'isoWeek' ? 'week' : filterGrain)
+            .startOf(filterGrain)
+            .toISOString()
         : moment.utc('9999-12-31').startOf(filterGrain).toISOString();
     } else if (timeFilter.operator === 'lte') {
       start = moment

--- a/packages/data/config/navi-config.d.ts
+++ b/packages/data/config/navi-config.d.ts
@@ -13,6 +13,7 @@ declare module 'navi-config' {
   export interface FiliConfigOptions {
     enableDimensionSearch?: boolean;
     enableSubtotals?: boolean;
+    sinceOperatorEndPeriod?: string;
   }
   export type FiliDataSource = BaseDataSource<'bard', FiliConfigOptions>;
 

--- a/packages/data/tests/dummy/config/environment.js
+++ b/packages/data/tests/dummy/config/environment.js
@@ -34,6 +34,7 @@ module.exports = function (environment) {
           type: 'bard',
           options: {
             enableDimensionSearch: true,
+            sinceOperatorEndPeriod: 'P3M',
           },
         },
         {

--- a/packages/data/tests/unit/adapters/facts/bard-test.ts
+++ b/packages/data/tests/unit/adapters/facts/bard-test.ts
@@ -342,7 +342,13 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     });
 
     const startDate = '2021-02-01';
-    const expectedEnd = moment().utc().add(3, 'months').startOf('isoWeek').toISOString().replace('Z', '');
+    const expectedEnd = moment()
+      .utc()
+      .add(3, 'months')
+      .add(1, 'week')
+      .startOf('isoWeek')
+      .toISOString()
+      .replace('Z', '');
     const since = singleValue(startDate, 'gte');
     assert.deepEqual(
       Adapter._buildDateTimeParam(since),

--- a/packages/data/tests/unit/adapters/facts/bard-test.ts
+++ b/packages/data/tests/unit/adapters/facts/bard-test.ts
@@ -342,11 +342,12 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     });
 
     const startDate = '2021-02-01';
+    const expectedEnd = moment().utc().add(3, 'months').startOf('isoWeek').toISOString().replace('Z', '');
     const since = singleValue(startDate, 'gte');
     assert.deepEqual(
       Adapter._buildDateTimeParam(since),
-      `${startDate}/P3M`,
-      '_buildDateTimeParam uses configured end date for since operator'
+      `${startDate}/${expectedEnd}`,
+      '_buildDateTimeParam uses configured end date period for since operator'
     );
 
     since.dataSource = 'bardTwo';

--- a/packages/data/tests/unit/adapters/facts/bard-test.ts
+++ b/packages/data/tests/unit/adapters/facts/bard-test.ts
@@ -16,7 +16,7 @@ const HOST2 = config.navi.dataSources[1].uri;
 
 const EmptyRequest: RequestV2 = {
   table: '',
-  dataSource: '',
+  dataSource: 'bardOne',
   requestVersion: '2.0',
   limit: null,
   columns: [],
@@ -242,7 +242,7 @@ module('Unit | Adapter | facts/bard', function (hooks) {
   });
 
   test('_buildDateTimeParam', function (assert) {
-    assert.expect(9);
+    assert.expect(10);
 
     let singleInterval: RequestV2 = {
       ...EmptyRequest,
@@ -345,8 +345,15 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     const since = singleValue(startDate, 'gte');
     assert.deepEqual(
       Adapter._buildDateTimeParam(since),
+      `${startDate}/P3M`,
+      '_buildDateTimeParam uses configured end date for since operator'
+    );
+
+    since.dataSource = 'bardTwo';
+    assert.deepEqual(
+      Adapter._buildDateTimeParam(since),
       `${startDate}/9999-12-27T00:00:00.000`,
-      '_buildDateTimeParam uses far future aligned to grain for since operator'
+      '_buildDateTimeParam uses far future aligned to grain for since operator when nothing is configured'
     );
 
     const sinceBadDate = singleValue('fakeDate', 'gte');


### PR DESCRIPTION
## Description

Default end date for dateTime `since` operator for fili was  9999, this actually causes an issue with fili to search way far out into the future for date buckets that don't exist.

## Proposed Changes

- Allow a configurable value per datasource to control how far out `since` will search for.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
