### PR TITLE
Fix: Add category order to vis service

### DIFF
--- a/packages/core/addon/services/visualization.ts
+++ b/packages/core/addon/services/visualization.ts
@@ -14,6 +14,7 @@ import { getOwner, setOwner } from '@ember/application';
 import { YavinVisualizationManifest } from 'navi-core/visualization/manifest';
 import NaviVisualizationConfigWrapper from 'navi-core/components/navi-visualization-config/wrapper';
 import NaviVisualizationWrapper from 'navi-core/components/navi-visualizations/wrapper';
+import { sortBy } from 'lodash-es';
 import type RequestFragment from 'navi-core/models/request';
 import type NaviVisualizationBaseManifest from 'navi-core/navi-visualization-manifests/base';
 import type { TypedVisualizationFragment } from 'navi-core/models/visualization';
@@ -95,6 +96,7 @@ class CompatManifest extends YavinVisualizationManifest {
 export default class YavinVisualizationsService extends Service {
   private registry: Map<string, Map<string, YavinVisualizationManifest<unknown>>> = new Map();
   private defaultCategory = 'Standard';
+  private categoryOrder = [this.defaultCategory];
 
   private owner = getOwner(this);
 
@@ -120,7 +122,7 @@ export default class YavinVisualizationsService extends Service {
   defaultVisualization(): YavinVisualizationManifest {
     const typeName = 'yavin:table';
     const visualization = this.getVisualization(typeName);
-    assert('Cannot find configured default visualization: ${typeName}', visualization);
+    assert(`Cannot find configured default visualization: ${typeName}`, visualization);
     return visualization;
   }
 
@@ -149,7 +151,13 @@ export default class YavinVisualizationsService extends Service {
   }
 
   getCategories(): string[] {
-    return [...this.registry.keys()];
+    const categories = [...this.registry.keys()];
+    const categoryOrdering = Object.fromEntries(this.categoryOrder.map((g, i) => [g, i]));
+    return sortBy(categories, (category) => categoryOrdering[category]);
+  }
+
+  setCategoryOrder(categoryOrder: string[]): void {
+    this.categoryOrder = categoryOrder;
   }
 
   getAllVisualizations(): YavinVisualizationManifest[] {

--- a/packages/core/tests/unit/services/visualization-test.ts
+++ b/packages/core/tests/unit/services/visualization-test.ts
@@ -97,4 +97,24 @@ module('Unit | Service | visualization', function (hooks) {
       'it succesfully rebuilds config and removes invalid settings'
     );
   });
+
+  test('categoryOrder', async function (assert) {
+    const table = Service.getVisualization('yavin:table');
+    Service.registerVisualization(table, 'Four');
+    Service.registerVisualization(table, 'Two');
+    Service.registerVisualization(table, 'Three');
+    Service.registerVisualization(table, 'One');
+
+    assert.deepEqual(
+      Service.getCategories(),
+      ['Standard', 'Four', 'Two', 'Three', 'One'],
+      'All registered categories show up in the order they were registered in'
+    );
+    Service.setCategoryOrder(['One', 'Standard', 'Four']);
+    assert.deepEqual(
+      Service.getCategories(),
+      ['One', 'Standard', 'Four', 'Two', 'Three'],
+      'The categories are sorted by the registered order first with the rest at the end'
+    );
+  });
 });

--- a/packages/reports/addon/components/visualization-toggle.hbs
+++ b/packages/reports/addon/components/visualization-toggle.hbs
@@ -7,7 +7,7 @@
 >
   <div class="flex align-items-center">
     <PowerSelect
-      @options={{keys this.categoryToVisualizations}}
+      @options={{this.categories}}
       @selected={{this.selectedCategory}}
       @searchEnabled={{false}}
       @onChange={{this.selectCategory}}

--- a/packages/reports/addon/components/visualization-toggle.ts
+++ b/packages/reports/addon/components/visualization-toggle.ts
@@ -60,7 +60,7 @@ export default class VisualizationToggle extends Component<Args> {
   }
 
   get categories() {
-    return this.visualization.getCategories().sort();
+    return this.visualization.getCategories();
   }
 
   get categoryToVisualizations() {


### PR DESCRIPTION
## Description
Adds a category order to the visualization service

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
