### PR TITLE
Fix: DimensionSearch ordering.

### DIFF
--- a/packages/data/addon/adapters/dimensions/bard.ts
+++ b/packages/data/addon/adapters/dimensions/bard.ts
@@ -178,7 +178,8 @@ export default class BardDimensionAdapter extends EmberObject implements NaviDim
     } else if (filiOptions?.enableDimensionSearch) {
       const url = this._buildUrl(dimension, 'search');
       const data: Record<string, string> = query ? { query } : {};
-      return yield this._find(url, data, options);
+      const results = yield this._find(url, data, options);
+      return this._searchDimensions(results, query); //TODO: Remove researching dimensions, when bard search ordering improves
     } else {
       const results = yield taskFor(this.find).perform(
         dimension,


### PR DESCRIPTION
## Description

Pass dimension searches through search util. (Temporary)

## Proposed Changes

- Due to tweaks needed server side search ordering, we will run search results through our client side ranking for the time being.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
