### PR TITLE
Fix: Delete action that destroys the component blows up

### DIFF
--- a/packages/reports/addon/components/common-actions/delete.hbs
+++ b/packages/reports/addon/components/common-actions/delete.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2022, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 {{yield (fn (toggle "showModal" this))}}
 <DenaliModal
   class="delete__modal"
@@ -10,7 +10,7 @@
     <h3 class="delete__modal-header m-b-10">Are You Sure?</h3>
     <p class="delete__modal-details m-b-20">This action cannot be undone. This will permanently delete the <span class="is-bold">{{@model.title}}</span> {{this.modelName}}.</p>
     {{#if this.isDeleting}}
-      <NaviLoadingMessage>
+      <NaviLoadingMessage class="m-b-20">
         Deleting {{classify this.modelName}}
       </NaviLoadingMessage>
     {{/if}}
@@ -18,7 +18,7 @@
       class="delete__modal-delete-btn m-r-5"
       @style="danger"
       disabled={{this.isDeleting}}
-      {{on "click" (pipe (toggle "isDeleting" this) (fn @deleteAction @model) (toggle "isDeleting" this))}}
+      {{on "click" (pipe (fn (mut this.isDeleting) true) (fn @deleteAction @model) (fn (mut this.isDeleting) false))}}
     >
       Delete
     </DenaliButton>

--- a/packages/reports/addon/components/common-actions/delete.ts
+++ b/packages/reports/addon/components/common-actions/delete.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021, Yahoo Holdings Inc.
+ * Copyright 2022, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -9,7 +9,7 @@ import Model from '@ember-data/model';
 
 interface Args {
   model: Model;
-  deleteAction: () => void;
+  deleteAction: (model: Model) => void | Promise<void>;
 }
 
 export default class DeleteActionComponent extends Component<Args> {

--- a/packages/reports/tests/integration/components/common-actions/delete-test.js
+++ b/packages/reports/tests/integration/components/common-actions/delete-test.js
@@ -69,4 +69,38 @@ module('Integration | Component | common actions/delete', function (hooks) {
     await click('.delete-button');
     await click('.delete__modal-delete-btn');
   });
+
+  test('delete action that destroys the component', async function (assert) {
+    assert.expect(1);
+
+    Template = hbs`
+      {{#unless this.widget.isDeleted}}
+        <CommonActions::Delete
+          class="delete"
+          @model={{this.widget}}
+          @deleteAction={{this.deleteWidget}}
+          as |onDelete|
+        >
+          <DenaliButton
+            @style="text"
+            @size="medium"
+            class="delete-button"
+            {{on "click" onDelete}}
+          >
+            Delete
+          </DenaliButton>
+        </CommonActions::Delete>
+      {{/unless}}
+    `;
+
+    this.set('deleteWidget', (widget) => {
+      widget.isDeleted = true;
+      return new Promise((resolve) => setTimeout(resolve, 200));
+    });
+
+    await render(Template);
+    await click('.delete-button');
+    await click('.delete__modal-delete-btn');
+    assert.ok(true, 'no error is thrown');
+  });
 });


### PR DESCRIPTION
Change `toggle` helper to `mut`.
`toggle` uses `set`. If `deleteAction` causes the component to be destroyed, an `Assertion Failed: calling set on destroyed object: [object Object].isDeleting = false` error is thrown. (we update `isDeleting` to false once `deleteAction` resolves).
the added test would've thrown when using `toggle`.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
