### PR TITLE
Update: Add global date filters to dashboards

### DIFF
--- a/packages/core/addon/mirage/fixtures/dashboard.ts
+++ b/packages/core/addon/mirage/fixtures/dashboard.ts
@@ -29,7 +29,14 @@ export default [
     deliveryRuleIds: [3],
     filters: [
       {
-        dimension: 'property',
+        type: 'timeDimension',
+        dimension: 'bardOne.network.dateTime',
+        operator: 'bet',
+        field: 'day',
+        values: ['P7D', 'current'],
+      },
+      {
+        dimension: 'bardOne.property',
         operator: 'contains',
         field: 'id',
         values: ['114', '100001'],
@@ -125,8 +132,15 @@ export default [
     updatedOn: '2016-01-01 03:00:00',
     deliveryRuleIds: [],
     filters: [
-      { dimension: 'bardOne.age', operator: 'in', field: 'id', values: [1, 2, 3] },
-      { dimension: 'bardTwo.container', operator: 'notin', field: 'id', values: [1] },
+      {
+        type: 'timeDimension',
+        dimension: 'bardOne.network.dateTime',
+        operator: 'bet',
+        field: 'day',
+        values: ['P7D', 'current'],
+      },
+      { type: 'dimension', dimension: 'bardOne.age', operator: 'in', field: 'id', values: [1, 2, 3] },
+      { type: 'dimension', dimension: 'bardTwo.container', operator: 'notin', field: 'id', values: [1] },
     ],
     presentation: {
       version: 1,

--- a/packages/core/addon/serializers/dashboard.js
+++ b/packages/core/addon/serializers/dashboard.js
@@ -1,41 +1,46 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2022, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
 import AssetSerializer from 'navi-core/serializers/asset';
 import { getDefaultDataSourceName } from 'navi-data/utils/adapter';
-import { getOwner } from '@ember/application';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
 
-function v1ToV2Filter(filter, metadataService) {
+function v1ToV2Filter(filter) {
   let source;
-  let dimension; // the filter.dimension might be stored as dataSource.dimension
-  if (filter.dimension.includes('.')) {
-    [source, ...dimension] = filter.dimension.split('.');
-    dimension = dimension.join('.');
+  let dimension;
+  const dotOccurences = (filter.dimension.match(/\./g) ?? []).length;
+  if (dotOccurences > 0) {
+    /**
+     * filter.dimension might be stored as:
+     * dataSource.dimension (fili)
+     * dataSource.table.dimension (elide or dateTime in fili)
+     * dataSource.namespace.table.dimension (elide)
+     */
+    const split = filter.dimension.split('.');
+    source = split.slice(0, dotOccurences > 2 ? 2 : 1).join('.');
+    dimension = split.slice(dotOccurences > 1 ? -2 : -1).join('.');
   } else {
     source = getDefaultDataSourceName();
     dimension = filter.dimension;
   }
 
-  const dimensionMetadata = metadataService.getById('dimension', dimension, source);
-  const timeDimensionMetadata = metadataService.getById('timeDimension', dimension, source);
-  let type;
-  if (!dimensionMetadata && timeDimensionMetadata) {
-    type = 'timeDimension';
-  } else if (dimensionMetadata && !timeDimensionMetadata) {
-    type = 'dimension';
-  } else {
-    type = 'dimension'; //fallback to just dimension
-  }
+  const type = filter.type ?? 'dimension';
+
+  const parameters =
+    type === 'timeDimension'
+      ? {
+          grain: filter.field,
+        }
+      : {
+          field: filter.field,
+        };
 
   return {
     type,
     field: dimension,
-    parameters: {
-      field: filter.field,
-    },
+    parameters,
     operator: filter.operator,
     values: filter.values,
     source,
@@ -56,11 +61,8 @@ export default AssetSerializer.extend({
         newPayload.attributes.filters = [];
       }
 
-      const metadataService = getOwner(this).lookup('service:navi-metadata');
       // TODO: We always convert since we only persist v1 filters
-      newPayload.attributes.filters = newPayload.attributes.filters.map((filter) =>
-        v1ToV2Filter(filter, metadataService)
-      );
+      newPayload.attributes.filters = newPayload.attributes.filters.map((filter) => v1ToV2Filter(filter));
 
       return this._super(type, newPayload);
     }
@@ -84,9 +86,10 @@ export default AssetSerializer.extend({
     dashboard.data.attributes.filters = dashboard.data.attributes.filters.map((filter) => {
       const source = filterSources[buildKey(filter)];
       return {
+        type: filter.type,
         dimension: `${source}.${filter.field}`,
         operator: filter.operator,
-        field: filter.parameters?.field,
+        field: filter.type === 'timeDimension' ? filter.parameters?.grain : filter.parameters?.field,
         values: filter.values,
       };
     });

--- a/packages/core/tests/unit/models/dashboard-test.js
+++ b/packages/core/tests/unit/models/dashboard-test.js
@@ -28,6 +28,15 @@ module('Unit | Model | dashboard', function (hooks) {
           createdOn: '2016-02-01 00:00:00.000',
           filters: [
             {
+              type: 'timeDimension',
+              field: 'network.dateTime',
+              parameters: {
+                grain: 'day',
+              },
+              operator: 'bet',
+              values: ['P7D', 'current'],
+            },
+            {
               type: 'dimension',
               field: 'property',
               parameters: {
@@ -155,6 +164,15 @@ module('Unit | Model | dashboard', function (hooks) {
       assert.deepEqual(
         clonedFilterModel.filters,
         [
+          {
+            type: 'timeDimension',
+            field: 'network.dateTime',
+            parameters: {
+              grain: 'day',
+            },
+            operator: 'bet',
+            values: ['P7D', 'current'],
+          },
           {
             type: 'dimension',
             field: 'age',

--- a/packages/dashboards/addon/components/dashboard-dimension-selector.js
+++ b/packages/dashboards/addon/components/dashboard-dimension-selector.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021, Yahoo Holdings Inc.
+ * Copyright 2022, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -78,8 +78,14 @@ export default class DashboardDimensionSelectorComponent extends Component {
     return Object.entries(dimensionMap).reduce((results, [table, dimensions]) => {
       let dataSource = getDefaultDataSourceName();
       if (table.includes('.')) {
-        [dataSource, ...table] = table.split('.');
-        table = table.join('.');
+        /**
+         * table might be:
+         * dataSource.table (fili/elide)
+         * dataSource.namespace.table (elide)
+         */
+        const split = table.split('.');
+        table = split.pop();
+        dataSource = split.join('.');
       }
 
       dimensions.forEach((dimension) => {
@@ -110,12 +116,11 @@ export default class DashboardDimensionSelectorComponent extends Component {
    */
   mergeWidgetDimensions(widgets) {
     return widgets.reduce((dimensionMap, widget) => {
-      // TODO: Consider including timeDimensions? This would potentially conflict with visualization manifests so skipping for now
-      const { id: tableKey, dimensions } = widget.requests?.firstObject?.tableMetadata || {};
+      const { id: tableKey, dimensions, timeDimensions } = widget.requests?.firstObject?.tableMetadata || {};
       const dataSource = widget?.requests?.firstObject?.dataSource;
       const key = `${dataSource}.${tableKey}`;
       if (!dimensionMap[key]) {
-        dimensionMap[key] = [...dimensions];
+        dimensionMap[key] = [...dimensions, ...timeDimensions];
       }
       return dimensionMap;
     }, {});

--- a/packages/dashboards/addon/services/dashboard-data.ts
+++ b/packages/dashboards/addon/services/dashboard-data.ts
@@ -185,7 +185,7 @@ export default class DashboardDataService extends Service {
       if (filter.type === 'timeDimension') {
         requestClone.filters
           .toArray()
-          .filter((f) => f.field === filter.field)
+          .filter((f) => f.source === filter.source && f.field === filter.field)
           .forEach((f) => requestClone.removeFilter(f));
       }
       requestClone.addFilter(filter);

--- a/packages/dashboards/addon/services/dashboard-data.ts
+++ b/packages/dashboards/addon/services/dashboard-data.ts
@@ -186,9 +186,7 @@ export default class DashboardDataService extends Service {
         requestClone.filters
           .toArray()
           .filter((f) => f.field === filter.field)
-          .forEach((f) => {
-            requestClone.removeFilter(f);
-          });
+          .forEach((f) => requestClone.removeFilter(f));
       }
       requestClone.addFilter(filter);
     });

--- a/packages/dashboards/addon/services/dashboard-data.ts
+++ b/packages/dashboards/addon/services/dashboard-data.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021, Yahoo Holdings Inc.
+ * Copyright 2022, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { A as arr } from '@ember/array';
@@ -179,9 +179,19 @@ export default class DashboardDataService extends Service {
    */
   protected applyFilters(dashboard: DashboardModel, request: RequestFragment): RequestFragment {
     const requestClone = request.clone();
-    this.getValidGlobalFilters(dashboard, request)
-      .filter((filter) => filter.values.length > 0)
-      .forEach((filter) => requestClone.addFilter(filter));
+    const validFilters = this.getValidGlobalFilters(dashboard, request).filter((filter) => filter.values.length > 0);
+
+    validFilters.forEach((filter) => {
+      if (filter.type === 'timeDimension') {
+        requestClone.filters
+          .toArray()
+          .filter((f) => f.field === filter.field)
+          .forEach((f) => {
+            requestClone.removeFilter(f);
+          });
+      }
+      requestClone.addFilter(filter);
+    });
 
     return requestClone;
   }
@@ -220,7 +230,10 @@ export default class DashboardDataService extends Service {
    * Checks if a filter can be applied to a request
    */
   protected isFilterValid(request: RequestFragment, filter: FilterFragment): boolean {
-    const validDimensions = request.tableMetadata?.dimensionIds ?? [];
+    const validDimensions = [
+      ...(request.tableMetadata?.dimensionIds ?? []),
+      ...(request.tableMetadata?.timeDimensionIds ?? []),
+    ];
 
     return filter.source === request.dataSource && validDimensions.includes(filter.columnMetadata.id);
   }

--- a/packages/dashboards/addon/templates/components/dashboard-dimension-selector.hbs
+++ b/packages/dashboards/addon/templates/components/dashboard-dimension-selector.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2022, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div
   class="dashboard-dimension-selector"
   ...attributes
@@ -14,7 +14,9 @@
       @triggerClass="is-medium"
       as |dimension|
     >
-      <div title="Data Source: {{dimension.dataSource}}">{{dimension.name}}</div>
+      <div title="Data Source: {{dimension.source}}, Table(s): {{join ", " dimension.tables}}">
+        {{dimension.name}}
+      </div>
     </PowerSelect>
   {{/if}}
 </div>

--- a/packages/dashboards/addon/templates/components/navi-widget.hbs
+++ b/packages/dashboards/addon/templates/components/navi-widget.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2022, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <GridStackItem
   class="navi-widget"
   @options={{hash
@@ -14,10 +14,10 @@
     <div class="navi-widget__title">
       {{@model.title}}
       {{#if this.filterErrors}}
-        <DenaliIcon 
-          id="navi-widget__filter-errors-{{@index}}" 
-          @icon="warning" 
-          class="navi-widget__filter-errors-icon" 
+        <DenaliIcon
+          id="navi-widget__filter-errors-{{@index}}"
+          @icon="warning"
+          class="navi-widget__filter-errors-icon"
         />
         <EmberTooltip @targetId="navi-widget__filter-errors-{{@index}}" @popperContainer="body">
           {{this.filterErrors}}
@@ -39,10 +39,10 @@
           @deleteAction={{route-action "deleteWidget"}}
           as |showDeleteModal|
         >
-          <DenaliIcon 
-            id="navi-widget__delete-btn-{{@index}}" 
-            @size="small" 
-            @icon="trash" 
+          <DenaliIcon
+            id="navi-widget__delete-btn-{{@index}}"
+            @size="small"
+            @icon="trash"
             class="navi-widget__delete-btn link"
             {{on "click" showDeleteModal}}
           />
@@ -62,13 +62,18 @@
   {{!-- Error --}}
   {{#if @taskInstance.isError}}
     {{!-- TODO: Use Routes::ReportsReportError --}}
-    {{#if (is-forbidden @taskInstance.error)}}
-      <UnauthorizedTable />
-    {{else}}
-      <div class="navi-widget__content error-container">
-        There was an error with your request.
-      </div>
-    {{/if}}
+    {{#let @taskInstance.error as |error|}}
+      {{#if (is-forbidden error)}}
+        <UnauthorizedTable />
+      {{else}}
+        <div class="navi-widget__content error-container">
+          <div>There was an error with your request{{if (is-empty error.details) "." ":"}}</div>
+          {{#each error.details as |errorDetail|}}
+            <div>{{errorDetail}}</div>
+          {{/each}}
+        </div>
+      {{/if}}
+    {{/let}}
   {{/if}}
 
   {{!-- Success --}}

--- a/packages/dashboards/tests/acceptance/dashboard-filter-test.js
+++ b/packages/dashboards/tests/acceptance/dashboard-filter-test.js
@@ -21,6 +21,8 @@ module('Acceptance | Dashboard Filters', function (hooks) {
   });
 
   test('dashboard filter flow', async function (assert) {
+    assert.expect(11);
+
     await visit('/dashboards/1/view');
 
     let dataRequests = [];
@@ -82,6 +84,16 @@ module('Acceptance | Dashboard Filters', function (hooks) {
 
     //test date filter
     await click('.dashboard-filters--expanded__add-filter-button');
+    await selectChoose('.dashboard-dimension-selector', 'Date Time');
+    await click('.dashboard-filters--expanded__add-filter-button');
+    selectChoose('.dashboard-dimension-selector', 'Date Time').catch((e) =>
+      assert.ok(
+        e.message.endsWith(`but "Date Time" didn't match any option`),
+        `"Date Time" is not available to select again`
+      )
+    );
+    //remove date filter, Date Time is again among options
+    await click(findAll('.filter-collection__remove')[1]);
     await selectChoose('.dashboard-dimension-selector', 'Date Time');
     await selectChoose(findAll('.dropdown-parameter-picker')[1], 'Day');
     await selectChoose(findAll('.filter-builder__operator-trigger')[1], 'In The Past');

--- a/packages/dashboards/tests/acceptance/dashboard-filter-test.js
+++ b/packages/dashboards/tests/acceptance/dashboard-filter-test.js
@@ -79,7 +79,20 @@ module('Acceptance | Dashboard Filters', function (hooks) {
       dataRequests.every((request) => request.queryParams.filters == 'platform|id-contains["win"]'),
       'each widget request has the right filters after one has been removed'
     );
+
+    //test date filter
+    await click('.dashboard-filters--expanded__add-filter-button');
+    await selectChoose('.dashboard-dimension-selector', 'Date Time');
+    await selectChoose(findAll('.dropdown-parameter-picker')[1], 'Day');
+    await selectChoose(findAll('.filter-builder__operator-trigger')[1], 'In The Past');
     dataRequests = [];
+    await fillIn('.filter-values--lookback-input__value', '7');
+
+    assert.ok(
+      dataRequests.every((request) => request.queryParams.dateTime === 'P7D/current'),
+      'each widget request has the right date filter'
+    );
+    assert.equal(dataRequests.length, 3, 'three data requests were made (one for each widget)');
 
     //test dashboard has the filter on save
     let dashboardBody = {};
@@ -95,7 +108,16 @@ module('Acceptance | Dashboard Filters', function (hooks) {
 
     assert.deepEqual(
       dashboardBody.data.attributes.filters,
-      [{ dimension: 'bardOne.platform', field: 'id', operator: 'contains', values: ['win'] }],
+      [
+        { type: 'dimension', dimension: 'bardOne.platform', field: 'id', operator: 'contains', values: ['win'] },
+        {
+          dimension: 'bardOne.network.dateTime',
+          field: 'day',
+          operator: 'bet',
+          type: 'timeDimension',
+          values: ['P7D', 'current'],
+        },
+      ],
       'Correct filters are saved with the dashboard'
     );
   });
@@ -127,7 +149,7 @@ module('Acceptance | Dashboard Filters', function (hooks) {
   });
 
   test('dashboard filter query params - ui changes update the model', async function (assert) {
-    assert.expect(12);
+    assert.expect(13);
 
     window.confirm = () => {
       assert.step('confirm called');
@@ -135,6 +157,11 @@ module('Acceptance | Dashboard Filters', function (hooks) {
     };
 
     const INITIAL_FILTERS = [
+      {
+        dimension: 'Date Time (Day)',
+        operator: 'in the past',
+        rawValues: ['7'],
+      },
       {
         dimension: 'Property (id)',
         operator: 'contains',
@@ -167,6 +194,7 @@ module('Acceptance | Dashboard Filters', function (hooks) {
 
     //Remove 3/4 of filters and change operator of remaining one
     await click('.dashboard-filters__expand-button');
+    await click('.filter-collection__remove');
     await click('.filter-collection__remove');
     await click('.filter-collection__remove');
     await click(findAll('.filter-collection__remove')[1]);
@@ -224,6 +252,12 @@ module('Acceptance | Dashboard Filters', function (hooks) {
         'property|id-contains["114","100001"],property|id-notin["1"],property|id-notin["2","3"]',
       ],
       'The requests are sent with the initial filters'
+    );
+
+    assert.deepEqual(
+      dataRequests.map((req) => req.queryParams.dateTime),
+      ['P7D/current', 'P7D/current'],
+      'The requests are sent with the initial date filters'
     );
   });
 
@@ -474,7 +508,7 @@ function extractCollapsedFilters() {
   return findAll('.filter-collection--collapsed-item').map((el) => ({
     dimension: el.querySelector('.filter-dimension--collapsed').textContent.trim(),
     operator: el.querySelector('.filter-operator--collapsed').textContent.trim(),
-    rawValues: [...el.querySelectorAll('.filter-values--collapsed--value')].map(
+    rawValues: [...el.querySelectorAll('.filter-values--collapsed')].map(
       (elm) => elm.textContent.trim().match(/\d+/)[0]
     ),
   }));

--- a/packages/dashboards/tests/acceptance/dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/dashboards-test.js
@@ -236,7 +236,7 @@ module('Acceptance | Dashboards', function (hooks) {
   });
 
   test('Collapsed filters render on load', async function (assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     await visit('/dashboards/1');
 
@@ -253,13 +253,16 @@ module('Acceptance | Dashboards', function (hooks) {
       el.textContent.replace(/\s+/g, ' ').trim()
     );
 
-    assert.equal(filters.length, 4, 'correct number of filters');
+    assert.equal(filters.length, 5, 'correct number of filters');
 
+    const firstFilter = filters.shift();
+
+    assert.ok(firstFilter.startsWith('Date Time (Day) in the past 7 days'), 'correct format of date filter');
     assert.ok(
       filters.every((filter) =>
         /^(Property|EventId) \(id\) (contains|not equals|equals) (.*?\d+.*?)( .*?\d+.*?)*$/.test(filter)
       ),
-      'correct format of filters'
+      'correct format of dimension filters'
     );
   });
 

--- a/packages/dashboards/tests/acceptance/mutli-datasource-dashboards-test.js
+++ b/packages/dashboards/tests/acceptance/mutli-datasource-dashboards-test.js
@@ -12,7 +12,7 @@ module('Acceptance | Multi datasource Dashboard', function (hooks) {
   setupMirage(hooks);
 
   test('Load multi-datasource dashboard', async function (assert) {
-    assert.expect(10);
+    assert.expect(13);
     await visit('/dashboards/6/view');
 
     assert.dom('.navi-widget__header').exists({ count: 3 }, 'Three widgets loaded');
@@ -22,29 +22,44 @@ module('Acceptance | Multi datasource Dashboard', function (hooks) {
 
     assert
       .dom('.filter-collection--collapsed')
-      .hasText('Age (id) equals 1 2 3 Container (id) not equals 1', 'Collapsed filter has the right text');
+      .containsText('Date Time (Day) in the past 7 days', 'Collapsed date dimension filter has the right text');
+
+    assert
+      .dom('.filter-collection--collapsed')
+      .containsText(
+        'Age (id) equals 1 2 3 Container (id) not equals 1',
+        'Collapsed dimension filters have the right text'
+      );
 
     await click('.dashboard-filters__toggle');
 
     assert
       .dom(findAll('.filter-builder__subject .name')[0])
-      .hasText('Age', 'Dimension 1 is properly labeled in filters');
+      .hasText('Date Time', 'Date Dimension is properly labeled in filters');
 
     assert
       .dom(findAll('.filter-builder__subject .chips')[0])
-      .hasText('id', 'Dimension 1 parameter is properly labeled in filters');
+      .hasText('Day', 'Date Dimension grain is properly labeled in filters');
 
     assert
       .dom(findAll('.filter-builder__subject .name')[1])
-      .hasText('Container', 'Dimension 2 is properly labeled in filters');
+      .hasText('Age', 'Dimension 1 is properly labeled in filters');
 
     assert
       .dom(findAll('.filter-builder__subject .chips')[1])
+      .hasText('id', 'Dimension 1 parameter is properly labeled in filters');
+
+    assert
+      .dom(findAll('.filter-builder__subject .name')[2])
+      .hasText('Container', 'Dimension 2 is properly labeled in filters');
+
+    assert
+      .dom(findAll('.filter-builder__subject .chips')[2])
       .hasText('id', 'Dimension 2 parameter is properly labeled in filters');
 
     assert.deepEqual(
       findAll('.filter-builder__operator-trigger').map((el) => el.textContent.trim()),
-      ['Equals', 'Not Equals'],
+      ['In The Past', 'Equals', 'Not Equals'],
       'Dimension filter operators are shown correctly'
     );
 
@@ -58,7 +73,7 @@ module('Acceptance | Multi datasource Dashboard', function (hooks) {
   });
 
   test('Create new multisource dashboard', async function (assert) {
-    assert.expect(8);
+    assert.expect(10);
 
     await visit('/dashboards/new');
     await click('.dashboard-header__add-widget-btn');
@@ -114,5 +129,22 @@ module('Acceptance | Multi datasource Dashboard', function (hooks) {
 
     await click('.navi-dashboard__save-button');
     assert.equal(currentURL(), '/dashboards/8/view', 'Dashboard saves without issue');
+
+    await click('.filter-collection__remove');
+    await click('.filter-collection__remove');
+
+    assert.deepEqual(
+      widgetsWithFilterWarning(),
+      [],
+      'Filters removed, no widget has a warning that filter does not apply'
+    );
+
+    //add date filter for first datasource
+    await selectChoose('.dashboard-dimension-selector', 'Date Time');
+    assert.deepEqual(
+      widgetsWithFilterWarning(),
+      ['Untitled Widget'],
+      'Widget with bardTwo datasource has a warning that filter does not apply'
+    );
   });
 });

--- a/packages/dashboards/tests/integration/components/dashboard-dimension-selector-test.js
+++ b/packages/dashboards/tests/integration/components/dashboard-dimension-selector-test.js
@@ -9,7 +9,7 @@ module('Integration | Component | dashboard dimension selector', function (hooks
   setupRenderingTest(hooks);
 
   test('it renders with right options', async function (assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     const dashboard = {
       widgets: Promise.resolve([
@@ -28,6 +28,9 @@ module('Integration | Component | dashboard dimension selector', function (hooks
                 dimensions: [
                   { id: 'dim1', name: 'dim1', category: 'cat1', metadataType: 'dimension' },
                   { id: 'dim2', name: 'dim2', category: 'cat2', metadataType: 'dimension' },
+                ],
+                timeDimensions: [
+                  { id: 'a.dateTime', name: 'Date Time', category: 'Date', metadataType: 'timeDimension' },
                 ],
               },
             },
@@ -49,6 +52,9 @@ module('Integration | Component | dashboard dimension selector', function (hooks
                 dimensions: [
                   { id: 'dim3', name: 'dim3', category: 'cat2', metadataType: 'dimension' },
                   { id: 'dim1', name: 'dim1', category: 'cat1', metadataType: 'dimension' },
+                ],
+                timeDimensions: [
+                  { id: 'b.dateTime', name: 'Date Time', category: 'Date', metadataType: 'timeDimension' },
                 ],
               },
             },
@@ -75,13 +81,29 @@ module('Integration | Component | dashboard dimension selector', function (hooks
 
     assert.deepEqual(
       structure(dropdown),
-      { cat1: ['dim1'], cat2: ['dim2', 'dim3'] },
+      { Date: ['Date Time', 'Date Time'], cat1: ['dim1'], cat2: ['dim2', 'dim3'] },
       'Correct select structure is shown'
     );
 
     assert.dom('.ember-power-select-placeholder').hasText('Dimension');
 
     await selectChoose('.ember-power-select-trigger', 'dim1');
+
+    this.set('changeme', function (selection) {
+      assert.deepEqual(
+        selection,
+        {
+          field: 'a.dateTime',
+          name: 'Date Time',
+          source: 'bardOne',
+          tables: ['a'],
+          type: 'timeDimension',
+        },
+        'Selection sends correct timeDimension object'
+      );
+    });
+
+    await selectChoose('.ember-power-select-trigger', 'Date Time');
   });
 
   test('it renders multi-datasource widgets with right options', async function (assert) {

--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021, Yahoo Holdings Inc.
+ * Copyright 2022, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Description: The fact adapter for the bard request v2 model.
@@ -245,15 +245,8 @@ export default class BardFactsAdapter extends EmberObject implements NaviFactAda
       );
     }
     const timeFilter = dateTimeFilters[0];
-    const filterGrain = timeFilter?.parameters?.grain as Grain;
-
     const timeColumn = request.columns.filter(isDateTime)[0];
     const columnGrain: GrainWithAll = (timeColumn?.parameters?.grain as Grain | undefined) ?? 'all';
-    if (timeColumn && columnGrain !== 'all' && columnGrain !== filterGrain) {
-      throw new FactAdapterError(
-        `The requested filter timeGrain '${filterGrain}', must match the column timeGrain '${columnGrain}'`
-      );
-    }
     const filterValues = buildTimeDimensionFilterValues(timeFilter, request.dataSource, true, true, columnGrain);
     if (timeFilter.operator === 'intervals') {
       return filterValues.join(',');

--- a/packages/data/addon/gql/schema.graphql
+++ b/packages/data/addon/gql/schema.graphql
@@ -845,6 +845,7 @@ input columnInput {
 }
 
 type dashboardFilter {
+  type: ColumnarType
   dimension: String
   field: String
   operator: String
@@ -852,6 +853,7 @@ type dashboardFilter {
 }
 
 input dashboardFilterInput {
+  type: ColumnarType
   dimension: String
   field: String
   operator: String

--- a/packages/data/tests/unit/adapters/facts/bard-test.ts
+++ b/packages/data/tests/unit/adapters/facts/bard-test.ts
@@ -246,7 +246,7 @@ module('Unit | Adapter | facts/bard', function (hooks) {
   });
 
   test('_buildDateTimeParam', function (assert) {
-    assert.expect(12);
+    assert.expect(11);
 
     let singleInterval: RequestV2 = {
       ...EmptyRequest,
@@ -265,33 +265,6 @@ module('Unit | Adapter | facts/bard', function (hooks) {
       Adapter._buildDateTimeParam(singleInterval),
       '2021-02-13T00:00:00.000/2021-04-13T00:00:00.000',
       '_buildDateTimeParam built the correct string for a single interval'
-    );
-
-    let differentColumnAndFilterGrain: RequestV2 = {
-      ...EmptyRequest,
-      columns: [
-        {
-          type: 'timeDimension',
-          field: '.dateTime',
-          parameters: { grain: 'day' },
-        },
-      ],
-      filters: [
-        {
-          type: 'timeDimension',
-          field: '.dateTime',
-          parameters: { grain: 'week' },
-          operator: 'bet',
-          values: [],
-        },
-      ],
-    };
-    assert.throws(
-      () => {
-        Adapter._buildDateTimeParam(differentColumnAndFilterGrain);
-      },
-      /The requested filter timeGrain 'week', must match the column timeGrain 'day'/,
-      '_buildDateTimeParam throws an error for different timeGrains requested'
     );
 
     let noIntervals: RequestV2 = { ...EmptyRequest };

--- a/packages/reports/addon/components/filter-builders/time-dimension.ts
+++ b/packages/reports/addon/components/filter-builders/time-dimension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2022, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { A as arr } from '@ember/array';
@@ -54,6 +54,27 @@ export function intervalPeriodForGrain(grain: Grain): DateGrain {
 }
 
 type FilterLike = Pick<FilterFragment, 'values' | 'parameters' | 'operator'>;
+
+export function findDefaultOperator(type: string): FilterFragment['operator'] {
+  type = type?.toLowerCase();
+  const opDictionary: Record<string, FilterFragment['operator']> = {
+    time: 'gte',
+    date: 'bet',
+    datetime: 'bet',
+    number: 'eq',
+    default: 'in',
+  };
+
+  return opDictionary[type] || opDictionary.default;
+}
+
+export function getDefaultValuesForTimeFilter(filter: FilterLike): TimeFilterValues {
+  const isTime = ['hour', 'minute', 'second'].includes(`${filter.parameters.grain}`);
+  if (isTime) {
+    return valuesForOperator(filter, 'day', OPERATORS.dateRange);
+  }
+  return valuesForOperator(filter, filter.parameters.grain as Grain, OPERATORS.lookback);
+}
 
 /**
  * Converts an Interval to a format suitable to the newOperator while retaining as much information as possible

--- a/packages/reports/addon/components/filter-values/dimension-select.hbs
+++ b/packages/reports/addon/components/filter-values/dimension-select.hbs
@@ -1,10 +1,10 @@
-{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2022, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#if @isCollapsed}}
   {{#if @filter.validations.attrs.values.isInvalid}}
     <FilterValues::InvalidValue/>
   {{else}}
     {{#each (await this.selectedDimensions) as |dim|}}
-      <span class="filter-values--collapsed--value">{{dim.model.displayValue}}</span>
+      <span ...attributes>{{dim.model.displayValue}}</span>
     {{/each}}
   {{/if}}
 {{else}}

--- a/packages/reports/addon/components/filter-values/multi-value-input.hbs
+++ b/packages/reports/addon/components/filter-values/multi-value-input.hbs
@@ -1,10 +1,10 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.--}}
+{{!-- Copyright 2022, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.--}}
 {{#if @isCollapsed}}
   {{#if @filter.validations.isInvalid}}
     <FilterValues::InvalidValue/>
   {{else}}
     {{#each @filter.values as |value|}}
-      <span class="filter-values--collapsed--value">{{value}}</span>
+      <span ...attributes>{{value}}</span>
     {{/each}}
   {{/if}}
 {{else}}

--- a/packages/reports/addon/components/filter-values/range-input.hbs
+++ b/packages/reports/addon/components/filter-values/range-input.hbs
@@ -1,9 +1,9 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2022, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#if @isCollapsed}}
   {{#if @filter.validations.attrs.values.isInvalid}}
     <FilterValues::InvalidValue/>
   {{else}}
-    {{concat @filter.values.[0] " and " @filter.values.[1]}}
+    <span ...attributes>{{concat @filter.values.[0] " and " @filter.values.[1]}}</span>
   {{/if}}
 {{else}}
   <div class="filter-values--range-input row" ...attributes>

--- a/packages/reports/addon/components/filter-values/time-dimension/advanced.hbs
+++ b/packages/reports/addon/components/filter-values/time-dimension/advanced.hbs
@@ -1,7 +1,7 @@
 {{!-- Copyright 2022, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#if @isCollapsed}}
   {{#if this.interval}}
-    {{this.dateRange}}
+    <span ...attributes>{{this.dateRange}}</span>
   {{else}}
     <FilterValues::InvalidValue />
   {{/if}}

--- a/packages/reports/addon/components/filter-values/time-dimension/current.hbs
+++ b/packages/reports/addon/components/filter-values/time-dimension/current.hbs
@@ -1,7 +1,7 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2022, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#if @isCollapsed}}
   {{#if this.interval}}
-    {{this.dateRange}}
+    <span ...attributes>{{this.dateRange}}</span>
   {{else}}
     <FilterValues::InvalidValue/>
   {{/if}}

--- a/packages/reports/addon/components/filter-values/time-dimension/date.hbs
+++ b/packages/reports/addon/components/filter-values/time-dimension/date.hbs
@@ -1,7 +1,7 @@
-{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2022, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#if @isCollapsed}}
   {{#if this.date}}
-    {{moment-format this.date this.calendarTriggerFormat}}
+    <span ...attributes>{{moment-format this.date this.calendarTriggerFormat}}</span>
   {{else}}
     <FilterValues::InvalidValue/>
   {{/if}}
@@ -13,12 +13,12 @@
       @onUpdate={{this.setDate}}
       class="filter-values--date-input__trigger"
     >
-      <DenaliInput 
+      <DenaliInput
         @size="medium"
         @iconBack="calendar-event"
         @iconBackClass="is-brand-300"
         value={{if this.date (moment-format this.date this.calendarTriggerFormat)}}
-        readonly={{true}} 
+        readonly={{true}}
         placeholder="Select Date"
       />
     </DropdownDatePicker>

--- a/packages/reports/addon/components/filter-values/time-dimension/lookback.hbs
+++ b/packages/reports/addon/components/filter-values/time-dimension/lookback.hbs
@@ -1,7 +1,7 @@
-{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2022, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#if @isCollapsed}}
   {{#if this.lookback}}
-    {{this.lookback}} {{this.dateDescription}}
+    <span ...attributes>{{this.lookback}} {{this.dateDescription}}</span>
   {{else}}
     <FilterValues::InvalidValue/>
   {{/if}}
@@ -17,8 +17,8 @@
       @triggerClass="filter-values--lookback-trigger is-medium"
       @dropdownClass="filter-values--lookback-dropdown"
       @triggerComponent="filter-values/time-dimension/lookback-trigger"
-      @extra={{hash 
-        value=this.lookback 
+      @extra={{hash
+        value=this.lookback
         onUpdate=this.setLookback
         placeholder=(capitalize (concat this.grain "s"))
       }}

--- a/packages/reports/addon/components/filter-values/time-dimension/range.hbs
+++ b/packages/reports/addon/components/filter-values/time-dimension/range.hbs
@@ -1,7 +1,7 @@
-{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2022, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#if @isCollapsed}}
   {{#if (and this.startDate this.endDate)}}
-    {{this.dateRange}}
+    <span ...attributes>{{this.dateRange}}</span>
   {{else}}
     <FilterValues::InvalidValue/>
   {{/if}}

--- a/packages/reports/addon/components/filter-values/value-input.hbs
+++ b/packages/reports/addon/components/filter-values/value-input.hbs
@@ -1,9 +1,9 @@
-{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2022, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{#if @isCollapsed}}
   {{#if @filter.validations.attrs.values.isInvalid}}
     <FilterValues::InvalidValue/>
   {{else}}
-    {{this.value}}
+    <span ...attributes>{{this.value}}</span>
   {{/if}}
 {{else}}
   <DenaliInput

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/DashboardFilter.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/fragments/request/DashboardFilter.kt
@@ -1,12 +1,15 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2022, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 package com.yahoo.navi.ws.models.beans.fragments.request
+
+import com.yahoo.navi.ws.models.beans.enums.ColumnarType
 
 data class DashboardFilter(
     var dimension: String = "",
     var operator: String = "",
     var values: List<String> = emptyList(),
-    var field: String = ""
+    var field: String = "",
+    var type: ColumnarType? = null,
 )


### PR DESCRIPTION
## Description

Add global date filters to dashboards

## Proposed Changes

- Include `timeDimension`s  in the dimension selector (**desirable TODO: Consolidate date dimensions of multiple datasources/tables into one option** while applying correctly to each request)
- Set default operator and filter values according to filter type
- Add filter type to dash filter model, serialize `grain` as `field` for `timeDimension`s
- Parse correctly elide datasources with namespace (`elide.namespace`)
- **Remove fact adapter error when grains don't match and let ws return errors**
- Display request errors in widgets

## Screenshots

![Jan-26-2022 22-49-40](https://user-images.githubusercontent.com/13946669/151306603-b2076e60-8948-4cee-a753-337adf3009a3.gif)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
