### PR TITLE
Fix: Keep fili dateTimes while switching tables

### DIFF
--- a/packages/reports/addon/components/filter-builders/time-dimension.ts
+++ b/packages/reports/addon/components/filter-builders/time-dimension.ts
@@ -13,6 +13,7 @@ import { DateTimePeriod, getPeriodForGrain, Grain } from 'navi-data/utils/date';
 import Interval from 'navi-data/utils/classes/interval';
 import BaseFilterBuilderComponent, { FilterValueBuilder } from './base';
 import { isEmpty } from '@ember/utils';
+import { GrainOrdering } from 'navi-data/models/metadata/bard/table';
 
 export const MONTHS_IN_QUARTER = 3;
 export const OPERATORS = <const>{
@@ -103,7 +104,8 @@ export function valuesForOperator(
   }
 
   const filterGrain = filter.parameters.grain as Grain;
-  const interval = Interval.parseInclusive(startStr, endStr, filterGrain);
+  const minGrain = GrainOrdering[filterGrain] < GrainOrdering.day ? 'day' : filterGrain;
+  const interval = Interval.parseInclusive(startStr, endStr, minGrain);
 
   if (newOperator === OPERATORS.current) {
     return ['current', 'next'];

--- a/packages/reports/addon/consumers/request/fili.ts
+++ b/packages/reports/addon/consumers/request/fili.ts
@@ -4,6 +4,7 @@
  */
 import ActionConsumer from 'navi-core/consumers/action-consumer';
 import { inject as service } from '@ember/service';
+import { assert } from '@ember/debug';
 import { RequestActions } from 'navi-reports/services/request-action-dispatcher';
 import { getDataSource } from 'navi-data/utils/adapter';
 import { valuesForOperator } from 'navi-reports/components/filter-builders/time-dimension';
@@ -20,9 +21,10 @@ import type Route from '@ember/routing/route';
 import type { Grain } from 'navi-data/utils/date';
 import type FilterFragment from 'navi-core/models/request/filter';
 import type SortFragment from 'navi-core/models/request/sort';
+import type TableMetadataModel from 'navi-data/models/metadata/table';
 
-function isFiliDateTime(col: ColumnFragment | FilterFragment | SortFragment) {
-  return col.field.endsWith('.dateTime') && col.type === 'timeDimension';
+function isFiliDateTime(table: string, col: ColumnFragment | FilterFragment | SortFragment) {
+  return col.field.endsWith(`${table}.dateTime`) && col.type === 'timeDimension';
 }
 
 export default class FiliConsumer extends ActionConsumer {
@@ -35,9 +37,11 @@ export default class FiliConsumer extends ActionConsumer {
   shouldConsumeAction(_actionName: string, route: Route) {
     const { routeName } = route;
     const { request } = route.modelFor(routeName) as ReportModel;
-    const { type } = getDataSource(request.dataSource);
-
-    return type === 'bard';
+    const { dataSource } = request;
+    if (dataSource) {
+      return getDataSource(dataSource).type === 'bard';
+    }
+    return false;
   }
 
   expandFilterInterval(route: Route, dateTimeFilter: FilterFragment, newGrain: Grain) {
@@ -49,7 +53,9 @@ export default class FiliConsumer extends ActionConsumer {
     if (dateTimeFilter.operator === 'bet') {
       const oldGrain = dateTimeFilter.parameters.grain as Grain;
       let [start, end] = dateTimeFilter.values as string[];
-      if (typeof end === 'string' && moment.utc(end).isValid()) {
+      if (intervalGrain === oldGrain) {
+        // don't update values unnecessarily
+      } else if (typeof end === 'string' && moment.utc(end).isValid()) {
         if (GrainOrdering[oldGrain] > GrainOrdering[intervalGrain]) {
           end = moment
             .utc(end as string)
@@ -57,7 +63,8 @@ export default class FiliConsumer extends ActionConsumer {
             .subtract(1, getPeriodForGrain(intervalGrain))
             .toISOString();
         } else {
-          const interval = Interval.parseInclusive(start, end, oldGrain).asMomentsInclusive(intervalGrain);
+          const minGrain = GrainOrdering[oldGrain] < GrainOrdering.day ? 'day' : oldGrain;
+          const interval = Interval.parseInclusive(start, end, minGrain).asMomentsInclusive(intervalGrain);
           start = interval.start.toISOString();
           end = interval.end.toISOString();
         }
@@ -90,13 +97,13 @@ export default class FiliConsumer extends ActionConsumer {
 
       const newGrain = changeset.parameters?.grain;
       // the grain was updated but no values were specified
-      if (isFiliDateTime(filterFragment) && newGrain) {
+      if (isFiliDateTime(request.table, filterFragment) && newGrain) {
         const values = valuesForOperator(filterFragment, newGrain as Grain);
         const changeset = { values };
         this.requestActionDispatcher.dispatch(RequestActions.UPDATE_FILTER, route, filterFragment, changeset);
       }
 
-      const filiDateTimeColumns = request.columns.filter(isFiliDateTime);
+      const filiDateTimeColumns = request.columns.filter((col) => isFiliDateTime(request.table, col));
       if (newGrain && filiDateTimeColumns.some((c) => c.parameters.grain !== newGrain)) {
         // update filterFragment before dispatch to prevent infinite loop
         filterFragment.setProperties(changeset);
@@ -134,17 +141,17 @@ export default class FiliConsumer extends ActionConsumer {
       const { request } = route.modelFor(routeName) as ReportModel;
 
       // If the date time grain was updated
-      if (isFiliDateTime(columnFragment) && parameterKey === 'grain') {
+      if (isFiliDateTime(request.table, columnFragment) && parameterKey === 'grain') {
         // and there is a date time filter, update filter grain to match
         request.filters
-          .filter((f) => isFiliDateTime(f) && f.parameters.grain !== parameterValue)
+          .filter((f) => isFiliDateTime(request.table, f) && f.parameters.grain !== parameterValue)
           .forEach((filiDateTimeFilter) =>
             this.expandFilterInterval(route, filiDateTimeFilter, parameterValue as Grain)
           );
 
         // update all other date time grains to match
         request.columns
-          .filter((c) => isFiliDateTime(c) && c !== columnFragment)
+          .filter((c) => isFiliDateTime(request.table, c) && c !== columnFragment)
           .forEach((dateTimeColumn) => {
             if (dateTimeColumn.parameters.grain !== parameterValue) {
               this.requestActionDispatcher.dispatch(
@@ -173,7 +180,7 @@ export default class FiliConsumer extends ActionConsumer {
       const { routeName } = route;
       const { request } = route.modelFor(routeName) as ReportModel;
 
-      const filiDateTimeColumn = request.columns.find(isFiliDateTime);
+      const filiDateTimeColumn = request.columns.find((col) => isFiliDateTime(request.table, col));
       const requestedGrain = parameters.grain;
       if (
         dimensionMetadataModel.metadataType === 'timeDimension' &&
@@ -181,15 +188,17 @@ export default class FiliConsumer extends ActionConsumer {
         requestedGrain &&
         filiDateTimeColumn.parameters.grain !== requestedGrain
       ) {
-        request.filters.filter(isFiliDateTime).forEach((filiDateTimeFilter) => {
-          const changeset = {
-            parameters: {
-              ...filiDateTimeFilter.parameters,
-              grain: filiDateTimeColumn.parameters.grain,
-            },
-          };
-          this.requestActionDispatcher.dispatch(RequestActions.UPDATE_FILTER, route, filiDateTimeFilter, changeset);
-        });
+        request.filters
+          .filter((fil) => isFiliDateTime(request.table, fil))
+          .forEach((filiDateTimeFilter) => {
+            const changeset = {
+              parameters: {
+                ...filiDateTimeFilter.parameters,
+                grain: filiDateTimeColumn.parameters.grain,
+              },
+            };
+            this.requestActionDispatcher.dispatch(RequestActions.UPDATE_FILTER, route, filiDateTimeFilter, changeset);
+          });
       }
     },
 
@@ -203,10 +212,10 @@ export default class FiliConsumer extends ActionConsumer {
       const { request } = route.modelFor(routeName) as ReportModel;
 
       const filtersAndColumns = [...request.columns.toArray(), ...request.filters.toArray()];
-      const filiDateTimes = filtersAndColumns.filter((col) => isFiliDateTime(col) && col !== column);
+      const filiDateTimes = filtersAndColumns.filter((col) => isFiliDateTime(request.table, col) && col !== column);
       const existingGrain = filiDateTimes.find((col) => col.parameters.grain)?.parameters.grain;
       // if a date time column was added and there is an existing grain, update the grain to match
-      if (isFiliDateTime(column) && existingGrain && column.parameters.grain !== existingGrain) {
+      if (isFiliDateTime(request.table, column) && existingGrain && column.parameters.grain !== existingGrain) {
         this.requestActionDispatcher.dispatch(
           RequestActions.UPDATE_COLUMN_FRAGMENT_WITH_PARAMS,
           route,
@@ -214,6 +223,46 @@ export default class FiliConsumer extends ActionConsumer {
           'grain',
           existingGrain
         );
+      }
+    },
+
+    /**
+     * Before switching to a new table, add that table's dateTime column if needed
+     * @action UPDATE_TABLE
+     * @param route - route that has a model that contains a request property
+     * @param table - the table metadata model
+     */
+    [RequestActions.WILL_UPDATE_TABLE](this: FiliConsumer, route: Route, table: TableMetadataModel) {
+      const { routeName } = route;
+      const { request } = route.modelFor(routeName) as ReportModel;
+
+      const oldDateTimeColumn = request.columns.find((col) => col.field.endsWith('.dateTime'));
+      const newDateTimeMetadata = table.timeDimensions.find((timeDim) => timeDim.id === `${table.id}.dateTime`);
+      if (oldDateTimeColumn && newDateTimeMetadata) {
+        // We know fili grain values are stored locally, so grab them
+        const grainValues = newDateTimeMetadata?.getParameter('grain')?.['_localValues'] ?? [];
+        const oldGrain = oldDateTimeColumn.parameters.grain;
+        // use current grain if valid otherwise lowest grain
+        const newGrain = (grainValues.find((param) => param.id === oldGrain) ? oldGrain : grainValues[0].id) as Grain;
+
+        const oldDateTimeFilter = request.filters.find((filter) => filter.field.endsWith('.dateTime'));
+        if (oldDateTimeFilter) {
+          this.requestActionDispatcher.dispatch(RequestActions.ADD_DIMENSION_FILTER, route, newDateTimeMetadata, {
+            grain: oldGrain,
+          });
+          const justAddedFilter = request.filters.find((filter) => filter.field === `${table.id}.dateTime`);
+          assert('The newly added date time filter is found', justAddedFilter);
+          this.requestActionDispatcher.dispatch(RequestActions.UPDATE_FILTER, route, justAddedFilter, {
+            operator: oldDateTimeFilter.operator,
+            values: oldDateTimeFilter.values,
+          });
+          if (oldGrain !== newGrain) {
+            this.expandFilterInterval(route, justAddedFilter, newGrain);
+          }
+        }
+        this.requestActionDispatcher.dispatch(RequestActions.ADD_COLUMN_WITH_PARAMS, route, newDateTimeMetadata, {
+          grain: newGrain,
+        });
       }
     },
   };

--- a/packages/reports/addon/consumers/request/table.ts
+++ b/packages/reports/addon/consumers/request/table.ts
@@ -17,6 +17,7 @@ export default class TableConsumer extends ActionConsumer {
     [RequestActions.UPDATE_TABLE](this: TableConsumer, route: Route, table: TableMetadataModel) {
       const { routeName } = route;
       const { request } = route.modelFor(routeName) as ReportModel;
+      this.requestActionDispatcher.dispatch(RequestActions.WILL_UPDATE_TABLE, route, table);
       request.setTableByMetadata(table);
       this.requestActionDispatcher.dispatch(RequestActions.DID_UPDATE_TABLE, route, table);
     },

--- a/packages/reports/addon/services/request-action-dispatcher.ts
+++ b/packages/reports/addon/services/request-action-dispatcher.ts
@@ -19,6 +19,7 @@ export const RequestActions = <const>{
   UPDATE_FILTER: 'updateFilter',
   REMOVE_FILTER: 'removeFilter',
 
+  WILL_UPDATE_TABLE: 'willUpdateTable',
   UPDATE_TABLE: 'updateTable',
   DID_UPDATE_TABLE: 'didUpdateTable',
 

--- a/packages/reports/tests/acceptance/fili-datasource-test.ts
+++ b/packages/reports/tests/acceptance/fili-datasource-test.ts
@@ -334,7 +334,7 @@ module('Acceptance | fili datasource', function (hooks) {
 
     assert
       .dom('.navi-column-config-item__name')
-      .hasText('Date Time (Day)', 'Date Time column is updated to match filter grain of hour');
+      .hasText('Date Time (Day)', 'Date Time column is updated to match filter grain of day');
     assert.dom('.filter-values--date-range-input__low-value input').hasValue('Nov 09, 2015', 'Start Date is correct');
     assert.dom('.filter-values--date-range-input__high-value input').hasValue('Nov 15, 2015', 'End Date is correct');
   });

--- a/packages/reports/tests/acceptance/fili-datasource-test.ts
+++ b/packages/reports/tests/acceptance/fili-datasource-test.ts
@@ -296,4 +296,46 @@ module('Acceptance | fili datasource', function (hooks) {
       'Date dimension columns shows up correctly with fields and grains'
     );
   });
+
+  test('Fili date time column and filter are preserved when switching tables', async function (assert) {
+    assert.expect(11);
+    await visit('reports/1/edit');
+
+    assert.deepEqual(
+      findAll('.navi-column-config-item__name').map((el) => el.textContent?.trim()),
+      ['Date Time (Day)', 'Property (id)', 'Ad Clicks', 'Nav Link Clicks'],
+      'All columns exist as expected'
+    );
+
+    await selectChoose('.dropdown-parameter-picker', 'Hour');
+    assert
+      .dom('.filter-builder__subject')
+      .hasText('Date Time Hour', 'Date time matches existing filter grain on the report');
+    assert
+      .dom('.navi-column-config-item__name')
+      .hasText('Date Time (Hour)', 'Date Time column is updated to match filter grain of hour');
+
+    assert.dom('.filter-values--date-range-input__low-value input').hasValue('Nov 09, 2015', 'Start Date is correct');
+    assert.dom('.filter-values--date-range-input__high-value input').hasValue('Nov 15, 2015', 'End Date is correct');
+
+    // Switch to Table A which also supports hour grain
+    await click('.report-builder-sidebar__breadcrumb-item[data-level="1"]');
+    await click('.report-builder-source-selector__source-button[data-source-name="Table A"]');
+
+    assert
+      .dom('.navi-column-config-item__name')
+      .hasText('Date Time (Hour)', 'Date Time column is updated to match filter grain of hour');
+    assert.dom('.filter-values--date-range-input__low-value input').hasValue('Nov 09, 2015', 'Start Date is correct');
+    assert.dom('.filter-values--date-range-input__high-value input').hasValue('Nov 15, 2015', 'End Date is correct');
+
+    // Switch to Table B which doesn't support hour grain
+    await click('.report-builder-sidebar__breadcrumb-item[data-level="1"]');
+    await click('.report-builder-source-selector__source-button[data-source-name="Table B"]');
+
+    assert
+      .dom('.navi-column-config-item__name')
+      .hasText('Date Time (Day)', 'Date Time column is updated to match filter grain of hour');
+    assert.dom('.filter-values--date-range-input__low-value input').hasValue('Nov 09, 2015', 'Start Date is correct');
+    assert.dom('.filter-values--date-range-input__high-value input').hasValue('Nov 15, 2015', 'End Date is correct');
+  });
 });

--- a/packages/reports/tests/unit/consumers/request/table-test.ts
+++ b/packages/reports/tests/unit/consumers/request/table-test.ts
@@ -8,7 +8,7 @@ import { TestContext } from 'ember-test-helpers';
 import NaviMetadataService from 'navi-data/services/navi-metadata';
 // @ts-ignore
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import StoreService from 'ember-data/store';
+import type StoreService from '@ember-data/store';
 
 const dispatchedActions: string[] = [];
 const dispatchedActionArgs: unknown[] = [];
@@ -16,7 +16,7 @@ const dispatchedActionArgs: unknown[] = [];
 const MockDispatcher = {
   dispatch(action: string, _route: Route, ...args: unknown[]) {
     dispatchedActions.push(action);
-    dispatchedActionArgs.push(...args);
+    dispatchedActionArgs.push(args);
   },
 };
 
@@ -61,8 +61,12 @@ module('Unit | Consumer | request table', function (hooks) {
 
     Consumer.send(RequestActions.UPDATE_TABLE, route, newTable);
 
-    assert.deepEqual(dispatchedActions, [RequestActions.DID_UPDATE_TABLE], 'actions are dispatched in correct order');
-    assert.deepEqual(dispatchedActionArgs, [newTable], 'actions are dispatched with correct args');
+    assert.deepEqual(
+      dispatchedActions,
+      [RequestActions.WILL_UPDATE_TABLE, RequestActions.DID_UPDATE_TABLE],
+      'actions are dispatched in correct order'
+    );
+    assert.deepEqual(dispatchedActionArgs, [[newTable], [newTable]], 'actions are dispatched with correct args');
     assert.equal(request.table, 'inventory', 'UPDATE_TABLE updates the table request attribute');
     assert.equal(request.dataSource, 'bardTwo', 'UPDATE_TABLE updates the dataSource request attribute');
   });


### PR DESCRIPTION
## Description
Fix for keeping the same dateTime grain/filter for fili reports when switching tables

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
