### PR TITLE
Fix: Columns that are not isSortable can still be sorted from column config

### DIFF
--- a/packages/reports/addon/components/navi-column-config/base.hbs
+++ b/packages/reports/addon/components/navi-column-config/base.hbs
@@ -25,7 +25,7 @@
             {{on "click" @cloneColumn}}
           />
           <DenaliIcon
-            class="navi-column-config-base__sort-icon {{unless @column.fragment.columnMetadata.isSortable "navi-column-config-base__sort-icon--disabled"}} {{if @column.fragment.sortedDirection "navi-column-config-base__sort-icon--active"}}"
+            class="navi-column-config-base__sort-icon {{unless @column.fragment.columnMetadata.isSortable "is-disabled"}} {{if @column.fragment.sortedDirection "navi-column-config-base__sort-icon--active"}}"
             @icon="swap-vertical-circle"
             @size="small"
             disabled={{not @column.fragment.columnMetadata.isSortable}}

--- a/packages/reports/addon/consumers/request/sort.ts
+++ b/packages/reports/addon/consumers/request/sort.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import ActionConsumer from 'navi-core/consumers/action-consumer';
@@ -55,6 +55,10 @@ export default class SortConsumer extends ActionConsumer {
       columnFragment: ColumnFragment,
       direction: SortDirection
     ) {
+      if (!columnFragment.columnMetadata.isSortable) {
+        return;
+      }
+
       const { routeName } = route;
       const { request } = route.modelFor(routeName) as ReportModel;
       const sorts = request.sorts.filter((sort) => sort.canonicalName === columnFragment.canonicalName);

--- a/packages/reports/app/styles/navi-reports/components/navi-column-config.scss
+++ b/packages/reports/app/styles/navi-reports/components/navi-column-config.scss
@@ -19,10 +19,6 @@
       color: map-get($denali-grey-colors, '100');
     }
   }
-
-  &--disabled {
-    @extend .is-disabled;
-  }
 }
 
 @mixin navi-subtotal-button {
@@ -33,7 +29,7 @@
   margin: 0 1px;
   padding: 3px;
 
-  &:hover {
+  &:hover:not(.is-disabled) {
     color: $links-hover-text-color;
   }
 

--- a/packages/reports/tests/acceptance/column-config-test.ts
+++ b/packages/reports/tests/acceptance/column-config-test.ts
@@ -288,8 +288,27 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
   });
 
   test('adding, removing and changing a sort', async function (assert) {
-    assert.expect(6);
+    assert.expect(11);
     await newReport();
+
+    await clickItem('dimension', 'Age');
+    assert.deepEqual(
+      findAll('.navi-column-config-item__parameter-label').map((el) => el.textContent?.trim()),
+      ['Dimension Field Type'],
+      'The sort direction is not listed'
+    );
+    await click('.navi-column-config-base__sort-icon');
+    assert
+      .dom('.navi-column-config-base__sort-icon')
+      .doesNotHaveClass(
+        'navi-column-config-base__sort-icon--active',
+        'The sort icon does not become active for a column that is not sortable'
+      );
+    assert.deepEqual(
+      findAll('.navi-column-config-item__parameter-label').map((el) => el.textContent?.trim()),
+      ['Dimension Field Type'],
+      'The sort direction is still not listed'
+    );
 
     await clickItem('dimension', 'Date Time');
     assert.deepEqual(
@@ -304,6 +323,10 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
       ['Sort Direction', 'Time Grain Type'],
       'A sort direction is applied and becomes the first parameter'
     );
+
+    assert
+      .dom('.navi-column-config-base__sort-icon')
+      .hasClass('navi-column-config-base__sort-icon--active', 'The sort icon becomes active');
 
     assert
       .dom('.navi-column-config-item__parameter-trigger')
@@ -325,6 +348,9 @@ module('Acceptance | Navi Report | Column Config', function (hooks) {
       ['Time Grain Type'],
       'The sort direction is not listed'
     );
+    assert
+      .dom('.navi-column-config-base__sort-icon')
+      .doesNotHaveClass('navi-column-config-base__sort-icon--active', 'The sort icon is no longer active');
   });
 
   test('toggling a sort', async function (assert) {

--- a/packages/reports/tests/acceptance/fili-datasource-test.ts
+++ b/packages/reports/tests/acceptance/fili-datasource-test.ts
@@ -152,13 +152,17 @@ module('Acceptance | fili datasource', function (hooks) {
   });
 
   test('Fili Dimension sorting disabled', async function (assert) {
-    assert.expect(4);
+    assert.expect(7);
     await newReport();
 
     await clickItem('dimension', 'Date Time');
     assert
       .dom('.navi-column-config-base__sort-icon')
       .doesNotHaveAttribute('disabled', 'A timeDimension column can be sorted');
+    await click('.navi-column-config-base__sort-icon');
+    assert
+      .dom('.navi-column-config-base__sort-icon')
+      .hasClass('navi-column-config-base__sort-icon--active', 'The timeDimension sort icon becomes active');
 
     await clickItem('dimension', 'Age');
     assert
@@ -167,9 +171,17 @@ module('Acceptance | fili datasource', function (hooks) {
     assert
       .dom('.navi-column-config-base__sort-icon')
       .hasAttribute('title', 'This column cannot be sorted', 'A dimension column cannot be sorted');
+    await click('.navi-column-config-base__sort-icon');
+    assert
+      .dom('.navi-column-config-base__sort-icon')
+      .doesNotHaveClass('navi-column-config-base__sort-icon--active', 'The dimension sort icon does not become active');
 
     await clickItem('metric', 'Revenue');
     assert.dom('.navi-column-config-base__sort-icon').doesNotHaveAttribute('disabled', 'A metric column can be sorted');
+    await click('.navi-column-config-base__sort-icon');
+    assert
+      .dom('.navi-column-config-base__sort-icon')
+      .hasClass('navi-column-config-base__sort-icon--active', 'The metric sort icon becomes active');
   });
 
   test('Fili Remove time column (all grain)', async function (assert) {

--- a/packages/reports/tests/unit/consumers/request/sort-test.ts
+++ b/packages/reports/tests/unit/consumers/request/sort-test.ts
@@ -75,9 +75,8 @@ module('Unit | Consumer | request sort', function (hooks) {
       {
         'network.dateTime(grain=day)': 'desc',
         adClicks: 'desc',
-        'age(field=id)': 'desc',
       },
-      'The sorts are added'
+      'The sorts are added only for columns that are sortable'
     );
 
     Consumer.send(RequestActions.UPSERT_SORT, route, request.columns.objectAt(0), 'asc');
@@ -88,18 +87,6 @@ module('Unit | Consumer | request sort', function (hooks) {
       {
         'network.dateTime(grain=day)': 'asc',
         adClicks: 'asc',
-        'age(field=id)': 'desc',
-      },
-      'The sorts are added'
-    );
-
-    Consumer.send(RequestActions.UPSERT_SORT, route, request.columns.objectAt(2), 'asc');
-    assert.deepEqual(
-      getSorts(request),
-      {
-        'network.dateTime(grain=day)': 'asc',
-        adClicks: 'asc',
-        'age(field=id)': 'asc',
       },
       'The sorts are updated'
     );


### PR DESCRIPTION
## Description

If a column is not `isSortable`, don't sort it.

## Screenshots

![Dec-14-2021 16-33-20](https://user-images.githubusercontent.com/13946669/146101124-2e77c1ab-7596-4796-b0b9-647055c5d8c3.gif)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
