### PR TITLE
Fix: Rollup mask is not calculated correctly

### DIFF
--- a/packages/core/addon/components/navi-visualizations/table.ts
+++ b/packages/core/addon/components/navi-visualizations/table.ts
@@ -165,7 +165,8 @@ export default class Table extends Component<Args> {
     if (request?.rollup?.columnCids?.length <= 0 && !request?.rollup?.grandTotal) {
       return tableData;
     }
-    const dimensionCount = new Set(request?.columns.filter((col) => col.type !== 'metric')).size;
+    const dimensionCount = new Set(request?.columns.filter((col) => col.type !== 'metric').map((col) => col.field))
+      .size;
     const fullMask = parseInt(new Array(dimensionCount).fill('1').join(''), 2);
     return tableData.map((row) => {
       if (row.__rollupMask === undefined || row.__rollupMask === null) {

--- a/packages/core/tests/unit/components/navi-visualizations/table-test.js
+++ b/packages/core/tests/unit/components/navi-visualizations/table-test.js
@@ -421,6 +421,7 @@ module('Unit | Component | table', function (hooks) {
               source: 'bardOne',
             },
             { cid: 'cid_osId', type: 'dimension', field: 'os', parameters: { field: 'id' }, source: 'bardOne' },
+            { cid: 'cid_osIddesc', type: 'dimension', field: 'os', parameters: { field: 'desc' }, source: 'bardOne' },
             { type: 'metric', field: 'uniqueIdentifier', parameters: {}, source: 'bardOne' },
           ],
           sorts: [{ type: 'metric', field: 'uniqueIdentifier', parameters: {}, direction: 'asc', source: 'bardOne' }],


### PR DESCRIPTION
## Description

Found bug where rollupMask is calculated incorrectly when there are duplicate dimensions (say they request both id and desc in same report).

## Proposed Changes

- dedupe correctly forehead.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
