### PR TITLE
New: Adding overwriteFile rule.

### DIFF
--- a/packages/core/addon/models/fragments/scheduling-rules.ts
+++ b/packages/core/addon/models/fragments/scheduling-rules.ts
@@ -8,6 +8,9 @@ import Fragment from 'ember-data-model-fragments/fragment';
 export default class SchedulingRuleFragment extends Fragment {
   @attr('boolean')
   mustHaveData!: boolean;
+
+  @attr('boolean')
+  overwriteFile!: boolean;
 }
 
 declare module 'navi-core/models/registry' {

--- a/packages/core/tests/unit/models/delivery-rule-test.js
+++ b/packages/core/tests/unit/models/delivery-rule-test.js
@@ -14,6 +14,7 @@ const ExpectedDeliveryRule = {
   frequency: 'week',
   schedulingRules: {
     mustHaveData: false,
+    overwriteFile: false,
   },
   format: {
     type: 'csv',

--- a/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/DeliveryRulesTest.kt
+++ b/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/DeliveryRulesTest.kt
@@ -20,7 +20,7 @@ class DeliveryRulesTest : IntegrationTest() {
     private val USER1 = "user1"
     private val USER2 = "user2"
     private val format: DeliveryFormat = DeliveryFormat(DeliveryType.csv)
-    private val schedulingRules: SchedulingRules = SchedulingRules(false)
+    private val schedulingRules: SchedulingRules = SchedulingRules(false, false)
 
     @BeforeEach
     fun setup() {
@@ -126,6 +126,7 @@ class DeliveryRulesTest : IntegrationTest() {
                 "data.attributes.frequency", equalTo("week"),
                 "data.attributes.format.type", equalTo("csv"),
                 "data.attributes.schedulingRules.mustHaveData", equalTo(false),
+                "data.attributes.schedulingRules.overwriteFile", equalTo(false),
                 "data.attributes.recipients", hasItems("email1@yavin.dev", "email2@yavin.dev", "email3@yavin.dev"),
                 "data.attributes.lastDeliveredOn", nullValue(),
                 "data.attributes.dataSources", equalTo(emptyList<String>()), // no request, no dataSources
@@ -288,7 +289,7 @@ class DeliveryRulesTest : IntegrationTest() {
                         id("1"),
                         attributes(
                             attr("frequency", "quarter"),
-                            attr("schedulingRules", SchedulingRules(true))
+                            attr("schedulingRules", SchedulingRules(true, true))
                         )
                     )
                 )
@@ -307,7 +308,8 @@ class DeliveryRulesTest : IntegrationTest() {
             .assertThat()
             .body(
                 "data.attributes.frequency", equalTo("quarter"),
-                "data.attributes.schedulingRules.mustHaveData", equalTo(true)
+                "data.attributes.schedulingRules.mustHaveData", equalTo(true),
+                "data.attributes.schedulingRules.overwriteFile", equalTo(true)
             )
 
         given()

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/SchedulingRules.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/SchedulingRules.kt
@@ -11,5 +11,6 @@ import org.hibernate.annotations.TypeDef
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @TypeDef(typeClass = JsonType::class, name = "json")
 data class SchedulingRules(
-    var mustHaveData: Boolean = false
+    var mustHaveData: Boolean = false,
+    var overwriteFile: Boolean = false
 )


### PR DESCRIPTION
## Description

Adds overwrite file to delivery rule for cloud based delivery systems where previous data exports can be reasonably overwritten.

## Proposed Changes

- Adds overwriteFile to scheduling rules.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
