### PR TITLE
Fix: Respect fili dimension field order from request

### DIFF
--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -227,7 +227,7 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
       ? `/${dimensions
           .map((dim) => {
             const fields = [...new Set(dimensionToFields[dim])].filter((field) => !!field);
-            return `${dim}${fields.length > 0 ? `;show=${fields.sort().join(',')}` : ''}`;
+            return `${dim}${fields.length > 0 ? `;show=${fields.join(',')}` : ''}`;
           })
           .join('/')}`
       : '';

--- a/packages/data/tests/unit/adapters/facts/bard-test.ts
+++ b/packages/data/tests/unit/adapters/facts/bard-test.ts
@@ -210,13 +210,17 @@ module('Unit | Adapter | facts/bard', function (hooks) {
         { field: 'd2', type: 'dimension', parameters: { field: 'id' } },
         { field: 'd2', type: 'dimension', parameters: { field: 'id' } },
         { field: 'd2', type: 'dimension', parameters: { field: 'key' } },
+        { field: 'd2', type: 'dimension', parameters: { field: 'other' } },
         { field: 'd1', type: 'dimension', parameters: { field: 'desc' } },
+        { field: 'd1', type: 'dimension', parameters: { field: 'desc' } },
+        { field: 'd1', type: 'dimension', parameters: { field: 'id' } },
+        { field: 'd1', type: 'dimension', parameters: { field: 'another' } },
       ],
     };
     assert.equal(
       Adapter._buildDimensionsPath(multipleFields),
-      '/d1;show=desc,id/d2;show=id,key',
-      '_buildDimensionsPath built the correct string for duplicate dimension with different and same fields'
+      '/d1;show=id,desc,another/d2;show=id,key,other',
+      '_buildDimensionsPath deduplicates dimension and fields while respecting the order of the fields'
     );
 
     let noFields: RequestV2 = {


### PR DESCRIPTION
## Description
Respects the dimension field order from the request so that CSV output matches better with the table visualization

## Proposed Changes
- Do not sort dimension fields in show clause

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
