### PR TITLE
Update: Make facts/dims/meta adapter interfaces generic

### DIFF
--- a/packages/client/src/adapters/metadata/interface.ts
+++ b/packages/client/src/adapters/metadata/interface.ts
@@ -16,14 +16,14 @@ export default interface NaviMetadataAdapter {
    * Bulk fetch of all metadata for a datasource
    * @param options
    */
-  fetchEverything(options?: MetadataOptions): Promise<unknown>;
+  fetchEverything(options?: MetadataOptions): PromiseLike<unknown>;
 
   /**
    * Fetch collection of metadata object
    * @param type - metadata type
    * @param options
    */
-  fetchAll(type: string, options?: MetadataOptions): Promise<unknown>;
+  fetchAll(type: string, options?: MetadataOptions): PromiseLike<unknown>;
 
   /**
    * Fetch metadata object by id
@@ -31,5 +31,5 @@ export default interface NaviMetadataAdapter {
    * @param id - metadata identifier
    * @param options
    */
-  fetchById(type: string, id: string, options?: MetadataOptions): Promise<unknown>;
+  fetchById(type: string, id: string, options?: MetadataOptions): PromiseLike<unknown>;
 }

--- a/packages/data/addon/adapters/dimensions/interface.ts
+++ b/packages/data/addon/adapters/dimensions/interface.ts
@@ -2,10 +2,7 @@
  * Copyright 2021, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
-import EmberObject from '@ember/object';
 import type { FilterOperator } from '@yavin/client/request';
-import type { ServiceOptions } from 'navi-data/services/navi-dimension';
-import type { TaskGenerator } from 'ember-concurrency';
 import type { DimensionColumn } from 'navi-data/models/metadata/dimension';
 
 export type DimensionFilter = {
@@ -13,13 +10,20 @@ export type DimensionFilter = {
   values: (string | number)[];
 };
 
-export default interface NaviDimensionAdapter extends EmberObject {
+export type Options = {
+  timeout?: number;
+  page?: number;
+  perPage?: number;
+  clientId?: string;
+};
+
+export default interface NaviDimensionAdapter {
   /**
    * Get all values for a dimension column
    * @param dimension - requested dimension
    * @param options - adapter options
    */
-  all(dimension: DimensionColumn, options?: ServiceOptions): TaskGenerator<unknown>;
+  all(dimension: DimensionColumn, options?: Options): PromiseLike<unknown>;
 
   /**
    * Get dimension value for a filter predicate
@@ -27,7 +31,7 @@ export default interface NaviDimensionAdapter extends EmberObject {
    * @param predicate - filter criteria
    * @param options - adapter options
    */
-  find(dimension: DimensionColumn, predicate: DimensionFilter[], options?: ServiceOptions): TaskGenerator<unknown>;
+  find(dimension: DimensionColumn, predicate: DimensionFilter[], options?: Options): PromiseLike<unknown>;
 
   /**
    * Get dimension values for a search string
@@ -35,5 +39,5 @@ export default interface NaviDimensionAdapter extends EmberObject {
    * @param query - query string
    * @param options - adapter options
    */
-  search(dimension: DimensionColumn, query: string, options?: ServiceOptions): TaskGenerator<unknown>;
+  search(dimension: DimensionColumn, query: string, options?: Options): PromiseLike<unknown>;
 }

--- a/packages/data/addon/adapters/facts/interface.ts
+++ b/packages/data/addon/adapters/facts/interface.ts
@@ -2,7 +2,6 @@
  * Copyright 2022, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
-import type { TaskGenerator } from 'ember-concurrency';
 import type { Request } from '@yavin/client/request';
 
 export type RequestOptions = {
@@ -84,7 +83,7 @@ export interface TableExportResult {
   message: string;
 }
 export default interface NaviFactAdapter {
-  fetchDataForRequest(request: Request, options: RequestOptions): TaskGenerator<unknown>;
+  fetchDataForRequest(request: Request, options: RequestOptions): PromiseLike<unknown>;
   urlForFindQuery(request: Request, options: RequestOptions): string;
-  urlForDownloadQuery(request: Request, options: RequestOptions): TaskGenerator<string>;
+  urlForDownloadQuery(request: Request, options: RequestOptions): PromiseLike<string>;
 }

--- a/packages/data/addon/serializers/dimensions/elide.ts
+++ b/packages/data/addon/serializers/dimensions/elide.ts
@@ -10,7 +10,7 @@ import type { DimensionColumn } from 'navi-data/models/metadata/dimension';
 import type ElideDimensionMetadataModel from 'navi-data/models/metadata/elide/dimension';
 import NaviDimensionModel from 'navi-data/models/navi-dimension';
 import NaviDimensionResponse from 'navi-data/models/navi-dimension-response';
-import type { ServiceOptions } from 'navi-data/services/navi-dimension';
+import type { Options } from 'navi-data/adapters/dimensions/interface';
 import { canonicalizeMetric } from 'navi-data/utils/metric';
 import { getPaginationFromPageInfo } from '../facts/elide';
 import type NaviDimensionSerializer from './interface';
@@ -20,11 +20,7 @@ export type ResponseEdge = {
 };
 
 export default class ElideDimensionSerializer extends EmberObject implements NaviDimensionSerializer {
-  normalize(
-    dimension: DimensionColumn,
-    rawPayload?: AsyncQueryResponse,
-    options: ServiceOptions = {}
-  ): NaviDimensionResponse {
+  normalize(dimension: DimensionColumn, rawPayload?: AsyncQueryResponse, options: Options = {}): NaviDimensionResponse {
     const responseStr = rawPayload?.asyncQuery.edges[0].node.result?.responseBody;
     const { valueSource, suggestionColumns } = dimension.columnMetadata as ElideDimensionMetadataModel;
     const { tableId } = valueSource;

--- a/packages/data/addon/serializers/dimensions/interface.ts
+++ b/packages/data/addon/serializers/dimensions/interface.ts
@@ -4,9 +4,9 @@
  */
 import EmberObject from '@ember/object';
 import type { DimensionColumn } from 'navi-data/models/metadata/dimension';
-import type { ServiceOptions } from 'navi-data/services/navi-dimension';
+import type { Options } from 'navi-data/adapters/dimensions/interface';
 import type NaviDimensionResponse from 'navi-data/models/navi-dimension-response';
 
 export default interface NaviDimensionSerializer extends EmberObject {
-  normalize(dimension: DimensionColumn, rawPayload: unknown, options: ServiceOptions): NaviDimensionResponse;
+  normalize(dimension: DimensionColumn, rawPayload: unknown, options: Options): NaviDimensionResponse;
 }

--- a/packages/data/addon/services/navi-facts.ts
+++ b/packages/data/addon/services/navi-facts.ts
@@ -73,7 +73,7 @@ export default class NaviFactsService extends Service {
   @task *getDownloadURL(request: RequestV2, options: RequestOptions): TaskGenerator<string> {
     const { type: dataSourceType } = getDataSource(request.dataSource);
     const adapter = this._adapterFor(dataSourceType);
-    return yield taskFor(adapter.urlForDownloadQuery).perform(request, options);
+    return yield adapter.urlForDownloadQuery(request, options);
   }
 
   /**
@@ -89,7 +89,7 @@ export default class NaviFactsService extends Service {
     const serializer = this._serializerFor(type);
 
     try {
-      const payload: unknown = yield taskFor(adapter.fetchDataForRequest).perform(request, options);
+      const payload: unknown = yield adapter.fetchDataForRequest(request, options);
       const response = serializer.normalize(payload, request, options);
       assert('The response is defined', response);
       return new NaviFactsModel(getOwner(this).lookup('service:client-injector'), { request, response });

--- a/packages/data/tests/unit/adapters/dimensions/bard-test.ts
+++ b/packages/data/tests/unit/adapters/dimensions/bard-test.ts
@@ -128,7 +128,7 @@ module('Unit | Adapter | Dimensions | Bard', function (hooks) {
       parameters: { field: 'id' },
     };
 
-    const result = await taskFor(this.adapter.all).perform(containerColumn);
+    const result = await this.adapter.all(containerColumn);
     assert.deepEqual(
       result,
       {
@@ -148,7 +148,7 @@ module('Unit | Adapter | Dimensions | Bard', function (hooks) {
       columnMetadata: this.naviMetadata.getById('dimension', 'container', 'bardTwo') as DimensionMetadataModel,
       parameters: { field: 'id' },
     };
-    const result = await taskFor(this.adapter.find).perform(containerColumn, [{ operator: 'in', values: ['1'] }]);
+    const result = await this.adapter.find(containerColumn, [{ operator: 'in', values: ['1'] }]);
     assert.deepEqual(
       result,
       {
@@ -164,7 +164,7 @@ module('Unit | Adapter | Dimensions | Bard', function (hooks) {
       parameters: { field: 'id' },
     };
 
-    const result = await taskFor(this.adapter.search).perform(containerColumn, 'a');
+    const result = await this.adapter.search(containerColumn, 'a');
     assert.deepEqual(
       result,
       {
@@ -213,7 +213,7 @@ module('Unit | Adapter | Dimensions | Bard', function (hooks) {
     });
 
     // Sending request for default clientId
-    await taskFor(this.adapter.find).perform(ageColumn, [{ operator: 'in', values: ['1'] }]);
+    await this.adapter.find(ageColumn, [{ operator: 'in', values: ['1'] }]);
 
     // Setting up assert for provided clientId
     this.server.get(`${HOST}/v1/dimensions/age/values/`, (_schema, request) => {
@@ -222,7 +222,7 @@ module('Unit | Adapter | Dimensions | Bard', function (hooks) {
     });
 
     // Sending request for provided clientId
-    await taskFor(this.adapter.find).perform(ageColumn, [{ operator: 'in', values: ['1'] }], { clientId: 'test id' });
+    await this.adapter.find(ageColumn, [{ operator: 'in', values: ['1'] }], { clientId: 'test id' });
   });
 
   test('searchUtil task calls and transforms search results', async function (this: TestContext, assert) {

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -11,7 +11,6 @@ import moment from 'moment';
 import ElideFactsAdapter, { getElideField } from 'navi-data/adapters/facts/elide';
 import type { Filter, RequestV2 } from '@yavin/client/request';
 import type MetadataModelRegistry from 'navi-data/models/metadata/registry';
-import { taskFor } from 'ember-concurrency-ts';
 
 const HOST = config.navi.dataSources[2].uri;
 const uuidRegex = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
@@ -788,7 +787,7 @@ module('Unit | Adapter | facts/elide', function (hooks) {
       return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: response })];
     });
 
-    const result = await taskFor(adapter.fetchDataForRequest).perform(TestRequest);
+    const result = await adapter.fetchDataForRequest(TestRequest);
     assert.deepEqual(result, response, 'fetchDataForRequest returns the correct response payload');
   });
 
@@ -800,7 +799,7 @@ module('Unit | Adapter | facts/elide', function (hooks) {
     Server.post(HOST, () => [400, { 'Content-Type': 'application/json' }, JSON.stringify({ errors })]);
 
     try {
-      await taskFor(adapter.fetchDataForRequest).perform(TestRequest);
+      await adapter.fetchDataForRequest(TestRequest);
     } catch ({ errors }) {
       const responseText = await errors[0].statusText;
       assert.deepEqual(responseText, errors[0].messages, 'fetchDataForRequest an array of response objects on error');
@@ -842,7 +841,7 @@ module('Unit | Adapter | facts/elide', function (hooks) {
       };
       return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: response })];
     });
-    const tableExportUrl: string = await taskFor(adapter.urlForDownloadQuery).perform(TestRequest, {});
+    const tableExportUrl: string = await adapter.urlForDownloadQuery(TestRequest, {});
     assert.deepEqual(tableExportUrl, downloadURL, 'urlForDownloadQuery returns the correct response payload');
   });
 
@@ -877,7 +876,7 @@ module('Unit | Adapter | facts/elide', function (hooks) {
     });
 
     try {
-      await taskFor(adapter.urlForDownloadQuery).perform(TestRequest, {});
+      await adapter.urlForDownloadQuery(TestRequest, {});
     } catch (e) {
       assert.deepEqual(
         e.errors[0].response.statusText,
@@ -916,7 +915,7 @@ module('Unit | Adapter | facts/elide', function (hooks) {
       return [200, { 'Content-Type': 'application/json' }, JSON.stringify({ data: response })];
     });
     try {
-      await taskFor(adapter.urlForDownloadQuery).perform(TestRequest, {});
+      await adapter.urlForDownloadQuery(TestRequest, {});
     } catch (e) {
       assert.deepEqual(
         e.message,

--- a/packages/data/tests/unit/services/navi-dimension-test.ts
+++ b/packages/data/tests/unit/services/navi-dimension-test.ts
@@ -4,18 +4,16 @@ import NaviDimensionModel from 'navi-data/models/navi-dimension';
 // @ts-ignore
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import GraphQLScenario from 'navi-data/mirage/scenarios/elide-one';
-import { task } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import config from 'ember-get-config';
 import EmberObject from '@ember/object';
 import DimensionMetadataModel, { DimensionColumn } from 'navi-data/models/metadata/dimension';
 import NaviDimensionResponse from 'navi-data/models/navi-dimension-response';
-import type { TaskGenerator } from 'ember-concurrency';
 import type NaviDimensionAdapter from 'navi-data/adapters/dimensions/interface';
 import type { TestContext as Context } from 'ember-test-helpers';
 import type { DimensionFilter } from 'navi-data/adapters/dimensions/interface';
 import type NaviDimensionService from 'navi-data/services/navi-dimension';
-import type { ServiceOptions } from 'navi-data/services/navi-dimension';
+import type { Options } from 'navi-data/adapters/dimensions/interface';
 import type NaviMetadataService from 'navi-data/services/navi-metadata';
 import type { Server } from 'miragejs';
 import type { AsyncQueryResponse } from 'navi-data/adapters/facts/interface';
@@ -81,19 +79,20 @@ module('Unit | Service | navi-dimension', function (hooks) {
     ];
 
     let call = 0;
-    let adapterCallback = (_call: number, _options: ServiceOptions): void => undefined;
+    let adapterCallback = (_call: number, _options: Options): void => undefined;
     class MockAdapter extends EmberObject implements Pick<NaviDimensionAdapter, 'all'> {
-      @task *all(_dimension: DimensionColumn, options: ServiceOptions): TaskGenerator<AsyncQueryResponse> {
+      async all(_dimension: DimensionColumn, options: Options): Promise<AsyncQueryResponse> {
         adapterCallback(call++, options);
-        return yield Promise.resolve({});
+        //@ts-expect-error - mock query response
+        return Promise.resolve({});
       }
     }
     this.owner.register(`adapter:dimensions/${dataSourceType}`, MockAdapter);
 
-    let serializerCallback = (_call: number, _options: ServiceOptions): ResponseV1['meta'] => ({});
+    let serializerCallback = (_call: number, _options: Options): ResponseV1['meta'] => ({});
     const { owner } = this;
     class MockSerializer extends EmberObject implements NaviDimensionSerializer {
-      normalize(_dimension: DimensionColumn, _rawPayload: unknown, options: ServiceOptions): NaviDimensionResponse {
+      normalize(_dimension: DimensionColumn, _rawPayload: unknown, options: Options): NaviDimensionResponse {
         const meta = serializerCallback(call++, options);
         //@ts-expect-error
         return new NaviDimensionResponse(owner, { meta: meta });


### PR DESCRIPTION
## Description
Use `PromiseLike` values for adapter interfaces so that the implementation can be more generic

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
