### PR TITLE
Fix missing intervals

### DIFF
--- a/packages/reports/addon/components/missing-intervals-warning.hbs
+++ b/packages/reports/addon/components/missing-intervals-warning.hbs
@@ -1,37 +1,40 @@
-{{!-- Copyright 2020, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2022, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <AnimatedContainer class="missing-intervals-warning" @motion={{this.resizeMotion}}>
   {{#animated-if this.warningEnabled initialInsertion=true use=this.drawerTransition}}
-    <div class="missing-intervals-warning__contents" role="button" {{on "click" (toggle "showDetails" this)}} ...attributes>
-      <DenaliIcon @icon="warning" @size="small" class="missing-intervals-warning__warning-icon" />
-      <span class="missing-intervals-warning__message-text">Important message(s) about your results.</span>
-      <span class="missing-intervals-warning__details-trigger">
-        {{#animated-if this.showDetails use=this.fadeTransition}}
-          <span class="missing-intervals-warning__details-desc link">Click to close.</span>
-          <DenaliIcon class="m-r-10 p-t-3" @icon="arrowhead-down" @size="small" />
-        {{else}}
-          <span class="missing-intervals-warning__details-desc link">Click for more details.</span>
-          <DenaliIcon class="m-r-10 p-t-3" @icon="arrowhead-up" @size="small" />
-        {{/animated-if}}
-      </span>
-    </div>
-    {{#if this.showDetails}}
-      <div class="missing-intervals-warning__details-content">
-        {{#each this.warningMessages as | message | }}
-          <div class="missing-intervals-warning__details-help-text">{{message}}</div>
-        {{/each}}
-        {{#if this.missingIntervals}}
-          <div class="missing-intervals-warning__details-help-text">The following intervals from the result set have missing data:</div>
-          <div class="missing-intervals-warning__dates">
-            {{#each this.missingIntervals as |interval|}}
-              <div class="missing-intervals-warning__date-row flex align-items-center">
-                <DenaliIcon @icon="close" class="is-status-danger p-r-5" @size="extrasmall" />
-                <span class="missing-intervals-warning__date-interval">{{interval}}</span>
-              </div>
-            {{/each}}
-          </div>
-          <div class="missing-intervals-warning__disclaimer">Note: Listed intervals include both the start and end dates.</div>
+    <div class="missing-intervals-warning__container-placeholder"></div>
+    <div class="missing-intervals-warning__container">
+      <div class="missing-intervals-warning__contents" role="button" {{on "click" (toggle "showDetails" this)}} ...attributes>
+        <DenaliIcon @icon="warning" @size="small" class="missing-intervals-warning__warning-icon" />
+        <span class="missing-intervals-warning__message-text">Important message(s) about your results.</span>
+        <span class="missing-intervals-warning__details-trigger">
+          {{#animated-if this.showDetails use=this.fadeTransition}}
+            <span class="missing-intervals-warning__details-desc link">Click to close.</span>
+            <DenaliIcon class="m-r-10 p-t-3" @icon="arrowhead-down" @size="small" />
+          {{else}}
+            <span class="missing-intervals-warning__details-desc link">Click for more details.</span>
+            <DenaliIcon class="m-r-10 p-t-3" @icon="arrowhead-up" @size="small" />
+          {{/animated-if}}
+        </span>
+      </div>
+      <div class="missing-intervals-warning__details-content {{if this.showDetails "missing-intervals-warning__details-content-expanded"}}">
+        {{#if this.showDetails}}
+          {{#each this.warningMessages as | message |}}
+            <div class="missing-intervals-warning__details-help-text">{{message}}</div>
+          {{/each}}
+          {{#if this.missingIntervals}}
+            <div class="missing-intervals-warning__details-help-text">The following intervals from the result set have missing data:</div>
+            <div class="missing-intervals-warning__dates">
+              {{#each this.missingIntervals as |interval|}}
+                <div class="missing-intervals-warning__date-row flex align-items-center">
+                  <DenaliIcon @icon="close" class="is-status-danger p-r-5" @size="extrasmall" />
+                  <span class="missing-intervals-warning__date-interval">{{interval}}</span>
+                </div>
+              {{/each}}
+            </div>
+            <div class="missing-intervals-warning__disclaimer">Note: Listed intervals include both the start and end dates.</div>
+          {{/if}}
         {{/if}}
       </div>
-    {{/if}}
+    </div>
   {{/animated-if}}
 </AnimatedContainer>

--- a/packages/reports/addon/components/missing-intervals-warning.hbs
+++ b/packages/reports/addon/components/missing-intervals-warning.hbs
@@ -17,22 +17,20 @@
         </span>
       </div>
       <div class="missing-intervals-warning__details-content {{if this.showDetails "missing-intervals-warning__details-content-expanded"}}">
-        {{#if this.showDetails}}
-          {{#each this.warningMessages as | message |}}
-            <div class="missing-intervals-warning__details-help-text">{{message}}</div>
-          {{/each}}
-          {{#if this.missingIntervals}}
-            <div class="missing-intervals-warning__details-help-text">The following intervals from the result set have missing data:</div>
-            <div class="missing-intervals-warning__dates">
-              {{#each this.missingIntervals as |interval|}}
-                <div class="missing-intervals-warning__date-row flex align-items-center">
-                  <DenaliIcon @icon="close" class="is-status-danger p-r-5" @size="extrasmall" />
-                  <span class="missing-intervals-warning__date-interval">{{interval}}</span>
-                </div>
-              {{/each}}
-            </div>
-            <div class="missing-intervals-warning__disclaimer">Note: Listed intervals include both the start and end dates.</div>
-          {{/if}}
+        {{#each this.warningMessages as | message |}}
+          <div class="missing-intervals-warning__details-help-text">{{message}}</div>
+        {{/each}}
+        {{#if this.missingIntervals}}
+          <div class="missing-intervals-warning__details-help-text">The following intervals from the result set have missing data:</div>
+          <div class="missing-intervals-warning__dates">
+            {{#each this.missingIntervals as |interval|}}
+              <div class="missing-intervals-warning__date-row flex align-items-center">
+                <DenaliIcon @icon="close" class="is-status-danger p-r-5" @size="extrasmall" />
+                <span class="missing-intervals-warning__date-interval">{{interval}}</span>
+              </div>
+            {{/each}}
+          </div>
+          <div class="missing-intervals-warning__disclaimer">Note: Listed intervals include both the start and end dates.</div>
         {{/if}}
       </div>
     </div>

--- a/packages/reports/addon/components/missing-intervals-warning.ts
+++ b/packages/reports/addon/components/missing-intervals-warning.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2022, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -77,8 +77,7 @@ export default class MissingIntervalWarning extends Component<Args> {
     yield Promise.all(
       insertedSprites.map((sprite) => {
         sprite.startAtPixel({ y });
-        sprite.applyStyles({ 'z-index': '1' });
-        return move(sprite, { easing: easeOut, duration: 1000 });
+        return move(sprite, { easing: easeOut, duration: 500 });
       })
     );
   }

--- a/packages/reports/app/styles/navi-reports/components/missing-intervals-warning.scss
+++ b/packages/reports/app/styles/navi-reports/components/missing-intervals-warning.scss
@@ -1,13 +1,24 @@
 /**
- * Copyright 2018, Yahoo Holdings Inc.
+ * Copyright 2022, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
 .missing-intervals-warning {
-  background-color: map-get($denali-grey-colors, '100');
   bottom: 0;
-  overflow: hidden;
+  position: relative;
   width: 100%;
+
+  &__container {
+    background-color: rgba(map-get($denali-grey-colors, '100'), 0.9);
+    bottom: 0;
+    position: absolute;
+    width: 100%;
+    z-index: 1;
+
+    &-placeholder {
+      height: 45px;
+    }
+  }
 
   &__contents {
     border-bottom: 1px solid map-get($denali-grey-colors, '400');
@@ -15,6 +26,7 @@
     cursor: pointer;
     display: flex;
     flex-direction: row;
+    flex-wrap: nowrap;
     padding: 10px;
     width: 100%;
   }
@@ -25,10 +37,16 @@
   }
 
   &__details-content {
-    max-height: 140px;
-    overflow-y: scroll;
-    padding: 10px;
+    height: 0;
+    overflow-y: hidden;
+    transition: height 0.5s ease-out;
     width: 100%;
+
+    &-expanded {
+      height: 140px;
+      overflow-y: scroll;
+      padding: 10px;
+    }
   }
 
   &__details-help-text {
@@ -39,8 +57,13 @@
 
   &__details-trigger {
     display: flex;
+    flex-wrap: nowrap;
     justify-content: space-between;
     width: 100%;
+  }
+
+  &__details-desc {
+    white-space: nowrap;
   }
 
   &__disclaimer {

--- a/packages/reports/app/styles/navi-reports/components/missing-intervals-warning.scss
+++ b/packages/reports/app/styles/navi-reports/components/missing-intervals-warning.scss
@@ -37,15 +37,15 @@
   }
 
   &__details-content {
-    height: 0;
+    max-height: 0;
     overflow-y: hidden;
-    transition: height 0.5s ease-out;
+    padding: 0 10px;
+    transition: max-height 0.5s ease-out;
     width: 100%;
 
     &-expanded {
-      height: 140px;
+      max-height: 140px;
       overflow-y: scroll;
-      padding: 10px;
     }
   }
 
@@ -53,6 +53,7 @@
     display: list-item;
     list-style-position: inside;
     list-style-type: square;
+    padding-top: 10px;
   }
 
   &__details-trigger {
@@ -68,6 +69,7 @@
 
   &__disclaimer {
     color: map-get($denali-grey-colors, '600');
+    padding-bottom: 10px;
   }
 
   &__message-text {

--- a/packages/reports/app/styles/navi-reports/components/report-builder.scss
+++ b/packages/reports/app/styles/navi-reports/components/report-builder.scss
@@ -57,7 +57,7 @@
     flex: 0 1 auto;
     flex-flow: column;
     margin-top: 5px;
-    max-height: 137px;
+    max-height: 35%;
 
     &--collapsed {
       align-items: flex-start;

--- a/packages/reports/app/styles/navi-reports/components/report-view.scss
+++ b/packages/reports/app/styles/navi-reports/components/report-view.scss
@@ -111,9 +111,10 @@
     display: flex;
     flex: 1;
     flex-flow: column;
+    margin: 10px;
     min-height: 0;
     min-width: 0;
-    padding: 10px;
+    position: relative;
   }
 }
 


### PR DESCRIPTION
## Description

Better fix for the missing intervals warning that leaves enough vertical space for the filters.

## Proposed Changes

Make expanded warning go over the visualization.

## Screenshots

https://user-images.githubusercontent.com/13946669/168120292-ee791e01-8fe4-421b-aca0-9b87784af596.mov

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
