### PR TITLE
Fix: Tooltip pass the row correctly

### DIFF
--- a/packages/core/addon/components/navi-visualizations/chart-builders-base.ts
+++ b/packages/core/addon/components/navi-visualizations/chart-builders-base.ts
@@ -24,7 +24,7 @@ export default class ChartBuildersBase<Args> extends Component<Args> {
     const builderMap = chartBuilderEntries.reduce((map: Record<string, BaseChartBuilder | undefined>, builderName) => {
       const [, chartBuilder] = builderRegExp.exec(builderName) || [];
       const builderKey = camelize(chartBuilder);
-      map[builderKey] = owner.lookup(`chart-builder:${builderKey}`);
+      map[builderKey] = owner.factoryFor(`chart-builder:${builderKey}`).create();
       return map;
     }, {});
     return builderMap;

--- a/packages/core/tests/acceptance/line-chart-test.ts
+++ b/packages/core/tests/acceptance/line-chart-test.ts
@@ -14,20 +14,40 @@ module('Acceptance | line chart', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
+  test('row count passed to tooltip formatter', async function (assert) {
+    assert.expect(2);
+
+    await visit('/line-chart');
+
+    const metricCharts = findAll('.line-chart-widget.type-metric');
+    // check text of the tooltip container
+    await showTooltip(getEmberComponent(metricCharts[0].id), 1);
+    assert
+      .dom(metricCharts[0].querySelector('.chart-tooltip__value'))
+      .includesText('rc=6', 'The row count is correct for the first metric chart.');
+    // await hideTooltip(0);
+
+    // check text of the tooltip container
+    await showTooltip(getEmberComponent(metricCharts[1].id), 1);
+    assert
+      .dom(metricCharts[1].querySelector('.chart-tooltip__value'))
+      .includesText('rc=2', 'The row count is correct for the second metric chart.');
+  });
+
   test('tooltip updates', async function (assert) {
     assert.expect(2);
 
     await visit('/line-chart');
 
     // check text of the tooltip container
-    await showTooltip();
+    await showTooltip(getChartComponent(5), 1);
     assert.dom('.chart-tooltip__sub-title').hasText('Ad Clicks', "The tooltip contains the metric's display name.");
 
     // Select a different metric
     await selectChoose('.metric-select__select-trigger', 'Revenue (USD)');
 
     // check text of the tooltip container
-    await showTooltip();
+    await showTooltip(getChartComponent(5), 1);
     assert
       .dom('.chart-tooltip__sub-title')
       .hasText(
@@ -160,15 +180,19 @@ module('Acceptance | line chart', function (hooks) {
   });
 
   /**
-   * @function showTooltip
-   * @param {Object} container - app container
    * This will show the chart tooltip so that we can fetch its contents.
    */
-  async function showTooltip() {
-    const emberId = findAll('.chart-container .navi-vis-c3-chart')[1]?.id;
-    const component = (getContext() as TestContext).owner.lookup('-view-registry:main')[emberId];
+  function getChartComponent(chartIndex: number) {
+    const chartElement = findAll('.navi-vis-c3-chart')[chartIndex];
+    return getEmberComponent(chartElement.id);
+  }
+  function getEmberComponent(id: string) {
+    const component = (getContext() as TestContext).owner.lookup('-view-registry:main')[id];
+    return component;
+  }
+  async function showTooltip(component: any, x: number) {
     const c3 = component.chart;
-    c3.tooltip.show({ x: 1 });
+    c3.tooltip.show({ x });
     await waitFor('.c3-tooltip-container');
   }
 });

--- a/packages/core/tests/acceptance/line-chart-test.ts
+++ b/packages/core/tests/acceptance/line-chart-test.ts
@@ -25,7 +25,6 @@ module('Acceptance | line chart', function (hooks) {
     assert
       .dom(metricCharts[0].querySelector('.chart-tooltip__value'))
       .includesText('rc=6', 'The row count is correct for the first metric chart.');
-    // await hideTooltip(0);
 
     // check text of the tooltip container
     await showTooltip(getEmberComponent(metricCharts[1].id), 1);

--- a/packages/core/tests/dummy/app/services/navi-formatter.js
+++ b/packages/core/tests/dummy/app/services/navi-formatter.js
@@ -1,0 +1,23 @@
+import NaviFormatterService from 'navi-data/services/navi-formatter';
+import { inject as service } from '@ember/service';
+import { isEmpty } from '@ember/utils';
+import { assert } from '@ember/debug';
+import numbro from 'numbro';
+import ColumnFragment from 'navi-core/models/request/column';
+
+export default class CustomFormatterService extends NaviFormatterService {
+  @service router;
+  formatMetricValue(value, column, row, requestedFormat) {
+    if (this.router.currentRouteName !== 'line-chart') {
+      return super.formatMetricValue(...arguments);
+    }
+    if (isEmpty(value)) {
+      return '--';
+    }
+    const format = requestedFormat ? requestedFormat : { mantissa: 9, trimMantissa: true, thousandSeparated: true };
+    assert('The column is passed', column instanceof ColumnFragment);
+    assert('The row is passed', typeof row === 'object');
+    assert('The correct value is passed', row[column.canonicalName] === value);
+    return numbro(value).format(format) + ` rc=${Object.keys(row).length}`;
+  }
+}

--- a/packages/core/tests/dummy/app/templates/line-chart.hbs
+++ b/packages/core/tests/dummy/app/templates/line-chart.hbs
@@ -1,5 +1,3 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-
 <h3>By Metric</h3>
 <div class="chart-container metric">
   <NaviVisualizationConfig::Wrapper
@@ -9,6 +7,7 @@
     @onUpdateConfig={{fn (mut this.metricOptions)}}
   />
   <NaviVisualizations::LineChart
+    class="type-{{this.metricOptions.axis.y.series.type}}"
     @model={{this.model.default}}
     @options={{this.metricOptions}}
   />
@@ -16,24 +15,28 @@
 
 <h3>By Year</h3>
 <NaviVisualizations::LineChart
+  class="type-{{this.timeOptions.axis.y.series.type}}"
   @model={{this.model.default}}
   @options={{this.timeOptions}}
 />
 
 <h3>Hours by Day</h3>
 <NaviVisualizations::LineChart
+  class="type-{{this.hourByDayTimeOptions.axis.y.series.type}}"
   @model={{this.model.hourGrain}}
   @options={{this.hourByDayTimeOptions}}
 />
 
 <h3>Minutes by Hour</h3>
 <NaviVisualizations::LineChart
+  class="type-{{this.minuteByHourTimeOptions.axis.y.series.type}}"
   @model={{this.model.minuteGrain}}
   @options={{this.minuteByHourTimeOptions}}
 />
 
 <h3>Seconds by Minute</h3>
 <NaviVisualizations::LineChart
+  class="type-{{this.secondByMinuteTimeOptions.axis.y.series.type}}"
   @model={{this.model.secondGrain}}
   @options={{this.secondByMinuteTimeOptions}}
 />
@@ -47,6 +50,7 @@
     @onUpdateConfig={{this.onUpdateConfig}}
   />
   <NaviVisualizations::LineChart
+    class="type-{{this.dimensionOptions.axis.y.series.type}}"
     @model={{this.model.dimension}}
     @options={{this.dimensionOptions}}
   />
@@ -54,13 +58,14 @@
 
 <h3>Highlight Anomalies</h3>
 <NaviVisualizations::LineChart
+  class="type-{{this.amomalousOptions.axis.y.series.type}}"
   @model={{this.model.anomalous}}
   @options={{this.amomalousOptions}}
 />
 
 <h3>Custom Chart Builder</h3>
 <NaviVisualizations::LineChart
-  class="custom-chart-builder"
+  class="custom-chart-builder type-{{this.customOptions.axis.y.series.type}}"
   @model={{this.model.default}}
   @options={{this.customOptions}}
 />


### PR DESCRIPTION
## Description
The buildTooltip function keeps a reference to the chart builder to access row information, but we lookup the same instance instead of creating new ones so it gets overwritten if used more than once

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
