### PR TITLE
Fix: Convert string to number for viz config

### DIFF
--- a/packages/core/addon/components/navi-visualization-config/goal-gauge.ts
+++ b/packages/core/addon/components/navi-visualization-config/goal-gauge.ts
@@ -3,7 +3,6 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { action, set } from '@ember/object';
-import { readOnly } from '@ember/object/computed';
 import ColumnFragment from 'navi-core/models/request/column';
 import { Args as GoalGaugeArgs } from '../navi-visualizations/goal-gauge';
 import NaviVisualizationConfigBaseComponent from './base';
@@ -11,7 +10,9 @@ import NaviVisualizationConfigBaseComponent from './base';
 type Options = GoalGaugeArgs['options'];
 
 export default class NaviVisualizationConfigGoalGaugeComponent extends NaviVisualizationConfigBaseComponent<Options> {
-  @readOnly('args.request.metricColumns.firstObject') metricColumn!: ColumnFragment;
+  get metricColumn(): ColumnFragment {
+    return this.args.request.metricColumns[0];
+  }
 
   /**
    * @param alias - date string input event
@@ -23,12 +24,12 @@ export default class NaviVisualizationConfigGoalGaugeComponent extends NaviVisua
   }
 
   @action
-  updateBaseline(baselineValue: number) {
-    this.args.onUpdateConfig?.({ baselineValue });
+  updateBaseline(baselineValue: string) {
+    this.args.onUpdateConfig?.({ ...this.args.options, baselineValue: Number(baselineValue) });
   }
 
   @action
-  updateGoal(goalValue: number) {
-    this.args.onUpdateConfig?.({ goalValue });
+  updateGoal(goalValue: string) {
+    this.args.onUpdateConfig?.({ ...this.args.options, goalValue: Number(goalValue) });
   }
 }

--- a/packages/core/addon/models/goal-gauge.ts
+++ b/packages/core/addon/models/goal-gauge.ts
@@ -41,13 +41,13 @@ export default class GoalGaugeModel
   extends VisualizationFragment.extend(Validations)
   implements GoalGaugeConfig, TypedVisualizationFragment {
   @attr('string', { defaultValue: 'goal-gauge' })
-  type!: GoalGaugeConfig['type'];
+  declare type: GoalGaugeConfig['type'];
 
   @attr('number', { defaultValue: 2 })
-  version!: GoalGaugeConfig['version'];
+  declare version: GoalGaugeConfig['version'];
 
   @attr({ defaultValue: () => ({}) })
-  metadata!: GoalGaugeConfig['metadata'];
+  declare metadata: GoalGaugeConfig['metadata'];
 
   /**
    * Rebuild config based on request and response
@@ -75,11 +75,11 @@ export default class GoalGaugeModel
         goalValue = 1;
       }
 
-      this.set('metadata', {
+      this.metadata = {
         metricCid,
         baselineValue,
         goalValue,
-      });
+      };
     }
     return this;
   }

--- a/packages/core/tests/integration/components/navi-visualization-config/goal-gauge-test.ts
+++ b/packages/core/tests/integration/components/navi-visualization-config/goal-gauge-test.ts
@@ -6,7 +6,7 @@ import { TestContext as Context } from 'ember-test-helpers';
 import StoreService from '@ember-data/store';
 import NaviVisualizationConfigGoalGaugeComponent from 'navi-core/components/navi-visualization-config/goal-gauge';
 
-const Template = hbs`
+const TEMPLATE = hbs`
   <NaviVisualizationConfig::GoalGauge
     @response={{this.response}}
     @request={{this.request}}
@@ -51,7 +51,7 @@ module('Integration | Component | visualization config/goal gauge', function (ho
   });
 
   test('it renders', async function (this: TestContext, assert) {
-    await render(hbs`<NaviVisualizationConfig::GoalGauge/>`);
+    await render(TEMPLATE);
 
     const headers = findAll('.goal-gauge-config__section-header').map((el) => el?.textContent?.trim());
     assert.deepEqual(headers, ['Goal Label', 'Baseline', 'Goal'], 'headers are displayed for goal gauge config');
@@ -60,22 +60,22 @@ module('Integration | Component | visualization config/goal gauge', function (ho
   test('onUpdateConfig baselineValue input', async function (this: TestContext, assert) {
     assert.expect(1);
 
-    this.set('onUpdateConfig', (result: { baselineValue: string | number }) => {
-      assert.equal(result.baselineValue, 1, 'onUpdateConfig action is called by baseline input');
+    this.set('onUpdateConfig', (result: { baselineValue: number }) => {
+      assert.strictEqual(result.baselineValue, 1, 'onUpdateConfig action is called by baseline input');
     });
 
-    await render(Template);
+    await render(TEMPLATE);
     await fillIn('.goal-gauge-config__baseline-input', '1');
   });
 
   test('onUpdateConfig goalValue input', async function (this: TestContext, assert) {
     assert.expect(1);
 
-    this.set('onUpdateConfig', (result: { goalValue: string | number }) => {
-      assert.equal(result.goalValue, 10, 'onUpdateConfig action is called by goal input');
+    this.set('onUpdateConfig', (result: { goalValue: number }) => {
+      assert.strictEqual(result.goalValue, 10, 'onUpdateConfig action is called by goal input');
     });
 
-    await render(Template);
+    await render(TEMPLATE);
 
     await fillIn('.goal-gauge-config__goal-input', '10');
   });
@@ -83,7 +83,7 @@ module('Integration | Component | visualization config/goal gauge', function (ho
   test('onUpdateConfig goal gauge label input', async function (this: TestContext, assert) {
     assert.expect(1);
 
-    await render(Template);
+    await render(TEMPLATE);
 
     await fillIn('.goal-gauge-config__label-input', 'bottles');
     assert.equal(this.request.metricColumns[0].alias, 'bottles', 'onUpdateConfig action is called by label input');


### PR DESCRIPTION
Resolves #1550 

## Description
The visualization did not convert the baseLine and goal values to numbers before updating the config 


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
