### PR TITLE
Fix: Don't client side sort dim search endpoint

### DIFF
--- a/packages/data/addon/adapters/dimensions/bard.ts
+++ b/packages/data/addon/adapters/dimensions/bard.ts
@@ -22,7 +22,6 @@ import type DimensionMetadataModel from 'navi-data/models/metadata/dimension';
 import type { DimensionColumn } from 'navi-data/models/metadata/dimension';
 import SearchUtils from 'navi-data/utils/search';
 import CARDINALITY_SIZES from 'navi-data/utils/enums/cardinality-sizes';
-import type { ResponseRow } from 'navi-data/models/navi-fact-response';
 
 const SUPPORTED_FILTER_OPERATORS = ['in', 'notin', 'startswith', 'contains'];
 
@@ -39,13 +38,13 @@ type LegacyAdapterOptions = {
 };
 
 export type FiliDimensionResponse = {
-  rows: ResponseRow[];
+  rows: Record<string, string>[];
   meta?: Record<string, unknown>;
 };
 
 type SearchUtilResult = {
   relevance: number;
-  record: ResponseRow;
+  record: Record<string, string>;
 };
 
 export const DefaultField = 'id';

--- a/packages/data/addon/adapters/dimensions/bard.ts
+++ b/packages/data/addon/adapters/dimensions/bard.ts
@@ -22,6 +22,7 @@ import type DimensionMetadataModel from 'navi-data/models/metadata/dimension';
 import type { DimensionColumn } from 'navi-data/models/metadata/dimension';
 import SearchUtils from 'navi-data/utils/search';
 import CARDINALITY_SIZES from 'navi-data/utils/enums/cardinality-sizes';
+import type { ResponseRow } from 'navi-data/models/navi-fact-response';
 
 const SUPPORTED_FILTER_OPERATORS = ['in', 'notin', 'startswith', 'contains'];
 
@@ -38,13 +39,13 @@ type LegacyAdapterOptions = {
 };
 
 export type FiliDimensionResponse = {
-  rows: Record<string, string>[];
+  rows: ResponseRow[];
   meta?: Record<string, unknown>;
 };
 
 type SearchUtilResult = {
   relevance: number;
-  record: Record<string, string>;
+  record: ResponseRow;
 };
 
 export const DefaultField = 'id';

--- a/packages/data/addon/utils/pagination.ts
+++ b/packages/data/addon/utils/pagination.ts
@@ -15,7 +15,7 @@ export default {
    * @param {Number} [limit] - number of records per page
    * @param {Number} [page] - page number
    */
-  getPaginatedRecords(allRecords, limit, page) {
+  getPaginatedRecords<T>(allRecords: Array<T>, limit: number, page: number): Array<T> {
     assert('allRecords param must be defined', allRecords);
     if (limit) {
       assert('Limit must be of type number', typeOf(limit) === 'number');

--- a/packages/data/addon/utils/search.ts
+++ b/packages/data/addon/utils/search.ts
@@ -6,6 +6,7 @@
 import { A } from '@ember/array';
 import { w } from '@ember/string';
 import PaginationUtils from './pagination';
+import type NativeArray from '@ember/array';
 
 export default {
   /**
@@ -19,7 +20,7 @@ export default {
    *           Number representing how close query matches string
    *           undefined if no match
    */
-  getPartialMatchWeight(string, query) {
+  getPartialMatchWeight(string: string, query: string): number | undefined {
     // Split search query into individual words
     let searchTokens = w(query.trim()),
       allTokensFound = true;
@@ -52,7 +53,7 @@ export default {
    *           Number representing how close query matches string
    *           undefined if no match
    */
-  getExactMatchWeight(string, query) {
+  getExactMatchWeight(string: string, query: string): number | undefined {
     if (string.indexOf(query) !== -1) {
       // Compute match weight
       return string.length - query.length + 1;
@@ -74,20 +75,25 @@ export default {
    *          record - asset record
    *          relevance - distance between record and search query
    */
-  searchDimensionRecords(records, query, resultLimit, page) {
+  searchDimensionRecords(
+    records: NativeArray<unknown>,
+    query: string,
+    resultLimit: number,
+    page = 1
+  ): { record: Record<string, string>; relevance: number }[] {
     let results = [],
       record;
 
     // Filter, map, and sort records based on how close each record is to the search query
     for (let i = 0; i < records.length; i++) {
-      record = records.objectAt(i);
+      record = records.objectAt(i) as Record<string, string>;
 
       // Determine relevance based on string match weight
       let descriptionMatchWeight = this.getPartialMatchWeight(
-          (record.description || '').toLowerCase(),
+          (record?.description || '').toLowerCase(),
           query.toLowerCase()
         ),
-        idMatchWeight = this.getExactMatchWeight((record.id || '').toLowerCase(), query.toLowerCase()),
+        idMatchWeight = this.getExactMatchWeight((record?.id || '').toLowerCase(), query.toLowerCase()),
         relevance = descriptionMatchWeight || idMatchWeight;
 
       // If both id and description match the query, take the most relevant

--- a/packages/data/addon/utils/search.ts
+++ b/packages/data/addon/utils/search.ts
@@ -89,16 +89,17 @@ export default {
       record = records.objectAt(i) as Record<string, string>;
 
       // Determine relevance based on string match weight
-      let descriptionMatchWeight = this.getPartialMatchWeight(
-          (record?.description || '').toLowerCase(),
+      const { id, ...rest } = record;
+      let nonIdMatchWeight = this.getPartialMatchWeight(
+          (Object.values(rest).join(' ') || '').toLowerCase(),
           query.toLowerCase()
         ),
-        idMatchWeight = this.getExactMatchWeight((record?.id || '').toLowerCase(), query.toLowerCase()),
-        relevance = descriptionMatchWeight || idMatchWeight;
+        idMatchWeight = this.getExactMatchWeight((id || '').toLowerCase(), query.toLowerCase()),
+        relevance = nonIdMatchWeight || idMatchWeight;
 
       // If both id and description match the query, take the most relevant
-      if (descriptionMatchWeight && idMatchWeight) {
-        relevance = Math.min(descriptionMatchWeight, idMatchWeight);
+      if (nonIdMatchWeight && idMatchWeight) {
+        relevance = Math.min(nonIdMatchWeight, idMatchWeight);
       }
 
       if (relevance) {

--- a/packages/data/tests/unit/adapters/dimensions/bard-test.ts
+++ b/packages/data/tests/unit/adapters/dimensions/bard-test.ts
@@ -253,7 +253,7 @@ module('Unit | Adapter | Dimensions | Bard', function (hooks) {
       meta: { some: 'metaData' },
     };
 
-    const results = await taskFor(this.adapter.searchUtil).perform(dimensionsToSearch, 'foo');
+    const results = this.adapter._searchDimensions(dimensionsToSearch, 'foo');
     assert.deepEqual(
       results,
       {

--- a/packages/data/tests/unit/adapters/dimensions/bard-test.ts
+++ b/packages/data/tests/unit/adapters/dimensions/bard-test.ts
@@ -174,12 +174,12 @@ module('Unit | Adapter | Dimensions | Bard', function (hooks) {
             id: '-3',
           },
           {
-            description: 'Not Available',
-            id: '-2',
-          },
-          {
             description: '65 and over',
             id: '10',
+          },
+          {
+            description: 'Not Available',
+            id: '-2',
           },
         ],
       },
@@ -223,5 +223,57 @@ module('Unit | Adapter | Dimensions | Bard', function (hooks) {
 
     // Sending request for provided clientId
     await taskFor(this.adapter.find).perform(ageColumn, [{ operator: 'in', values: ['1'] }], { clientId: 'test id' });
+  });
+
+  test('searchUtil task calls and transforms search results', async function (this: TestContext, assert) {
+    assert.expect(1);
+    const dimensionsToSearch = {
+      rows: [
+        {
+          id: '1',
+          description: 'foo bar',
+        },
+        {
+          id: '2',
+          description: 'nope',
+        },
+        {
+          id: '3',
+          description: 'foo bar foo',
+        },
+        {
+          id: 'foo4',
+          description: 'nah',
+        },
+        {
+          id: '5',
+          description: 'nadda',
+        },
+      ],
+      meta: { some: 'metaData' },
+    };
+
+    const results = await taskFor(this.adapter.searchUtil).perform(dimensionsToSearch, 'foo');
+    assert.deepEqual(
+      results,
+      {
+        rows: [
+          {
+            id: 'foo4',
+            description: 'nah',
+          },
+          {
+            id: '1',
+            description: 'foo bar',
+          },
+          {
+            id: '3',
+            description: 'foo bar foo',
+          },
+        ],
+        meta: { some: 'metaData' },
+      },
+      'Returns expected search results and returns results as a FiliDimensionResult, passing through meta prop'
+    );
   });
 });

--- a/packages/reports/addon/components/filter-values/dimension-select.hbs
+++ b/packages/reports/addon/components/filter-values/dimension-select.hbs
@@ -14,7 +14,6 @@
       @onOpen={{this.fetchDimensionOptions}}
       @options={{this.options}}
       @selected={{this.selectedDimensions}}
-      @extra={{hash sortFn=this.sortValues}}
       @triggerComponent="power-select-bulk-import-trigger"
       @optionsComponent="power-select-collection-options"
       @onChange={{this.setValues}}

--- a/packages/reports/tests/integration/components/filter-values/dimension-select-test.ts
+++ b/packages/reports/tests/integration/components/filter-values/dimension-select-test.ts
@@ -284,7 +284,7 @@ module('Integration | Component | filter values/dimension select', function (hoo
     );
   });
 
-  test('sort is applied to search', async function (this: TestContext, assert) {
+  test('sort is NOT applied to search', async function (this: TestContext, assert) {
     assert.expect(1);
     this.filter = this.fragmentFactory.createFilter('dimension', 'bardOne', 'property', { field: 'id' }, 'in', []);
     const factory = this.dimensionModelFactory;
@@ -302,10 +302,11 @@ module('Integration | Component | filter values/dimension select', function (hoo
 
     await clickTrigger(); // open
     await selectSearch('.filter-values--dimension-select__trigger', 'Property');
+    //if client side sorting was applied we'd see: ['Property 1', 'Property 11', 'Property 111', 'Property 2', 'Property 3']
     assert.deepEqual(
       findAll('.ember-power-select-option').map((el) => el.textContent?.trim()),
-      ['Property 1', 'Property 11', 'Property 111', 'Property 2', 'Property 3'],
-      'Sort is applied as number for string number dimensions'
+      ['Property 1', 'Property 3', 'Property 2', 'Property 11', 'Property 111'],
+      'Sort is applied as it was given from server mock'
     );
   });
 


### PR DESCRIPTION
## Description

Lucene based dimension searching endpoint has better result sorting than client side provides. So in the case of that dimension sort we do not want to resort the result

## Proposed Changes

- Do not client side sort if cardinality is larger than "Small" and we're using the enhanced dimension search.
- TODO: add caching to `all` in the adapter will be in a followup PR.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
