### PR TITLE
Fix: Advanced datetime filter builder bugs.

### DIFF
--- a/packages/reports/addon/components/filter-builders/time-dimension.ts
+++ b/packages/reports/addon/components/filter-builders/time-dimension.ts
@@ -176,8 +176,6 @@ export function internalOperatorForValues(filter: FilterLike): InternalOperatorT
     end === 'current'
   ) {
     internalId = OPERATORS.lookback;
-  } else if (moment.isMoment(interval['_start']) && end === 'current') {
-    internalId = OPERATORS.since;
   } else if (moment.isMoment(interval['_start']) && moment.isMoment(interval['_end'])) {
     internalId = OPERATORS.dateRange;
   } else {

--- a/packages/reports/addon/components/filter-values/time-dimension/advanced.ts
+++ b/packages/reports/addon/components/filter-values/time-dimension/advanced.ts
@@ -9,6 +9,7 @@ import Interval from 'navi-data/utils/classes/interval';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { isIntervalValid } from 'navi-core/models/request/filter';
+import { next } from '@ember/runloop';
 
 export default class FilterValuesTimeDimensionAdvanced extends BaseIntervalComponent {
   @tracked start = this.formatValue(this.args.filter.values[0]);
@@ -47,6 +48,10 @@ export default class FilterValuesTimeDimensionAdvanced extends BaseIntervalCompo
 
   @action
   commitValues() {
-    this.args.onUpdateFilter({ values: this.newValues });
+    next(this, () => {
+      if (!document.activeElement?.className.includes('filter-values--advanced-interval-input')) {
+        this.args.onUpdateFilter({ values: this.newValues });
+      }
+    });
   }
 }

--- a/packages/reports/addon/components/filter-values/time-dimension/advanced.ts
+++ b/packages/reports/addon/components/filter-values/time-dimension/advanced.ts
@@ -9,7 +9,6 @@ import Interval from 'navi-data/utils/classes/interval';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { isIntervalValid } from 'navi-core/models/request/filter';
-import { next } from '@ember/runloop';
 
 export default class FilterValuesTimeDimensionAdvanced extends BaseIntervalComponent {
   @tracked start = this.formatValue(this.args.filter.values[0]);
@@ -47,11 +46,9 @@ export default class FilterValuesTimeDimensionAdvanced extends BaseIntervalCompo
   }
 
   @action
-  commitValues() {
-    next(this, () => {
-      if (!document.activeElement?.className.includes('filter-values--advanced-interval-input')) {
-        this.args.onUpdateFilter({ values: this.newValues });
-      }
-    });
+  commitValues(event: { relatedTarget: HTMLElement }) {
+    if (!event.relatedTarget?.className.includes('filter-values--advanced-interval-input')) {
+      this.args.onUpdateFilter({ values: this.newValues });
+    }
   }
 }

--- a/packages/reports/tests/unit/components/filter-builders/time-dimension-test.ts
+++ b/packages/reports/tests/unit/components/filter-builders/time-dimension-test.ts
@@ -102,8 +102,8 @@ module('Unit | Component | filter-builders/time-dimension', function (hooks) {
 
     assert.deepEqual(
       intervalId('2019-01-01', 'current'),
-      'since',
-      'Use since operator for specific dates ending with current interval'
+      'advanced',
+      'Use advanced operator for specific dates ending with current interval'
     );
     assert.deepEqual(
       intervalId('2019-01-01', 'next'),


### PR DESCRIPTION
## Description

Since is a 'gte' operation and advanced filter shouldn't swap to 'since' when end date is pinned to 'current' as having a fixed end date is incompatible with the concept of 'gte' date time filter.

Also advanced filter is frustrating to use as it swaps out filter builders after blurring only one input.

## Proposed Changes

   - datetime to current should not be 'Since'
   - advanced filter shouldn't update until both advanced inputs blur.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
