### PR TITLE
Graphql import

### DIFF
--- a/packages/data/addon/gql/fragments/table.graphql
+++ b/packages/data/addon/gql/fragments/table.graphql
@@ -1,4 +1,4 @@
-#import "./arguments.graphql"
+# import * from "./arguments.graphql"
 
 fragment TableFragment on ElideTable {
   id

--- a/packages/data/addon/gql/queries/table.graphql
+++ b/packages/data/addon/gql/queries/table.graphql
@@ -1,4 +1,4 @@
-#import "../fragments/table.graphql"
+# import * from "../fragments/table.graphql"
 
 query GetTable($ids: [String!], $filter: String!) {
   table(ids: $ids, filter: $filter) {

--- a/packages/data/addon/gql/queries/tables.graphql
+++ b/packages/data/addon/gql/queries/tables.graphql
@@ -1,4 +1,4 @@
-#import "../fragments/table.graphql"
+# import * from "../fragments/table.graphql"
 
 query GetTables($filter: String!) {
   table(filter: $filter) {


### PR DESCRIPTION
Resolves #

Fixes the deprecation warning: 

```
[DEPRECATION] Legacy import syntax found in ... See https://git.io/fjym5 for migration details
```
## Description

## Proposed Changes

-

## Screenshots

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
