### PR TITLE
Fix: Hide categories with no valid visualizations

### DIFF
--- a/packages/reports/addon/components/visualization-toggle.hbs
+++ b/packages/reports/addon/components/visualization-toggle.hbs
@@ -7,7 +7,7 @@
 >
   <div class="flex align-items-center">
     <PowerSelect
-      @options={{this.categories}}
+      @options={{this.valid.categories}}
       @selected={{this.selectedCategory}}
       @searchEnabled={{false}}
       @onChange={{this.selectCategory}}
@@ -18,7 +18,7 @@
     </PowerSelect>
   </div>
   <DenaliToggle
-    @options={{get this.categoryToVisualizations this.selectedCategory}}
+    @options={{get this.valid.categoryToVisualizations this.selectedCategory}}
     @activeOption={{this.selectedVisualization}}
     @onChange={{@onVisualizationTypeUpdate}}
     @isSmall={{true}}

--- a/packages/reports/addon/components/visualization-toggle.ts
+++ b/packages/reports/addon/components/visualization-toggle.ts
@@ -36,7 +36,7 @@ export default class VisualizationToggle extends Component<Args> {
   @action
   selectCategory(category: string) {
     this.selectedCategory = category;
-    const visualizations = this.categoryToVisualizations[this.selectedCategory];
+    const visualizations = this.valid.categoryToVisualizations[this.selectedCategory];
     this.args.onVisualizationTypeUpdate(visualizations[visualizations.length - 1]);
   }
 
@@ -49,31 +49,28 @@ export default class VisualizationToggle extends Component<Args> {
   getCurrentCategory() {
     const { manifest } = this.args.report.visualization;
     const [category] =
-      Object.entries(this.categoryToVisualizations).find(([_category, validVisualizations]) =>
+      Object.entries(this.valid.categoryToVisualizations).find(([_category, validVisualizations]) =>
         validVisualizations.includes(manifest)
       ) ?? [];
-    return category ?? this.categories[0];
+    return category ?? this.valid.categories[0];
   }
 
   get selectedVisualization() {
     return this.args.report.visualization.manifest;
   }
 
-  get categories() {
-    return this.visualization.getCategories();
-  }
-
-  get categoryToVisualizations() {
-    const { categories } = this;
-    const categoryToValidVisualizations: Record<string, YavinVisualizationManifest[]> = {};
-    categories.forEach((category) => {
+  get valid() {
+    const categories: string[] = [];
+    const categoryToVisualizations: Record<string, YavinVisualizationManifest[]> = {};
+    this.visualization.getCategories().forEach((category) => {
       const validVisualizations = this.visualization
         .getVisualizations(category)
         .filter((v) => this.args.validVisualizations.includes(v));
       if (validVisualizations.length > 0) {
-        categoryToValidVisualizations[category] = validVisualizations;
+        categories.push(category);
+        categoryToVisualizations[category] = validVisualizations;
       }
     });
-    return categoryToValidVisualizations;
+    return { categories, categoryToVisualizations };
   }
 }


### PR DESCRIPTION
## Description

Fixes an issue with the visualization toggle where it would show all categories and try to select a visualization even if it was invalid

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
