### PR TITLE
Fix: Permissions on DeliveryRules

### DIFF
--- a/packages/core/addon/models/delivery-rule.ts
+++ b/packages/core/addon/models/delivery-rule.ts
@@ -76,9 +76,6 @@ export default class DeliveryRuleModel extends Model.extend(Validations) {
   @attr('boolean', { defaultValue: false })
   isDisabled!: boolean;
 
-  @attr('number', { defaultValue: 0 })
-  failureCount!: number;
-
   @belongsTo('deliverable-item', { async: true, inverse: 'deliveryRules', polymorphic: true })
   deliveredItem!: DS.PromiseObject<DeliverableItemModel>;
 

--- a/packages/core/tests/unit/models/delivery-rule-test.js
+++ b/packages/core/tests/unit/models/delivery-rule-test.js
@@ -23,7 +23,6 @@ const ExpectedDeliveryRule = {
   recipients: ['user-or-list1@navi.io', 'user-or-list2@navi.io'],
   version: 1,
   isDisabled: false,
-  failureCount: 0,
 };
 
 module('Unit | Model | delivery rule', function (hooks) {

--- a/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/DeliveryRulesTest.kt
+++ b/packages/webservice/app/src/test/kotlin/com/yahoo/navi/ws/test/integration/DeliveryRulesTest.kt
@@ -105,7 +105,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("version", "1"),
                             attr("schedulingRules", schedulingRules),
                             attr("isDisabled", false),
-                            attr("failureCount", 0),
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("reports"), id("1"))),
@@ -129,6 +128,8 @@ class DeliveryRulesTest : IntegrationTest() {
             .body(
                 "data.id", equalTo("1"),
                 "data.attributes.delivery", equalTo("email"),
+                "data.attributes.isDisabled", equalTo(false),
+                "data.attributes.failureCount", equalTo(0),
                 "data.attributes.deliveryType", equalTo("report"),
                 "data.attributes.frequency", equalTo("week"),
                 "data.attributes.format.type", equalTo("csv"),
@@ -156,7 +157,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("recipients", arrayOf("email1@yavin.dev", "email2@yavin.dev")),
                             attr("version", "1"),
                             attr("isDisabled", false),
-                            attr("failureCount", 0),
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("reports"), id("1"))),
@@ -186,7 +186,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("recipients", arrayOf("email1@yavin.dev", "email2@yavin.dev")),
                             attr("version", "1"),
                             attr("isDisabled", false),
-                            attr("failureCount", 0),
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("dashboards"), id("2"))),
@@ -250,7 +249,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("lastDeliveredOn", "2018-12-03 00:00:00"),
                             attr("version", "1"),
                             attr("isDisabled", false),
-                            attr("failureCount", 0),
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("reports"), id("1"))),
@@ -282,7 +280,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("recipients", arrayOf("email1@yavin.dev", "email2@yavin.dev")),
                             attr("version", "1"),
                             attr("isDisabled", false),
-                            attr("failureCount", 0),
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("reports"), id("1"))),
@@ -329,7 +326,6 @@ class DeliveryRulesTest : IntegrationTest() {
                         attributes(
                             attr("delivery", "none"),
                             attr("isDisabled", true),
-                            attr("failureCount", 0)
                         )
                     )
                 )
@@ -380,7 +376,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("recipients", arrayOf("email1@yavin.dev", "email2@yavin.dev")),
                             attr("version", "1"),
                             attr("isDisabled", false),
-                            attr("failureCount", 0),
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("reports"), id("1"))),
@@ -410,7 +405,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("recipients", arrayOf<String>()),
                             attr("version", "1"),
                             attr("isDisabled", false),
-                            attr("failureCount", 0),
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("reports"), id("1"))),
@@ -439,7 +433,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("delivery", "email"),
                             attr("version", "1"),
                             attr("isDisabled", false),
-                            attr("failureCount", 0),
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("reports"), id("1"))),
@@ -469,7 +462,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("recipients", arrayOf("user1@yavin.dev", "uasdf")),
                             attr("version", "1"),
                             attr("isDisabled", false),
-                            attr("failureCount", 0),
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("reports"), id("1"))),
@@ -499,7 +491,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("recipients", arrayOf("user1@yavin.dev")),
                             attr("format", format),
                             attr("isDisabled", false),
-                            attr("failureCount", 0),
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("reports"), id("1"))),
@@ -532,7 +523,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("recipients", arrayOf("email1@yavin.dev", "email2@yavin.dev")),
                             attr("version", "1"),
                             attr("isDisabled", false),
-                            attr("failureCount", 0)
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("reports"), id("1"))),
@@ -561,7 +551,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("recipients", arrayOf("email1@yavin.dev", "email2@yavin.dev")),
                             attr("version", "1"),
                             attr("isDisabled", false),
-                            attr("failureCount", 0)
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("reports"), id("1"))),
@@ -588,7 +577,6 @@ class DeliveryRulesTest : IntegrationTest() {
                         attributes(
                             attr("frequency", "month"),
                             attr("isDisabled", false),
-                            attr("failureCount", 0),
                         )
                     )
                 ).toJSON()
@@ -632,7 +620,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("recipients", arrayOf("email1@yavin.dev", "email2@yavin.dev")),
                             attr("version", "1"),
                             attr("isDisabled", false),
-                            attr("failureCount", 0)
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("reports"), id("1"))),
@@ -659,7 +646,6 @@ class DeliveryRulesTest : IntegrationTest() {
                         attributes(
                             attr("frequency", "month"),
                             attr("isDisabled", false),
-                            attr("failureCount", 0),
                         )
                     )
                 ).toJSON()
@@ -696,7 +682,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("recipients", arrayOf("email1@yavin.dev", "email2@yavin.dev")),
                             attr("version", "1"),
                             attr("isDisabled", false),
-                            attr("failureCount", 0)
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("reports"), id("1"))),
@@ -791,7 +776,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("version", "1"),
                             attr("schedulingRules", schedulingRules),
                             attr("isDisabled", false),
-                            attr("failureCount", 0)
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("reports"), id(reportId))),
@@ -897,7 +881,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("version", "1"),
                             attr("schedulingRules", schedulingRules),
                             attr("isDisabled", false),
-                            attr("failureCount", 0)
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("dashboards"), id(dashboardId))),
@@ -968,7 +951,6 @@ class DeliveryRulesTest : IntegrationTest() {
                             attr("version", "1"),
                             attr("schedulingRules", schedulingRules),
                             attr("isDisabled", false),
-                            attr("failureCount", 0)
                         ),
                         relationships(
                             relation("deliveredItem", linkage(type("reports"), id("1"))),
@@ -1010,7 +992,6 @@ class DeliveryRulesTest : IntegrationTest() {
                         attributes(
                             attr("format", formatWithOptions),
                             attr("isDisabled", false),
-                            attr("failureCount", 0),
                         )
                     )
                 )

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/DeliveryRule.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/DeliveryRule.kt
@@ -19,6 +19,7 @@ import com.yahoo.navi.ws.models.checks.DefaultAdminCheck
 import com.yahoo.navi.ws.models.checks.DefaultAdminCheck.Companion.IS_ADMIN
 import com.yahoo.navi.ws.models.checks.DefaultJobRunnerCheck
 import com.yahoo.navi.ws.models.checks.DefaultNobodyCheck
+import com.yahoo.navi.ws.models.checks.DefaultOwnerCheck
 import com.yahoo.navi.ws.models.checks.DefaultOwnerCheck.Companion.IS_OWNER
 import com.yahoo.yavin.ws.hooks.DeliveryRuleConditionalRecipientsHook
 import org.hibernate.annotations.CreationTimestamp
@@ -93,10 +94,12 @@ class DeliveryRule : HasOwner {
     var delivery: Delivery? = null
 
     @NotNull
-    var isDisabled: Boolean? = null
+    @UpdatePermission(expression = "${DefaultJobRunnerCheck.IS_JOB_RUNNER} OR ${DefaultAdminCheck.IS_ADMIN} OR ${DefaultOwnerCheck.IS_OWNER}")
+    var isDisabled: Boolean? = false
 
     @NotNull
-    var failureCount: Int? = null
+    @UpdatePermission(expression = "${DefaultJobRunnerCheck.IS_JOB_RUNNER} OR ${DefaultAdminCheck.IS_ADMIN} OR ${DefaultOwnerCheck.IS_OWNER}")
+    var failureCount: Int? = 0
 
     @Column(name = "scheduling_rules", columnDefinition = "MEDIUMTEXT")
     @Type(

--- a/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/DeliveryRule.kt
+++ b/packages/webservice/models/src/main/kotlin/com/yahoo/navi/ws/models/beans/DeliveryRule.kt
@@ -94,11 +94,13 @@ class DeliveryRule : HasOwner {
     var delivery: Delivery? = null
 
     @NotNull
+    @CreatePermission(expression = "${DefaultJobRunnerCheck.IS_JOB_RUNNER} OR ${DefaultAdminCheck.IS_ADMIN} OR ${DefaultOwnerCheck.IS_OWNER}")
     @UpdatePermission(expression = "${DefaultJobRunnerCheck.IS_JOB_RUNNER} OR ${DefaultAdminCheck.IS_ADMIN} OR ${DefaultOwnerCheck.IS_OWNER}")
     var isDisabled: Boolean? = false
 
     @NotNull
-    @UpdatePermission(expression = "${DefaultJobRunnerCheck.IS_JOB_RUNNER} OR ${DefaultAdminCheck.IS_ADMIN} OR ${DefaultOwnerCheck.IS_OWNER}")
+    @CreatePermission(expression = "${DefaultJobRunnerCheck.IS_JOB_RUNNER} OR ${DefaultAdminCheck.IS_ADMIN}")
+    @UpdatePermission(expression = "${DefaultJobRunnerCheck.IS_JOB_RUNNER} OR ${DefaultAdminCheck.IS_ADMIN}")
     var failureCount: Int? = 0
 
     @Column(name = "scheduling_rules", columnDefinition = "MEDIUMTEXT")


### PR DESCRIPTION
## Description

JobRunner can not update failureCount or isDisabled

## Proposed Changes

- Adding correct Elide permissions on those fields

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
