### PR TITLE
Fix: Subtotal changes no longer needs deep merge

### DIFF
--- a/packages/core/addon/components/navi-visualization-config/table.ts
+++ b/packages/core/addon/components/navi-visualization-config/table.ts
@@ -43,7 +43,6 @@ export default class NaviVisualizationConfigTableComponent extends NaviVisualiza
   @action
   onToggleGrandTotal(grandTotal: boolean): void {
     const subtotal = this.args.options?.showTotals?.subtotal;
-    console.log(subtotal, { showTotals: { grandTotal, ...(subtotal ? { subtotal } : null) } });
     this.args.onUpdateConfig({ showTotals: { grandTotal, ...(subtotal ? { subtotal } : null) } });
   }
 

--- a/packages/core/addon/components/navi-visualization-config/table.ts
+++ b/packages/core/addon/components/navi-visualization-config/table.ts
@@ -42,7 +42,9 @@ export default class NaviVisualizationConfigTableComponent extends NaviVisualiza
    */
   @action
   onToggleGrandTotal(grandTotal: boolean): void {
-    this.args.onUpdateConfig({ showTotals: { grandTotal } });
+    const subtotal = this.args.options?.showTotals?.subtotal;
+    console.log(subtotal, { showTotals: { grandTotal, ...(subtotal ? { subtotal } : null) } });
+    this.args.onUpdateConfig({ showTotals: { grandTotal, ...(subtotal ? { subtotal } : null) } });
   }
 
   /**
@@ -57,7 +59,7 @@ export default class NaviVisualizationConfigTableComponent extends NaviVisualiza
       const { request } = this.args;
       const firstDim = request.dimensionColumns[0];
       this.args.onUpdateConfig({
-        showTotals: { subtotal: firstDim?.cid },
+        showTotals: { subtotal: firstDim?.cid, grandTotal: this.args.options?.showTotals?.grandTotal ?? false },
       });
     } else if (this.args.options?.showTotals?.subtotal !== undefined) {
       const newOptions = { ...this.args.options };
@@ -73,6 +75,8 @@ export default class NaviVisualizationConfigTableComponent extends NaviVisualiza
    */
   @action
   updateSubtotal(dimension: ColumnFragment): void {
-    this.args.onUpdateConfig({ showTotals: { subtotal: dimension.cid } });
+    this.args.onUpdateConfig({
+      showTotals: { subtotal: dimension.cid, grandTotal: this.args.options?.showTotals?.grandTotal ?? false },
+    });
   }
 }

--- a/packages/reports/tests/acceptance/report-visualizations-test.js
+++ b/packages/reports/tests/acceptance/report-visualizations-test.js
@@ -293,4 +293,24 @@ module('Acceptance | navi-report - report visualizations', function (hooks) {
       .dom('.report-view__info-text')
       .isNotVisible('Updating the column config does not prompt the user to rerun the report');
   });
+
+  test('Table subtotal/total config', async function (assert) {
+    assert.expect(2);
+    await visit('/reports/new?datasource=bardOne');
+
+    await click('.report-builder-source-selector__source-button[data-source-name="Table A"]');
+
+    await clickItem('dimension', 'Date Time');
+    await clickItem('dimension', 'Browser');
+    await clickItem('metric', 'Revenue');
+    await click('.navi-report__run-btn');
+    await click('.report-view__visualization-edit-btn');
+
+    await click('.table-config__total-toggle-button--grand-total');
+    await click('.table-config__total-toggle-button--subtotal');
+    await click('.navi-report__run-btn');
+
+    assert.dom('.table-row__total-row .table-cell--total').hasText('Subtotal');
+    assert.dom('.table-row__total-row.table-row__last-row .table-cell--total').hasText('Grand Total');
+  });
 });


### PR DESCRIPTION
## Description

changes in how visualization changes are merged, deep merges no longer work

## Proposed Changes

- total/subtotal was requiring a deep merge, fixed so that config includes all properties so deep merge no longer is required.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
