### PR TITLE
Update: Export TotalType, TotalRow types

### DIFF
--- a/packages/core/addon/components/navi-visualizations/table.ts
+++ b/packages/core/addon/components/navi-visualizations/table.ts
@@ -28,7 +28,7 @@ const HEADER_TITLE = {
   grandTotal: 'Grand Total',
   subtotal: 'Subtotal',
 };
-type TotalType = keyof typeof HEADER_TITLE;
+export type TotalType = keyof typeof HEADER_TITLE;
 
 export type TableSortDirection = SortDirection | 'none';
 const NEXT_SORT_DIRECTION: Record<TableSortDirection, TableSortDirection> = {
@@ -37,7 +37,7 @@ const NEXT_SORT_DIRECTION: Record<TableSortDirection, TableSortDirection> = {
   asc: 'none',
 };
 
-type TotalRow = ResponseRow;
+export type TotalRow = ResponseRow;
 
 type UpdateAction = string;
 export type VisualizationModelEntry = { request: RequestFragment; response: NaviFactResponse };


### PR DESCRIPTION
## Description

Export these types to allow `computeColumnTotal` to be overriden

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
