### PR TITLE
Fix: Sorts removed when params are changed.

### DIFF
--- a/packages/reports/addon/consumers/request/sort.ts
+++ b/packages/reports/addon/consumers/request/sort.ts
@@ -109,8 +109,13 @@ export default class SortConsumer extends ActionConsumer {
       route: Route,
       columnFragment: ColumnFragment
     ) {
-      const { columnMetadata, parameters } = columnFragment;
-      this.onRemoveColumn(route, columnMetadata, parameters);
+      const { routeName } = route;
+      const { request } = route.modelFor(routeName) as ReportModel;
+      const { columnMetadata } = columnFragment;
+
+      request.sorts
+        .filter((sort) => sort.columnMetadata === columnMetadata)
+        .forEach((sort) => request.removeSort(sort));
     },
   };
 }

--- a/packages/reports/tests/unit/consumers/request/sort-test.ts
+++ b/packages/reports/tests/unit/consumers/request/sort-test.ts
@@ -22,6 +22,12 @@ const metric = {
   parameters: {},
   source: 'bardOne',
 };
+const metricWithParam = {
+  type: 'metric',
+  field: 'revenue',
+  parameters: { currency: 'USD' },
+  source: 'bardOne',
+};
 const dimension = {
   type: 'dimension',
   field: 'age',
@@ -131,5 +137,27 @@ module('Unit | Consumer | request sort', function (hooks) {
     Consumer.send(RequestActions.REMOVE_COLUMN_FRAGMENT, route, first);
 
     assert.deepEqual(getSorts(request), {}, 'The sorts are removed');
+  });
+
+  test('UPDATE_COLUMN_FRAGMENT_WITH_PARAMS', function (assert) {
+    const request: RequestFragment = Store.createFragment('request', {
+      table: 'network',
+      limit: null,
+      dataSource: 'bardOne',
+      requestVersion: '2.0',
+      columns: [metricWithParam],
+      filters: [],
+      sorts: [{ ...metricWithParam, direction: 'desc' }],
+    });
+
+    assert.deepEqual(getSorts(request), { 'revenue(currency=USD)': 'desc' }, 'The existing sort is correct');
+
+    const route = routeFor(request);
+
+    const first = request.columns.firstObject as ColumnFragment;
+    first.parameters.currency = 'CAD';
+    Consumer.send(RequestActions.UPDATE_COLUMN_FRAGMENT_WITH_PARAMS, route, first);
+
+    assert.deepEqual(getSorts(request), {}, 'The sorts are removed with matching base metric');
   });
 });

--- a/packages/reports/tests/unit/consumers/request/sort-test.ts
+++ b/packages/reports/tests/unit/consumers/request/sort-test.ts
@@ -140,6 +140,7 @@ module('Unit | Consumer | request sort', function (hooks) {
   });
 
   test('UPDATE_COLUMN_FRAGMENT_WITH_PARAMS', function (assert) {
+    const revenueWithDiffParam = { ...metricWithParam, parameters: { currency: 'GBP' } };
     const request: RequestFragment = Store.createFragment('request', {
       table: 'network',
       limit: null,
@@ -147,10 +148,22 @@ module('Unit | Consumer | request sort', function (hooks) {
       requestVersion: '2.0',
       columns: [metricWithParam],
       filters: [],
-      sorts: [{ ...metricWithParam, direction: 'desc' }],
+      sorts: [
+        { ...metricWithParam, direction: 'desc' },
+        { ...revenueWithDiffParam, direction: 'asc' },
+        { ...metric, direction: 'desc' },
+      ],
     });
 
-    assert.deepEqual(getSorts(request), { 'revenue(currency=USD)': 'desc' }, 'The existing sort is correct');
+    assert.deepEqual(
+      getSorts(request),
+      {
+        adClicks: 'desc',
+        'revenue(currency=GBP)': 'asc',
+        'revenue(currency=USD)': 'desc',
+      },
+      'The existing sort is correct'
+    );
 
     const route = routeFor(request);
 
@@ -158,6 +171,6 @@ module('Unit | Consumer | request sort', function (hooks) {
     first.parameters.currency = 'CAD';
     Consumer.send(RequestActions.UPDATE_COLUMN_FRAGMENT_WITH_PARAMS, route, first);
 
-    assert.deepEqual(getSorts(request), {}, 'The sorts are removed with matching base metric');
+    assert.deepEqual(getSorts(request), { adClicks: 'desc' }, 'The sorts are removed with matching base metric');
   });
 });


### PR DESCRIPTION
## Description

The original intent was sorts matching the base metric would be removed after a parameter is changed. However that behavior was lost as removal functions became more strict matching parameters. Causing invalid requests.

## Proposed Changes

- Change back to original intent where changing a parameter will remove all base metrics from sort.
- Future update will make this a bit better as we can map the sort to the intended column and update the sort instead of removing it.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
