### PR TITLE
Fix: Report builder sidebar cuts off long strings

### DIFF
--- a/packages/reports/addon/components/report-builder/sidebar.hbs
+++ b/packages/reports/addon/components/report-builder/sidebar.hbs
@@ -2,7 +2,7 @@
 <AnimatedContainer class="report-builder-sidebar {{if (is-mobile) "report-builder-sidebar--float"}} column">
   <AnimatedIf @predicate={{@isOpen}} @use={{this.drawerTransition}} @duration={{100}}>
     <div class="report-builder-sidebar__header row align-items-center space-between p-l-18 p-y-7">
-      <div>
+      <div class="col">
         {{#if (eq this.sourcePath.length 0)}}
           <DenaliBreadcrumb class="report-builder-sidebar__breadcrumb flex-1 font-12" @items={{array "Select A Datasource"}} as |item|>
             <button

--- a/packages/reports/addon/components/report-builder/source-selector.hbs
+++ b/packages/reports/addon/components/report-builder/source-selector.hbs
@@ -1,5 +1,5 @@
 {{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<div class="report-builder-source-selector" ...attributes>
+<div class="report-builder-source-selector flex-1" ...attributes>
   {{#if @sourcesTask.isSuccessful}}
     {{#if (gt @sourcesTask.value.length 0)}}
       {{#let (filter-by "isSuggested" @sourcesTask.value) as |suggestedSources|}}

--- a/packages/reports/app/styles/navi-reports/components/report-builder/sidebar.scss
+++ b/packages/reports/app/styles/navi-reports/components/report-builder/sidebar.scss
@@ -41,10 +41,14 @@
   }
 
   &__source {
-    max-width: 400px;
+    max-width: 250px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    &[data-selecting='columns'] {
+      max-width: 400px;
+    }
   }
 
   &__separator {

--- a/packages/reports/app/styles/navi-reports/components/report-builder/sidebar.scss
+++ b/packages/reports/app/styles/navi-reports/components/report-builder/sidebar.scss
@@ -41,7 +41,7 @@
   }
 
   &__source {
-    max-width: 200px;
+    max-width: 400px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/reports/app/styles/navi-reports/components/report-builder/source-selector.scss
+++ b/packages/reports/app/styles/navi-reports/components/report-builder/source-selector.scss
@@ -4,7 +4,7 @@
  */
 
 .report-builder-source-selector {
-  width: 300px;
+  min-width: 300px;
 
   &-title {
     &:not(:first-child) {


### PR DESCRIPTION
## Description

Fix the sidebar layout to display long strings better

## Screenshots

Before:
<img width="508" alt="before" src="https://user-images.githubusercontent.com/12093492/142920905-3cfec14e-d839-4a85-ab7a-1fc07e2a81f3.png">

After:
<img width="507" alt="after" src="https://user-images.githubusercontent.com/12093492/142920901-81a1de42-7687-47e2-86fc-30a5cf495a6c.png">

Datasource/Table selector stays small:
<img width="329" alt="Screen Shot 2021-11-22 at 1 30 18 PM" src="https://user-images.githubusercontent.com/12093492/142923580-989de2f5-9b40-4df8-80df-73e4f07c6ab3.png">

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
