### PR TITLE
Fix: Don't load search valueSourceType NONE dims

### DIFF
--- a/packages/data/addon/models/metadata/dimension.ts
+++ b/packages/data/addon/models/metadata/dimension.ts
@@ -6,6 +6,7 @@ import ColumnMetadataModel from 'navi-data/models/metadata/column';
 import type { ColumnInstance, ColumnMetadataPayload, ColumnType } from 'navi-data/models/metadata/column';
 import type { Cardinality } from '../../utils/enums/cardinality-sizes';
 import type { Parameters } from 'navi-data/adapters/facts/interface';
+import { ValueSourceType } from './elide/dimension';
 
 interface Field {
   name: string;
@@ -25,7 +26,7 @@ export interface DimensionMetadataPayload extends ColumnMetadataPayload {
   tableSource?: TableSource;
   fields?: Field[];
   cardinality?: Cardinality;
-  storageStrategy?: TODO<'loaded' | 'none' | null>;
+  valueSourceType: ValueSourceType;
 }
 
 export type DimensionColumn = ColumnInstance<DimensionMetadataModel>;
@@ -66,7 +67,7 @@ export default class DimensionMetadataModel extends ColumnMetadataModel {
 
   declare tableSource?: TableSource;
 
-  declare storageStrategy?: TODO<'loaded' | 'none' | null>;
+  declare valueSourceType: ValueSourceType;
 
   /**
    * Fetches tags for a given field name

--- a/packages/data/addon/models/metadata/elide/dimension.ts
+++ b/packages/data/addon/models/metadata/elide/dimension.ts
@@ -24,7 +24,6 @@ export default class ElideDimensionMetadataModel extends DimensionMetadataModel 
     }
   }
 
-  declare valueSourceType: ValueSourceType;
   declare values: string[];
 
   get valueSource(): ElideDimensionMetadataModel {

--- a/packages/data/addon/serializers/metadata/bard.ts
+++ b/packages/data/addon/serializers/metadata/bard.ts
@@ -56,7 +56,7 @@ type RawColumnPayload = {
 
 export type RawDimensionPayload = RawColumnPayload & {
   datatype?: 'text' | 'number' | 'date' | 'dateTime' | 'url';
-  storageStrategy?: TODO<'loaded' | 'none'>;
+  storageStrategy?: 'loaded' | 'none';
   cardinality: number;
   fields: RawDimensionField[];
 };
@@ -398,6 +398,7 @@ export default class BardMetadataSerializer extends NaviMetadataSerializer {
       isSortable: true,
       type: 'field',
       valueType: 'date',
+      valueSourceType: ValueSourceType.NONE,
       supportedGrains: timeGrainInfo.timeGrains.map(({ name }) => ({
         id: name,
         expression: '',
@@ -619,7 +620,7 @@ export default class BardMetadataSerializer extends NaviMetadataSerializer {
           suggestionColumns: fields?.map((field) => ({ id: name, parameters: { field: field.name } })),
         },
         cardinality: dimCardinality,
-        storageStrategy: storageStrategy || null,
+        valueSourceType: storageStrategy === 'none' ? ValueSourceType.NONE : ValueSourceType.TABLE,
         source: dataSourceName,
         partialData: isNone(description),
       };

--- a/packages/data/addon/serializers/metadata/elide.ts
+++ b/packages/data/addon/serializers/metadata/elide.ts
@@ -314,6 +314,7 @@ export default class ElideMetadataSerializer extends NaviMetadataSerializer {
         isSortable: true,
         type: node.columnType,
         expression: node.expression,
+        valueSourceType: node.valueSourceType,
       };
       return {
         timeDimension: this.createTimeDimensionModel(timeDimensionPayload),

--- a/packages/data/tests/unit/models/metadata/dimension-test.ts
+++ b/packages/data/tests/unit/models/metadata/dimension-test.ts
@@ -6,6 +6,7 @@ import { TestContext } from 'ember-test-helpers';
 //@ts-ignore
 import metadataRoutes from 'navi-data/test-support/helpers/metadata-routes';
 import { Factory } from 'navi-data/models/native-with-create';
+import { ValueSourceType } from 'navi-data/models/metadata/elide/dimension';
 
 let Payload: DimensionMetadataPayload,
   Dimension: DimensionMetadataModel,
@@ -23,7 +24,7 @@ module('Unit | Metadata Model | Dimension', function (hooks) {
       valueType: 'text',
       isSortable: false,
       type: 'field',
-      storageStrategy: null,
+      valueSourceType: ValueSourceType.TABLE,
       fields: [
         {
           name: 'id',

--- a/packages/data/tests/unit/serializers/metadata/bard-test.ts
+++ b/packages/data/tests/unit/serializers/metadata/bard-test.ts
@@ -372,6 +372,7 @@ const Payload: RawEverythingPayload = {
                   longName: 'Foo',
                 },
               ],
+              storageStrategy: 'none',
             },
             {
               category: 'dateCategory',
@@ -442,7 +443,7 @@ const DimensionsPayloads: DimensionMetadataPayload[] = [
     type: 'field',
     valueType: 'text',
     isSortable: false,
-    storageStrategy: null,
+    valueSourceType: ValueSourceType.TABLE,
     partialData: true,
     fields: [
       {
@@ -484,7 +485,7 @@ const DimensionsPayloads: DimensionMetadataPayload[] = [
     tableSource: {
       suggestionColumns: [{ id: 'dimensionTwo', parameters: { field: 'foo' } }],
     },
-    storageStrategy: null,
+    valueSourceType: ValueSourceType.NONE,
     partialData: true,
   },
 ];
@@ -511,7 +512,7 @@ const TimeDimensionPayloads: TimeDimensionMetadataPayload[] = [
     },
     isSortable: true,
     valueType: 'dateTime',
-    storageStrategy: null,
+    valueSourceType: ValueSourceType.TABLE,
     partialData: true,
     supportedGrains: [
       {
@@ -547,6 +548,7 @@ const TimeDimensionPayloads: TimeDimensionMetadataPayload[] = [
     type: 'field',
     isSortable: true,
     valueType: 'date',
+    valueSourceType: ValueSourceType.NONE,
   },
   {
     category: 'Date',
@@ -573,6 +575,7 @@ const TimeDimensionPayloads: TimeDimensionMetadataPayload[] = [
     type: 'field',
     isSortable: true,
     valueType: 'date',
+    valueSourceType: ValueSourceType.NONE,
   },
 ];
 
@@ -1076,7 +1079,7 @@ module('Unit | Serializer | metadata/bard', function (hooks) {
       cardinality: 'SMALL',
       type: 'field',
       isSortable: false,
-      storageStrategy: null,
+      valueSourceType: ValueSourceType.TABLE,
       fields: rawDimension.fields,
       tableSource: {
         suggestionColumns: rawDimension.fields.map((f) => ({ id: rawDimension.name, parameters: { field: f.name } })),

--- a/packages/data/tests/unit/serializers/metadata/elide-test.ts
+++ b/packages/data/tests/unit/serializers/metadata/elide-test.ts
@@ -439,6 +439,7 @@ module('Unit | Serializer | metadata/elide', function (hooks) {
         timeZone: 'UTC',
         source: 'bardOne',
         tableId: 'tableA',
+        valueSourceType: ValueSourceType.NONE,
         columnFunctionId: 'normalizer-generated:timeGrain(column=tableA.td1;grains=day,week)',
       },
     ];
@@ -900,6 +901,7 @@ module('Unit | Serializer | metadata/elide', function (hooks) {
           type: 'field',
           isSortable: true,
           expression: '',
+          valueSourceType: ValueSourceType.NONE,
           columnFunctionId: 'normalizer-generated:timeGrain(column=userSignupDate;grains=day,month,week)',
         },
         columnFunction: {
@@ -952,6 +954,7 @@ module('Unit | Serializer | metadata/elide', function (hooks) {
           type: 'field',
           isSortable: true,
           expression: '',
+          valueSourceType: ValueSourceType.NONE,
           columnFunctionId: 'normalizer-generated:timeGrain(column=orderMonth;grains=month)',
         },
         columnFunction: {

--- a/packages/reports/addon/components/filter-builders/dimension.ts
+++ b/packages/reports/addon/components/filter-builders/dimension.ts
@@ -5,6 +5,7 @@
 import BaseFilterBuilderComponent, { FilterValueBuilder } from './base';
 import DimensionMetadataModel from 'navi-data/models/metadata/dimension';
 import { assert } from '@ember/debug';
+import { ValueSourceType } from 'navi-data/models/metadata/elide/dimension';
 
 export const OPERATORS = <const>{
   in: 'in',
@@ -15,12 +16,12 @@ export const OPERATORS = <const>{
 };
 type InternalOperatorType = typeof OPERATORS[keyof typeof OPERATORS];
 
-interface InteralFilterBuilderOperators extends FilterValueBuilder {
+interface InternalFilterBuilderOperators extends FilterValueBuilder {
   internalId: InternalOperatorType;
 }
 
 export default class DimensionFilterBuilderComponent extends BaseFilterBuilderComponent {
-  get selectedValueBuilder(): InteralFilterBuilderOperators {
+  get selectedValueBuilder(): InternalFilterBuilderOperators {
     const { operator, values } = this.args.filter;
 
     let builder;
@@ -37,12 +38,12 @@ export default class DimensionFilterBuilderComponent extends BaseFilterBuilderCo
     return builder;
   }
 
-  get valueBuilders(): InteralFilterBuilderOperators[] {
-    const storageStrategy = (this.args.filter.columnMetadata as DimensionMetadataModel).storageStrategy;
+  get valueBuilders(): InternalFilterBuilderOperators[] {
+    const { valueSourceType } = this.args.filter.columnMetadata as DimensionMetadataModel;
 
-    //Allow free form input of dimension values when dimension's storageStrategy is 'none'
+    //Allow free form input of dimension values when dimension source type is NONE
     const inputComponent =
-      storageStrategy === 'none' ? 'filter-values/multi-value-input' : 'filter-values/dimension-select';
+      valueSourceType === ValueSourceType.NONE ? 'filter-values/multi-value-input' : 'filter-values/dimension-select';
 
     return [
       { internalId: OPERATORS.in, operator: 'in' as const, name: 'Equals', component: inputComponent },


### PR DESCRIPTION

## Description

Fix: Don't load search valueSourceType NONE dims

## Proposed Changes

- Conform dimension metadata to use `valueSourceType` and remove `storageStrategy`
-  Don't search dimension values when `valueSourceType` is `NONE`

## Screenshots

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
