### PR TITLE
Support Fili new date macros

### DIFF
--- a/packages/data/addon/mirage/routes/bard-lite.ts
+++ b/packages/data/addon/mirage/routes/bard-lite.ts
@@ -85,7 +85,7 @@ function _getDates(grain: GrainWithAll, start: string, end: string) {
   if (grain === 'all') {
     let validInterval = true;
 
-    // try and match for currentDay, currentWeek etc.
+    // try matching for currentDay, currentWeek etc.
     let match = start.match(/^(?<macro>(current))(?<grain>[A-Z][a-z]+)$/)?.groups;
     startMacro = match?.macro;
     const startGrain = match?.grain?.toLowerCase() as Grain;
@@ -98,7 +98,7 @@ function _getDates(grain: GrainWithAll, start: string, end: string) {
       validInterval = false;
     }
 
-    // try and match for currentDay, nextWeek etc.
+    // try matching for currentDay, nextWeek etc.
     match = end.match(/^(?<macro>(current|next))(?<grain>[A-Z][a-z]+)$/)?.groups;
     endMacro = match?.macro;
     nonAllGrain = (match?.grain?.toLowerCase() ?? 'day') as Grain;

--- a/packages/data/addon/mirage/routes/bard-lite.ts
+++ b/packages/data/addon/mirage/routes/bard-lite.ts
@@ -84,9 +84,10 @@ function _getDates(grain: GrainWithAll, start: string, end: string) {
 
   if (grain === 'all') {
     let validInterval = true;
+    const regex = (macro: string) => new RegExp(`^(?<macro>(${macro}))(?<grain>[A-Z][a-z]+)$`);
 
     // try matching for currentDay, currentWeek etc.
-    let match = start.match(/^(?<macro>(current))(?<grain>[A-Z][a-z]+)$/)?.groups;
+    let match = start.match(regex('current'))?.groups;
     startMacro = match?.macro;
     const startGrain = match?.grain?.toLowerCase() as Grain;
     // validate grain
@@ -99,7 +100,7 @@ function _getDates(grain: GrainWithAll, start: string, end: string) {
     }
 
     // try matching for currentDay, nextWeek etc.
-    match = end.match(/^(?<macro>(current|next))(?<grain>[A-Z][a-z]+)$/)?.groups;
+    match = end.match(regex('current|next'))?.groups;
     endMacro = match?.macro;
     nonAllGrain = (match?.grain?.toLowerCase() ?? 'day') as Grain;
     // validate grain

--- a/packages/data/tests/unit/adapters/facts/bard-test.ts
+++ b/packages/data/tests/unit/adapters/facts/bard-test.ts
@@ -253,7 +253,7 @@ module('Unit | Adapter | facts/bard', function (hooks) {
           type: 'timeDimension',
           parameters: { grain: 'day' },
           operator: 'bet',
-          values: ['2021-02-13', '2021-04-12'],
+          values: ['2021-02-13T00:00:00.000Z', '2021-04-12T00:00:00.000Z'],
         },
       ],
     };
@@ -445,22 +445,21 @@ module('Unit | Adapter | facts/bard', function (hooks) {
     const request1 = allWithFilterGrain('day', ['P1D', 'current']);
     assert.strictEqual(
       Adapter._buildDateTimeParam(request1),
-      `P1D/${moment.utc().startOf('day').toISOString().replace('Z', '')}`,
+      `P1D/currentDay`,
       '_buildDateTimeParam forces the "current" macro to a real date if the all grain is used'
     );
 
-    const request2 = allWithFilterGrain('isoWeek', ['2020-04-20', 'next']);
+    const request2 = allWithFilterGrain('isoWeek', ['2020-04-20T00:00:00.000Z', 'next']);
     assert.strictEqual(
       Adapter._buildDateTimeParam(request2),
-      `2020-04-20T00:00:00.000/${moment.utc().startOf('isoWeek').add(1, 'week').toISOString().replace('Z', '')}`,
+      `2020-04-20T00:00:00.000/nextWeek`,
       '_buildDateTimeParam forces the "next" macro to a real date if the all grain is used'
     );
 
     const request3 = allWithFilterGrain('month', ['current', 'next']);
-    const currentMonth = moment.utc().startOf('month');
     assert.strictEqual(
       Adapter._buildDateTimeParam(request3),
-      `${currentMonth.toISOString().replace('Z', '')}/${currentMonth.add(1, 'month').toISOString().replace('Z', '')}`,
+      `currentMonth/nextMonth`,
       '_buildDateTimeParam forces the "current" and "next" macro to a real date if the all grain is used'
     );
   });

--- a/packages/data/tests/unit/services/navi-facts-bard-test.ts
+++ b/packages/data/tests/unit/services/navi-facts-bard-test.ts
@@ -49,7 +49,7 @@ module('Unit | Service | Navi Facts - Bard', function (hooks) {
   });
 
   test('fetch and catch error', async function (this: TestContext, assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     const request = allWithFilterGrain('day', ['currentFoo', 'nextDay']);
     await taskFor(this.service.fetch)
@@ -73,8 +73,19 @@ module('Unit | Service | Navi Facts - Bard', function (hooks) {
         );
       });
 
-    const request3 = allWithFilterGrain('day', ['value1', 'value1']);
-    request3.columns = [
+    const request3 = allWithFilterGrain('day', ['2021-04-31', '2021-05-03']);
+    await taskFor(this.service.fetch)
+      .perform(request3, { dataSourceName: request3.dataSource })
+      .catch((response) => {
+        assert.equal(
+          response.details[0],
+          "Invalid interval for 'all' grain. 2021-04-31/2021-05-04T00:00:00.000.",
+          'Error is thrown for using invalid dates with "all" grain'
+        );
+      });
+
+    const request4 = allWithFilterGrain('day', ['value1', 'value1']);
+    request4.columns = [
       {
         type: 'timeDimension',
         field: '.dateTime',
@@ -83,7 +94,7 @@ module('Unit | Service | Navi Facts - Bard', function (hooks) {
     ];
 
     await taskFor(this.service.fetch)
-      .perform(request3, { dataSourceName: request3.dataSource })
+      .perform(request4, { dataSourceName: request4.dataSource })
       .catch((response) => {
         assert.equal(
           response.details[0],

--- a/packages/data/tests/unit/services/navi-facts-bard-test.ts
+++ b/packages/data/tests/unit/services/navi-facts-bard-test.ts
@@ -76,7 +76,7 @@ module('Unit | Service | Navi Facts - Bard', function (hooks) {
       .catch((response) => {
         assert.equal(
           response.details[0],
-          'Date time cannot have zero length intervals. value1/value1.',
+          'Date time cannot have zero length interval. value1/value1.',
           'Error is thrown for using macros with "all" grain'
         );
       });


### PR DESCRIPTION
## Description

Support Fili's new `currentDay`, `nextWeek` etc. date macros.

## Proposed Changes

- Allow "custom macros" for the `all` time grain. If `current`/`next` is passed in, add filter grain suffix.
- Add support in mirage route handler

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
