### PR TITLE
Fix: Validate request only when trying to schedule a report

### DIFF
--- a/packages/core/addon/mirage/fixtures/users.ts
+++ b/packages/core/addon/mirage/fixtures/users.ts
@@ -3,7 +3,7 @@ export default [
     id: 'navi_user',
     createdOn: '01-01-2015 00:00:00',
     updatedOn: '01-01-2016 00:00:00',
-    reportIds: [1, 2, 4],
+    reportIds: [1, 2, 4, 6],
     favoriteReportIds: [2],
     favoriteDashboardIds: [1],
     deliveryRuleIds: [1, 2, 3],

--- a/packages/directory/tests/acceptance/dir-table-test.js
+++ b/packages/directory/tests/acceptance/dir-table-test.js
@@ -12,7 +12,7 @@ module('Acceptance | dir table', function (hooks) {
 
     await visit('/directory/my-data');
 
-    assert.dom('tbody tr').exists({ count: 6 }, 'All items for a user are listed by default in my-data');
+    assert.dom('tbody tr').exists({ count: 7 }, 'All items for a user are listed by default in my-data');
 
     await visit('/directory/my-data?filter=favorites');
 
@@ -29,6 +29,7 @@ module('Acceptance | dir table', function (hooks) {
       '02/01/2016 - 12:00:00 am',
       '01/01/2016 - 03:00:00 am',
       '01/01/2016 - 12:00:00 am',
+      '04/01/2015 - 12:00:00 am',
       '01/03/2015 - 12:00:00 am',
       '01/01/2015 - 12:00:00 am',
     ];

--- a/packages/reports/addon/components/navi-action-list.ts
+++ b/packages/reports/addon/components/navi-action-list.ts
@@ -16,6 +16,6 @@ export default class NaviActionList extends NaviBaseActionList<ReportModel> {
   @action
   async isItemValid() {
     await this.args.item.request?.loadMetadata();
-    return this.args.item.validations?.isTruelyValid;
+    return this.args.item.request?.validations?.isTruelyValid;
   }
 }

--- a/packages/reports/addon/templates/components/report-actions.hbs
+++ b/packages/reports/addon/templates/components/report-actions.hbs
@@ -130,7 +130,7 @@
           @style="text"
           @size="medium"
           @icon="time"
-          disabled={{not @model.validations.isTruelyValid}}
+          disabled={{not @model.request.validations.isTruelyValid}}
           {{on "click" onOpen}}
         >
           Schedule
@@ -138,7 +138,7 @@
       </span>
     </CommonActions::Schedule>
     <EmberTooltip @targetId="report-actions__schedule">
-      {{if @model.validations.isTruelyValid "Schedule the report" "Unable to schedule invalid report"}}
+      {{if @model.request.validations.isTruelyValid "Schedule the report" "Unable to schedule invalid report"}}
     </EmberTooltip>
   {{/if}}
 

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -835,7 +835,7 @@ module('Acceptance | Navi Report', function (hooks) {
 
     assert.deepEqual(
       reportNames,
-      ['Hyrule News', 'Hyrule Ad&Nav Clicks', 'Report 12'],
+      ['Hyrule News', 'Hyrule Ad&Nav Clicks', 'Report 12', 'Invalid report'],
       'Report 1 is initially listed in reports route'
     );
 
@@ -852,7 +852,11 @@ module('Acceptance | Navi Report', function (hooks) {
 
     reportNames = findAll('.table tbody td:first-child').map((el) => el.innerText.trim());
 
-    assert.deepEqual(reportNames, ['Hyrule Ad&Nav Clicks', 'Report 12'], 'Deleted report is removed from list');
+    assert.deepEqual(
+      reportNames,
+      ['Hyrule Ad&Nav Clicks', 'Report 12', 'Invalid report'],
+      'Deleted report is removed from list'
+    );
 
     // /* == Not owner == */
     await visit('/reports/3/view');
@@ -974,7 +978,7 @@ module('Acceptance | Navi Report', function (hooks) {
 
     assert.deepEqual(
       titles,
-      ['Hyrule News', 'Hyrule Ad&Nav Clicks', 'Report 12'],
+      ['Hyrule News', 'Hyrule Ad&Nav Clicks', 'Report 12', 'Invalid report'],
       'the report list with `navi-users`s reports is shown'
     );
   });
@@ -1014,7 +1018,11 @@ module('Acceptance | Navi Report', function (hooks) {
 
     let reportNames = findAll('.table tbody td:first-child').map((el) => el.innerText.trim());
 
-    assert.deepEqual(reportNames, ['Hyrule Ad&Nav Clicks', 'Report 12'], 'Deleted report is removed from list');
+    assert.deepEqual(
+      reportNames,
+      ['Hyrule Ad&Nav Clicks', 'Report 12', 'Invalid report'],
+      'Deleted report is removed from list'
+    );
   });
 
   test('Visiting Reports Route From Breadcrumb', async function (assert) {

--- a/packages/reports/tests/acceptance/schedule-modal-test.js
+++ b/packages/reports/tests/acceptance/schedule-modal-test.js
@@ -527,7 +527,7 @@ module('Acceptance | Navi Report Schedule Modal', function (hooks) {
     await visit('/reports');
 
     // Click "Schedule"
-    await triggerEvent('.navi-collection__row1', 'mouseenter');
+    await triggerEvent('.navi-collection__row3', 'mouseenter');
     await click('.navi-report-actions__schedule');
 
     assert

--- a/packages/reports/tests/unit/routes/reports/index-test.js
+++ b/packages/reports/tests/unit/routes/reports/index-test.js
@@ -21,11 +21,11 @@ module('Unit | Route | reports/index', function (hooks) {
       return run(() => {
         return route.model().then((model) => {
           return model.get('reports').then((reports) => {
-            assert.deepEqual(reports.mapBy('id'), ['1', '2', '4'], 'Routes model returns the reports');
+            assert.deepEqual(reports.mapBy('id'), ['1', '2', '4', '6'], 'Routes model returns the reports');
 
             assert.deepEqual(
               reports.mapBy('title'),
-              ['Hyrule News', 'Hyrule Ad&Nav Clicks', 'Report 12'],
+              ['Hyrule News', 'Hyrule Ad&Nav Clicks', 'Report 12', 'Invalid report'],
               'Model contains user reports and favorite reports'
             );
           });


### PR DESCRIPTION
## Proposed Changes

- validate the request, not the whole report
- add an invalid report to the mocks for testing

## Screenshots

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
