### PR TITLE
Fix: Revert invalid type imports

### DIFF
--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -11,27 +11,22 @@ import { A as array } from '@ember/array';
 import EmberObject from '@ember/object';
 import { canonicalizeMetric } from '../../utils/metric';
 import { configHost, getDataSource } from '../../utils/adapter';
-import NaviFactAdapter, { type RequestOptions, type AsyncQueryResponse, FactAdapterError } from './interface';
-import {
-  SORT_DIRECTIONS,
-  type Request,
-  type Filter,
-  type Column,
-  type Sort,
-  type ParameterValue,
-} from '@yavin/client/request';
+import NaviFactAdapter, { FactAdapterError } from './interface';
+import { SORT_DIRECTIONS } from '@yavin/client/request';
 import { omit, capitalize } from 'lodash-es';
 import { getPeriodForGrain, Grain } from '@yavin/client/utils/date';
 import moment from 'moment';
 import config from 'ember-get-config';
 import { task } from 'ember-concurrency';
+import Interval from '@yavin/client/utils/classes/interval';
+import { FiliDataSource } from 'navi-config';
+import type { RequestOptions, AsyncQueryResponse } from './interface';
+import type { Request, Filter, Column, Sort, ParameterValue } from '@yavin/client/request';
 import type NaviMetadataService from 'navi-data/services/navi-metadata';
 import type RequestDecoratorService from 'navi-data/services/request-decorator';
 import type BardTableMetadataModel from 'navi-data/models/metadata/bard/table';
 import type { GrainWithAll } from 'navi-data/serializers/metadata/bard';
 import type { TaskGenerator } from 'ember-concurrency';
-import Interval from '@yavin/client/utils/classes/interval';
-import { FiliDataSource } from 'navi-config';
 
 export type Query = Record<string, string | number | boolean>;
 

--- a/packages/data/addon/serializers/facts/elide.ts
+++ b/packages/data/addon/serializers/facts/elide.ts
@@ -8,13 +8,9 @@
 import EmberObject from '@ember/object';
 import { getOwner } from '@ember/application';
 import NaviFactSerializer, { ResponseV1 } from './interface';
-import {
-  type AsyncQueryResponse,
-  FactAdapterError,
-  type PageInfo,
-  type RequestOptions,
-} from 'navi-data/adapters/facts/interface';
-import { type RequestV2 } from '@yavin/client/request';
+import { FactAdapterError } from 'navi-data/adapters/facts/interface';
+import type { AsyncQueryResponse, PageInfo, RequestOptions } from 'navi-data/adapters/facts/interface';
+import type { RequestV2 } from '@yavin/client/request';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
 import NaviFactResponse from 'navi-data/models/navi-fact-response';
 import NaviFactError, { NaviErrorDetails } from 'navi-data/errors/navi-adapter-error';

--- a/packages/data/tests/unit/adapters/dimensions/elide-test.ts
+++ b/packages/data/tests/unit/adapters/dimensions/elide-test.ts
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import ElideDimensionAdapter from 'navi-data/adapters/dimensions/elide';
-import { type AsyncQueryResponse, QueryStatus, type RequestOptions } from 'navi-data/adapters/facts/interface';
+import { QueryStatus } from 'navi-data/adapters/facts/interface';
+import type { AsyncQueryResponse, RequestOptions } from 'navi-data/adapters/facts/interface';
 import type { RequestV2 } from '@yavin/client/request';
 import DimensionMetadataModel, { DimensionColumn } from 'navi-data/models/metadata/dimension';
 import ElideDimensionMetadataModel from 'navi-data/models/metadata/elide/dimension';

--- a/packages/data/tests/unit/serializers/facts/elide-test.ts
+++ b/packages/data/tests/unit/serializers/facts/elide-test.ts
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import NaviFactSerializer from 'navi-data/serializers/facts/interface';
-import { type AsyncQueryResponse, QueryStatus } from 'navi-data/adapters/facts/interface';
+import { QueryStatus } from 'navi-data/adapters/facts/interface';
+import type { AsyncQueryResponse } from 'navi-data/adapters/facts/interface';
 import type { RequestV2 } from '@yavin/client/request';
 import NaviFactResponse from 'navi-data/models/navi-fact-response';
 import { ExecutionResult, GraphQLError } from 'graphql';


### PR DESCRIPTION
## Description
Removes possibly invalid type imports which are breaking consuming apps. I'm not sure if these are valid and the consuming apps are broken or if these are invalid and should not have published

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
