### PR TITLE
Fix: Missing intervals are hidden when multiple filters are expanded

### DIFF
--- a/packages/reports/app/styles/navi-reports/components/report-builder.scss
+++ b/packages/reports/app/styles/navi-reports/components/report-builder.scss
@@ -57,7 +57,7 @@
     flex: 0 1 auto;
     flex-flow: column;
     margin-top: 5px;
-    max-height: 35%;
+    max-height: 137px;
 
     &--collapsed {
       align-items: flex-start;

--- a/packages/reports/app/styles/navi-reports/components/report-view.scss
+++ b/packages/reports/app/styles/navi-reports/components/report-view.scss
@@ -28,7 +28,7 @@
     flex: 1;
     flex-basis: 0;
     min-height: 0;
-    min-height: 300px;
+    min-height: 200px;
   }
 
   &__navi-visualization-config {


### PR DESCRIPTION
Unfortunately filters at 35% and vis at 300px don't play nicely and push the warning down.

## Screenshots

![May-05-2022 17-38-29](https://user-images.githubusercontent.com/13946669/167030232-420bd295-b3fa-479d-91a6-31f8838929b4.gif)


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
