### PR TITLE
Fix: Update start or end when they become invalid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "navi",
       "version": "0.4.0",
       "hasInstallScript": true,
       "license": "MIT",

--- a/packages/reports/addon/components/filter-values/time-dimension/range.ts
+++ b/packages/reports/addon/components/filter-values/time-dimension/range.ts
@@ -18,7 +18,12 @@ export default class DimensionDateRange extends BaseIntervalComponent {
    */
   @action
   setTimeStartMoment(start: Moment) {
-    this.setTimeStart(start.toISOString());
+    // if the start date is after the end date, set the end date to the start date
+    if (start.isAfter(this.endDate)) {
+      this.setTimeValues([start.toISOString(), start.toISOString()]);
+    } else {
+      this.setTimeStart(start.toISOString());
+    }
   }
 
   /**
@@ -26,6 +31,11 @@ export default class DimensionDateRange extends BaseIntervalComponent {
    */
   @action
   setTimeEndMoment(end: Moment) {
-    this.setTimeEnd(end.toISOString());
+    // if the end date is before the start date, set the start date to the end date
+    if (end.isBefore(this.startDate)) {
+      this.setTimeValues([end.toISOString(), end.toISOString()]);
+    } else {
+      this.setTimeEnd(end.toISOString());
+    }
   }
 }

--- a/packages/reports/tests/integration/components/filter-values/time-dimension/range-test.ts
+++ b/packages/reports/tests/integration/components/filter-values/time-dimension/range-test.ts
@@ -94,6 +94,30 @@ module('Integration | Component | filter-values/time-dimension/range', function 
     await click(`.ember-power-calendar-day[data-date="${newEndStr}"]`);
   });
 
+  test('changing values - invalid range', async function (this: TestContext, assert) {
+    this.filter.values = ['2022-01-20', '2022-01-26'];
+    await render(TEMPLATE);
+
+    // Click start date
+    const newStartStr = '2022-01-27';
+    this.set('onUpdateFilter', ({ values }: Partial<FilterFragment>) => {
+      const newDate = `${newStartStr}T00:00:00.000Z`;
+      assert.deepEqual(values, [newDate, newDate], 'The end date is updated if it is before the new start date');
+      this.set('filter.values', values);
+    });
+    await click('.filter-values--date-range-input__low-value.dropdown-date-picker__trigger');
+    await click(`.ember-power-calendar-day[data-date="${newStartStr}"]`);
+
+    // Click end date
+    const newEndStr = '2022-01-12';
+    this.set('onUpdateFilter', ({ values }: Partial<FilterFragment>) => {
+      const newDate = `${newEndStr}T00:00:00.000Z`;
+      assert.deepEqual(values, [newDate, newDate], 'The start date is updated if it is after the new end date');
+    });
+    await click('.filter-values--date-range-input__high-value.dropdown-date-picker__trigger');
+    await click(`.ember-power-calendar-day[data-date="${newEndStr}"]`);
+  });
+
   test('collapsed', async function (this: TestContext, assert) {
     assert.expect(2);
 


### PR DESCRIPTION
## Description
When updating the start past the end or the end before the start, update both so the interval stays valid

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
