### PR TITLE
Fix: Group order when search gets alpha sorted

### DIFF
--- a/packages/reports/addon/components/column-selector.hbs
+++ b/packages/reports/addon/components/column-selector.hbs
@@ -18,6 +18,7 @@
       <GroupedList
         @items={{this.filteredColumns}}
         @shouldOpenAllGroups={{this.query.length}}
+        @shouldSort={{not this.query.length}}
         @groupByField="category"
         @sortByField={{unless this.query.length "name"}}
         @isSingleCategory={{this.isSingleCategory}}

--- a/packages/reports/addon/components/grouped-list.ts
+++ b/packages/reports/addon/components/grouped-list.ts
@@ -15,6 +15,7 @@ interface Args {
   groupByField: string;
   sortByField?: string | null;
   isSingleCategory?: boolean;
+  shouldSort?: boolean;
 }
 
 export default class GroupedListComponent extends Component<Args> {
@@ -43,7 +44,7 @@ export default class GroupedListComponent extends Component<Args> {
   get flatItems() {
     const {
       groupedItems,
-      args: { shouldOpenAllGroups },
+      args: { shouldOpenAllGroups, shouldSort },
       groupConfigs,
     } = this;
 
@@ -58,7 +59,7 @@ export default class GroupedListComponent extends Component<Args> {
       } else if (b[0] === `Uncategorized`) {
         return -1;
       } else {
-        return a[0].localeCompare(b[0]);
+        return shouldSort ? a[0].localeCompare(b[0]) : 0;
       }
     });
 

--- a/packages/reports/tests/integration/components/grouped-list-test.js
+++ b/packages/reports/tests/integration/components/grouped-list-test.js
@@ -56,6 +56,7 @@ module('Integration | Component | grouped list', function (hooks) {
         @shouldOpenAllGroups={{this.shouldOpenAllGroups}}
         @groupByField="field"
         @containerSelector="body"
+        @shouldSort={{true}}
         as | item |
       >
         {{item.val}}
@@ -89,6 +90,42 @@ module('Integration | Component | grouped list', function (hooks) {
     );
   });
 
+  test('groups are not sorted when @shouldSort is false', async function (assert) {
+    assert.expect(3);
+
+    await render(hbs`
+      <GroupedList
+        @items={{this.items}}
+        @shouldOpenAllGroups={{this.shouldOpenAllGroups}}
+        @groupByField="field"
+        @containerSelector="body"
+        @shouldSort={{false}}
+        as | item |
+      >
+        {{item.val}}
+      </GroupedList>
+    `);
+
+    const groups = findAll('.grouped-list__group-header-content');
+    assert.deepEqual(
+      groups.map((el) => el.textContent.trim()),
+      ['foo (3)', 'bar (1)', 'Uncategorized (2)'],
+      'the groups are in expected order when @shouldSort is false'
+    );
+
+    assert.dom(groups[1]).hasText('bar (1)', 'the second group header is `bar (1)`');
+
+    this.set('shouldOpenAllGroups', true);
+    // changing shouldOpenAllGroups causes vertical collection render so we need to wait
+    await settled();
+
+    assert.deepEqual(
+      findAll('.grouped-list li').map((el) => el.textContent.trim()),
+      ['foo (3)', '1', '2', '3', 'bar (1)', '6', 'Uncategorized (2)', '4', '5'],
+      'All groups are open when `shouldOpenAllGroups` attribute is true'
+    );
+  });
+
   test('groups are sorted by sortByField', async function (assert) {
     assert.expect(1);
 
@@ -99,6 +136,7 @@ module('Integration | Component | grouped list', function (hooks) {
         @containerSelector="body"
         @groupByField="cat"
         @sortByField="name"
+        @shouldSort={{true}}
         as | item |
       >
         {{item.name}}
@@ -123,6 +161,7 @@ module('Integration | Component | grouped list', function (hooks) {
         @containerSelector="body"
         @groupByField="cat"
         @sortByField="name"
+        @shouldSort={{true}}
         as | item |
       >
         {{item.name}}
@@ -148,6 +187,7 @@ module('Integration | Component | grouped list', function (hooks) {
         @groupByField="category"
         @sortByField="name"
         @isSingleCategory="true"
+        @shouldSort={{true}}
         as | item |
       >
         {{item.name}}


### PR DESCRIPTION
## Description

Discovered when searching for metric/dimension, the groups get ordered alphabetically, which puts better search results farther down the list.

## Proposed Changes

- Keep alpha group sorting, but we'll disable that when there is a search happening
- To do that we just add a `@shouldSort` argument to `GroupedList` component
- `Uncategorized` will still get sorted to bottom.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
