### PR TITLE
Update: Replace numeral.js with numbro

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "navi",
       "version": "0.4.0",
       "hasInstallScript": true,
       "license": "MIT",

--- a/packages/core/addon/components/navi-visualizations/goal-gauge.ts
+++ b/packages/core/addon/components/navi-visualizations/goal-gauge.ts
@@ -10,7 +10,7 @@ import { isPresent } from '@ember/utils';
 import { guidFor } from '@ember/object/internals';
 // @ts-ignore
 import d3 from 'd3';
-import numeral from 'numeral';
+import numbro from 'numbro';
 import FilterFragment from 'navi-core/models/request/filter';
 import { VisualizationModel } from './table';
 import { GoalGaugeConfig } from 'navi-core/models/goal-gauge';
@@ -207,7 +207,11 @@ export default class GoalGaugeVisualization extends Component<Args> {
    * @returns {String} formatted number
    */
   _formatNumber(value: number) {
-    const formatStr = value >= 1000000000 ? '0.[000]a' : '0.[00]a';
-    return numeral(value).format(formatStr).toUpperCase();
+    const formatObj = {
+      mantissa: value > 1000000000 ? 3 : 2,
+      trimMantissa: true,
+      average: value > 1000,
+    };
+    return numbro(value).format(formatObj).toUpperCase();
   }
 }

--- a/packages/core/addon/components/navi-visualizations/line-chart.ts
+++ b/packages/core/addon/components/navi-visualizations/line-chart.ts
@@ -9,7 +9,7 @@ import EmberArray from '@ember/array';
 import { readOnly } from '@ember/object/computed';
 import { getOwner } from '@ember/application';
 import { guidFor } from '@ember/object/internals';
-import numeral from 'numeral';
+import numbro from 'numbro';
 import { merge } from 'lodash-es';
 import moment from 'moment';
 import { run } from '@ember/runloop';
@@ -43,7 +43,7 @@ const DEFAULT_OPTIONS = <const>{
         config: {},
       },
       tick: {
-        format: (val: number) => numeral(val).format('0.00a'),
+        format: (val: number) => numbro(val).format('0.00a'),
         count: 4,
       },
       label: {
@@ -386,7 +386,7 @@ export default class LineChart extends ChartBuildersBase<Args> {
    * @param val - number to format
    * @returns formatted number
    */
-  formattingFunction = (val: number) => numeral(val).format('0.00a');
+  formattingFunction = (val: number) => numbro(val).format({ mantissa: 2, average: val > 1000 });
 
   /**
    * adds the formattingFunction to the chart config

--- a/packages/core/addon/components/navi-visualizations/line-chart.ts
+++ b/packages/core/addon/components/navi-visualizations/line-chart.ts
@@ -43,7 +43,7 @@ const DEFAULT_OPTIONS = <const>{
         config: {},
       },
       tick: {
-        format: (val: number) => numbro(val).format('0.00a'),
+        format: (val: number) => numbro(val).format({ mantissa: 2, average: val > 1000 }),
         count: 4,
       },
       label: {

--- a/packages/core/addon/components/number-format-selector.hbs
+++ b/packages/core/addon/components/number-format-selector.hbs
@@ -49,7 +49,7 @@
   <DenaliLink
     @iconFront="help-circle"
     @size="small"
-    href="http://numeraljs.com/#format"
+    href="https://numbrojs.com/old-format.html"
     target="_blank"
     rel="noopener noreferrer"
     class="number-format-selector__doc-link link"

--- a/packages/core/addon/helpers/smart-format-number.ts
+++ b/packages/core/addon/helpers/smart-format-number.ts
@@ -4,7 +4,7 @@
  */
 
 import { helper as buildHelper } from '@ember/component/helper';
-import numeral from 'numeral';
+import numbro from 'numbro';
 
 /**
  * Formats the number smartly
@@ -31,13 +31,13 @@ export function smartFormatNumber([value]: Array<number | string>): string {
   let absValue = Math.abs(value);
 
   if (absValue === 0 || (absValue >= 1 && absValue < 100)) {
-    return numeral(value).format(hasPoint ? '0,0.00' : '0,0[.]00');
+    return numbro(value).format({ mantissa: 2, optionalMantissa: !hasPoint, thousandSeparated: true });
   } else if (absValue >= 0.0001 && absValue < 1) {
-    return numeral(value).format('0.0000');
+    return numbro(value).format({ mantissa: 4 });
   } else if (absValue < 0.0001) {
     return value.toExponential(4);
   }
-  return numeral(value).format('0,0');
+  return numbro(value).format({ thousandSeparated: true });
 }
 
 export default buildHelper(smartFormatNumber);

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -16,7 +16,6 @@
         "@glimmer/component": "^1.0.3",
         "@glimmer/tracking": "^1.0.3",
         "@html-next/vertical-collection": "^2.0.0",
-        "@types/numeral": "0.0.28",
         "ember-ajax": "^5.0.0",
         "ember-auto-import": "^1.10.1",
         "ember-basic-dropdown": "^3.0.19",
@@ -49,7 +48,7 @@
         "lodash-es": "^4.17.11",
         "lz-string": "^1.4.4",
         "nanoid": "^3.1.12",
-        "numeral": "^2.0.6",
+        "numbro": "^2.3.5",
         "resize-observer-polyfill": "^1.5.1"
       },
       "devDependencies": {
@@ -145,7 +144,7 @@
         "graphql-tag": "^2.10.1",
         "lodash-es": "^4.17.11",
         "miragejs": "^0.1.41",
-        "numeral": "^2.0.6",
+        "numbro": "^2.3.5",
         "papaparse": "^5.1.1",
         "pretender": "^3.4.3"
       },
@@ -158,7 +157,6 @@
         "@types/ember-qunit": "^3.4.8",
         "@types/faker": "^5.1.6",
         "@types/lodash-es": "^4.17.3",
-        "@types/numeral": "0.0.28",
         "@types/papaparse": "^5.0.3",
         "@types/qunit": "^2.9.1",
         "@types/rsvp": "^4.0.3",
@@ -4829,10 +4827,6 @@
       "version": "14.14.35",
       "license": "MIT"
     },
-    "node_modules/@types/numeral": {
-      "version": "0.0.28",
-      "license": "MIT"
-    },
     "node_modules/@types/qs": {
       "version": "6.9.6",
       "dev": true,
@@ -6596,6 +6590,14 @@
     "node_modules/big.js": {
       "version": "5.2.2",
       "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==",
       "engines": {
         "node": "*"
       }
@@ -25058,9 +25060,13 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/numeral": {
-      "version": "2.0.6",
-      "license": "MIT",
+    "node_modules/numbro": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/numbro/-/numbro-2.3.5.tgz",
+      "integrity": "sha512-xlKC0GIZn0iaF7LHE60/DmGfQadDNfnskXdGDGWJfaZfP4pbhc0x+nR8yIIpQkF9n7gJWS6fgBR3Pkvp/W6sDg==",
+      "dependencies": {
+        "bignumber.js": "^8.1.1"
+      },
       "engines": {
         "node": "*"
       }
@@ -33235,9 +33241,6 @@
     "@types/node": {
       "version": "14.14.35"
     },
-    "@types/numeral": {
-      "version": "0.0.28"
-    },
     "@types/qs": {
       "version": "6.9.6",
       "dev": true
@@ -34543,6 +34546,11 @@
     },
     "big.js": {
       "version": "5.2.2"
+    },
+    "bignumber.js": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -47836,8 +47844,13 @@
       "version": "1.0.1",
       "dev": true
     },
-    "numeral": {
-      "version": "2.0.6"
+    "numbro": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/numbro/-/numbro-2.3.5.tgz",
+      "integrity": "sha512-xlKC0GIZn0iaF7LHE60/DmGfQadDNfnskXdGDGWJfaZfP4pbhc0x+nR8yIIpQkF9n7gJWS6fgBR3Pkvp/W6sDg==",
+      "requires": {
+        "bignumber.js": "^8.1.1"
+      }
     },
     "nwsapi": {
       "version": "2.2.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,6 @@
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "@html-next/vertical-collection": "^2.0.0",
-    "@types/numeral": "0.0.28",
     "ember-ajax": "^5.0.0",
     "ember-auto-import": "^1.10.1",
     "ember-basic-dropdown": "^3.0.19",
@@ -60,7 +59,7 @@
     "lz-string": "^1.4.4",
     "nanoid": "^3.1.12",
     "navi-data": "0.4.0",
-    "numeral": "^2.0.6",
+    "numbro": "^2.3.5",
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {

--- a/packages/data/addon/services/navi-formatter.ts
+++ b/packages/data/addon/services/navi-formatter.ts
@@ -4,7 +4,7 @@
  */
 import Service from '@ember/service';
 import { isEmpty } from '@ember/utils';
-import numeral from 'numeral';
+import numbro from 'numbro';
 import type { Parameters } from 'navi-data/adapters/facts/interface';
 import type ColumnMetadataModel from 'navi-data/models/metadata/column';
 import type { MetricColumn } from 'navi-data/models/metadata/metric';
@@ -60,8 +60,8 @@ export default class NaviFormatterService extends Service {
     if (isEmpty(value)) {
       return '--';
     }
-    const format = requestedFormat ? requestedFormat : '0,0.[0000000000]';
-    return numeral(value).format(format);
+    const format = requestedFormat ? requestedFormat : { mantissa: 9, trimMantissa: true, thousandSeparated: true };
+    return numbro(value).format(format);
   }
 }
 

--- a/packages/data/package-lock.json
+++ b/packages/data/package-lock.json
@@ -30,7 +30,7 @@
         "graphql-tag": "^2.10.1",
         "lodash-es": "^4.17.11",
         "miragejs": "^0.1.41",
-        "numeral": "^2.0.6",
+        "numbro": "^2.3.5",
         "papaparse": "^5.1.1",
         "pretender": "^3.4.3"
       },
@@ -43,7 +43,6 @@
         "@types/ember-qunit": "^3.4.8",
         "@types/faker": "^5.1.6",
         "@types/lodash-es": "^4.17.3",
-        "@types/numeral": "0.0.28",
         "@types/papaparse": "^5.0.3",
         "@types/qunit": "^2.9.1",
         "@types/rsvp": "^4.0.3",
@@ -2824,12 +2823,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
       "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag=="
     },
-    "node_modules/@types/numeral": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@types/numeral/-/numeral-0.0.28.tgz",
-      "integrity": "sha512-Sjsy10w6XFHDktJJdXzBJmoondAKW+LcGpRFH+9+zXEDj0cOH8BxJuZA9vUDSMAzU1YRJlsPKmZEEiTYDlICLw==",
-      "dev": true
-    },
     "node_modules/@types/papaparse": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.2.5.tgz",
@@ -4879,6 +4872,14 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==",
       "engines": {
         "node": "*"
       }
@@ -20704,10 +20705,13 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/numeral": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
-      "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY=",
+    "node_modules/numbro": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/numbro/-/numbro-2.3.5.tgz",
+      "integrity": "sha512-xlKC0GIZn0iaF7LHE60/DmGfQadDNfnskXdGDGWJfaZfP4pbhc0x+nR8yIIpQkF9n7gJWS6fgBR3Pkvp/W6sDg==",
+      "dependencies": {
+        "bignumber.js": "^8.1.1"
+      },
       "engines": {
         "node": "*"
       }
@@ -28440,12 +28444,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
       "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag=="
     },
-    "@types/numeral": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@types/numeral/-/numeral-0.0.28.tgz",
-      "integrity": "sha512-Sjsy10w6XFHDktJJdXzBJmoondAKW+LcGpRFH+9+zXEDj0cOH8BxJuZA9vUDSMAzU1YRJlsPKmZEEiTYDlICLw==",
-      "dev": true
-    },
     "@types/papaparse": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.2.5.tgz",
@@ -30240,6 +30238,11 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+    },
+    "bignumber.js": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -43577,10 +43580,13 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
-    "numeral": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
-      "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY="
+    "numbro": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/numbro/-/numbro-2.3.5.tgz",
+      "integrity": "sha512-xlKC0GIZn0iaF7LHE60/DmGfQadDNfnskXdGDGWJfaZfP4pbhc0x+nR8yIIpQkF9n7gJWS6fgBR3Pkvp/W6sDg==",
+      "requires": {
+        "bignumber.js": "^8.1.1"
+      }
     },
     "nwsapi": {
       "version": "2.2.0",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -52,7 +52,7 @@
     "graphql-tag": "^2.10.1",
     "lodash-es": "^4.17.11",
     "miragejs": "^0.1.41",
-    "numeral": "^2.0.6",
+    "numbro": "^2.3.5",
     "papaparse": "^5.1.1",
     "pretender": "^3.4.3"
   },
@@ -65,7 +65,6 @@
     "@types/ember-qunit": "^3.4.8",
     "@types/faker": "^5.1.6",
     "@types/lodash-es": "^4.17.3",
-    "@types/numeral": "0.0.28",
     "@types/papaparse": "^5.0.3",
     "@types/qunit": "^2.9.1",
     "@types/rsvp": "^4.0.3",


### PR DESCRIPTION
Resolves #1065 

<!-- The above line will close the issue upon merge -->

## Description

Replace numeral with numbro

## Proposed Changes

- Other than obvious library swap there was some inconsistencies with numeral
- 'a' formatter works different and is a bit more aggressive about rounding up on numbers less than 1000. so `500` got formatted to `.5k` to fix this I set average flag only when number > 1000.
- There seems a bug with things getting floatty even with safe ints with large Mantissa. https://github.com/BenjaminVanRyseghem/numbro/issues/587 so the default metric formatter from 10 mantissa to 9. We might see more issues. Might investigate this in numbro so we can go back to 10.
- used the new formatting object rather than strings for all programmatic formats. (leaving old style for users).

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
