### PR TITLE
Fix: Allow admins to update dashboard editors

### DIFF
--- a/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/DashboardTest.kt
+++ b/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/DashboardTest.kt
@@ -236,7 +236,8 @@ class DashboardTest : IntegrationTest() {
                             attr("title", "A New Dashboard")
                         ),
                         relationships(
-                            relation("owner", linkage(type("users"), id(USER2)))
+                            relation("owner", linkage(type("users"), id(USER2))),
+                            relation("editors", linkage(type("users"), id(USER3)))
                         )
                     )
                 )

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/User.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/User.kt
@@ -71,7 +71,7 @@ class User : HasRoles {
     @Where(clause = "ASSET_TYPE = 'dashboard'")
     var dashboards: MutableSet<Dashboard> = mutableSetOf()
 
-    @UpdatePermission(expression = IS_DASHBOARD_OWNER)
+    @UpdatePermission(expression = "$IS_DASHBOARD_OWNER OR $IS_ADMIN")
     @ManyToMany
     @JoinTable(
         name = "map_editor_to_dashboard_collections",


### PR DESCRIPTION
Resolves #

<!-- The above line will close the issue upon merge -->

## Description

## Proposed Changes

- Fix: Allow admins to update dashboard editors

## Screenshots

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
