### PR TITLE
Fix: Filter model updates correctly on filter-value input

### DIFF
--- a/packages/reports/addon/components/filter-values/multi-value-input.hbs
+++ b/packages/reports/addon/components/filter-values/multi-value-input.hbs
@@ -12,7 +12,7 @@
     class="filter-values--multi-value-input {{if @filter.validations.isInvalid "filter-values--multi-value-input--error"}}"
     @tags={{readonly @filter.values}}
     @addTag={{this.addValue}}
-    @placeholder={{concat @filter.subject.name " Values"}}
+    @placeholder="{{capitalize (await @filter.displayNiceName)}} Values"
     @removeTagAtIndex={{this.removeValueAtIndex}}
     @allowSpacesInTags={{true}}
     @splitOnPaste={{true}}

--- a/packages/reports/addon/components/filter-values/multi-value-input.ts
+++ b/packages/reports/addon/components/filter-values/multi-value-input.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2022, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:
@@ -29,12 +29,12 @@ export default class MultiValueInput extends Component<Args> {
    */
   @action
   addValue(tag: string | number) {
-    const { tags } = this;
-    tags.push(tag);
+    const tags = [...this.tags, tag];
 
     this.args.onUpdateFilter({
       values: tags.slice(),
     });
+    this.tags = tags;
   }
 
   /**
@@ -43,11 +43,12 @@ export default class MultiValueInput extends Component<Args> {
    */
   @action
   removeValueAtIndex(index: number) {
-    const { tags } = this;
+    const tags = [...this.tags];
     tags.splice(index, 1);
 
     this.args.onUpdateFilter({
       values: tags.slice(),
     });
+    this.tags = tags;
   }
 }

--- a/packages/reports/app/styles/navi-reports/components/filter-values/multi-value-input.scss
+++ b/packages/reports/app/styles/navi-reports/components/filter-values/multi-value-input.scss
@@ -3,6 +3,12 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
-@import 'time-dimension/index';
-@import 'dimension-select';
-@import 'multi-value-input';
+.filter-values--multi-value-input {
+  .emberTagInput-new {
+    flex-grow: 1;
+
+    input {
+      width: 100%;
+    }
+  }
+}

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -1449,13 +1449,19 @@ module('Acceptance | Navi Report', function (hooks) {
   });
 
   test("filtering on a dimension with a storage strategy of 'none'", async function (assert) {
-    assert.expect(4);
+    assert.expect(5);
+
     //Add filter for a dimension where storageStrategy is 'none' and try to run the report
     await visit('/reports/13/view');
     await clickItem('dimension', 'Context Id');
     await clickItemFilter('dimension', 'Context Id');
+    await click('.navi-report__run-btn');
+
+    // fill in the filter and run the report
     await fillIn('.emberTagInput-new>input', 'This_will_not_match_any_dimension_values');
     await blur('.js-ember-tag-input-new');
+    assert.dom('.report-view-overlay__button--run').exists('run report overlay appears when filter is changed');
+
     await click('.navi-report__run-btn');
 
     assert


### PR DESCRIPTION
## License

This PR fixes the following issue:

1. add a dimension filter that does not have type ahead
1. type a value into the filter values box
1. press run
1. add another value into the filter values box
1. observe that you're not prompted to press 'run'
1. press 'run'
1. observe that nothing happens


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
