### PR TITLE
Fix: Align asset actions

### DIFF
--- a/packages/dashboards/addon/components/dashboard-actions.hbs
+++ b/packages/dashboards/addon/components/dashboard-actions.hbs
@@ -1,5 +1,5 @@
 {{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<div class="dashboard-actions flex-1 flex" ...attributes>
+<div class="dashboard-actions flex-1 flex align-items-center" ...attributes>
   {{#with @item as | dashboard |}}
     {{!-- Clone action enabled at all times --}}
     <LinkTo class="dashboard-actions__clone" @route="dashboards.dashboard.clone" @model={{dashboard.id}}>
@@ -35,7 +35,7 @@
 
     <CommonActions::Share
       @buildUrl={{fn this.buildUrl dashboard}}
-      class="dashboard-actions__share p-0"
+      class="dashboard-actions__share p-0 flex"
     >
       <DenaliIcon
         id="dashboard-actions__share-{{dashboard.id}}"

--- a/packages/directory/addon/components/dir-item-favorite-cell.hbs
+++ b/packages/directory/addon/components/dir-item-favorite-cell.hbs
@@ -1,6 +1,6 @@
 {{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <DenaliIcon
-  class="link p-x-30"
+  class="link p-x-16"
   @icon={{if @value.isFavorite "star-solid" "star"}}
   @size="small"
   {{on "click" (fn this.toggleFavorite @value.isFavorite)}}

--- a/packages/directory/addon/components/dir-table.ts
+++ b/packages/directory/addon/components/dir-table.ts
@@ -51,7 +51,7 @@ export default class DirTableComponent extends Component<DirTableComponentArgs> 
         sortable: false,
         hideable: false,
         draggable: false,
-        width: '80px',
+        width: '50px',
         classNames: 'dir-table__header-cell dir-table__header-cell--favorite',
         cellComponent: 'dir-item-favorite-cell',
         cellClassNames: 'dir-table__cell dir-table__cell--favorite',

--- a/packages/reports/addon/components/navi-action-list.hbs
+++ b/packages/reports/addon/components/navi-action-list.hbs
@@ -1,5 +1,5 @@
 {{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
-<div class="navi-report-actions flex-1 flex" ...attributes>
+<div class="navi-report-actions flex-1 flex align-items-center" ...attributes>
   {{!-- Clone only enabled on a saved report --}}
   <LinkTo
     class="navi-report-actions__clone"
@@ -10,7 +10,7 @@
     <DenaliIcon
       @size="small"
       @icon="copy-file"
-      class="p-4 link m-r-4"
+      class="p-x-4 link m-r-4"
       disabled={{@item.isNew}}
     />
     <EmberTooltip @popperContainer="body">
@@ -26,7 +26,7 @@
         @model={{@item}}
       >
         <DenaliIcon
-          class="navi-report-actions__export-btn p-4 link m-r-4"
+          class="navi-report-actions__export-btn p-x-4 link m-r-4"
           @size="small"
           @icon="download"
         />
@@ -39,7 +39,7 @@
         {{!-- this wrapper div exists because tooltip doesn't render for a disabled button --}}
         <DenaliIcon
           id="navi-report-actions__export-{{@index}}"
-          class="navi-report-actions__export-btn p-4 link m-r-4"
+          class="navi-report-actions__export-btn p-x-4 link m-r-4"
           @size="small"
           @icon="download"
           {{on "click" onClick}}
@@ -58,12 +58,12 @@
     @pageTitle={{@item.title}}
     @buildUrl={{this.buildUrl}}
     @disabled={{@item.isNew}}
-    class="p-0"
+    class="p-0 flex"
   >
     <DenaliIcon
       id="navi-report-actions__share-{{@index}}"
       disabled={{@item.isNew}}
-      class="p-4 link m-r-4"
+      class="p-x-4 link m-r-4"
       @size="small"
       @icon="share-arrow"
     />
@@ -88,7 +88,7 @@
           id="navi-report-actions__schedule-{{@index}}"
           @icon="time"
           @size="small"
-          class="navi-report-actions__schedule p-4 link m-r-4"
+          class="navi-report-actions__schedule p-x-4 link m-r-4"
           {{on "click" onOpen}}
         />
         <EmberTooltip @popperContainer="body" @targetId="navi-report-actions__schedule-{{@index}}">
@@ -110,7 +110,7 @@
       <DenaliIcon
         @size="small"
         @icon="trash"
-        class="navi-report-actions__delete-btn p-4 link m-r-4"
+        class="navi-report-actions__delete-btn p-x-4 link m-r-4"
         id="navi-report-actions__delete-{{@index}}"
         {{on "click" onDelete}}
       />


### PR DESCRIPTION
## Description
Align report and dashboard actions, make favorite section smaller

## Screenshots
<img width="588" alt="asset actions" src="https://user-images.githubusercontent.com/12093492/146692695-7ee1aaf5-4376-482e-997b-72ff5ba5e01b.png">

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
