### PR TITLE
Fix: Make dashboard view match report view when no data present

### DIFF
--- a/packages/dashboards/addon/components/navi-widget.hbs
+++ b/packages/dashboards/addon/components/navi-widget.hbs
@@ -84,7 +84,7 @@
   {{#if @taskInstance.isSuccessful}}
     {{#let @model.visualization.manifest.visualizationComponent as |VisualizationComponent|}}
       {{#if this.hasNoData}}
-        <div class="navi-widget__content--no-results">
+        <div class="navi-widget__content error-container">
           No results available.
         </div>
       {{else}}

--- a/packages/dashboards/addon/components/navi-widget.hbs
+++ b/packages/dashboards/addon/components/navi-widget.hbs
@@ -83,18 +83,24 @@
   {{!-- Success --}}
   {{#if @taskInstance.isSuccessful}}
     {{#let @model.visualization.manifest.visualizationComponent as |VisualizationComponent|}}
-      <VisualizationComponent
-        class="navi-widget__content visualization-container"
-        @request={{this.data.firstObject.request}}
-        @response={{this.data.firstObject.response}}
-        @settings={{@model.visualization.metadata}}
-        @isReadOnly={{true}}
-        @isEditing={{false}}
-        {{!-- @onUpdateReport={{noop}} --}}
-        {{!-- @onUpdateSettings={{noop}} --}}
-        @container={{item}}
-        @manifest={{@model.visualization.manifest}}
-      />
+      {{#if this.hasNoData}}
+        <div class="navi-widget__content--no-results">
+          No results available.
+        </div>
+      {{else}}
+        <VisualizationComponent
+          class="navi-widget__content visualization-container"
+          @request={{this.data.firstObject.request}}
+          @response={{this.data.firstObject.response}}
+          @settings={{@model.visualization.metadata}}
+          @isReadOnly={{true}}
+          @isEditing={{false}}
+          {{!-- @onUpdateReport={{noop}} --}}
+          {{!-- @onUpdateSettings={{noop}} --}}
+          @container={{item}}
+          @manifest={{@model.visualization.manifest}}
+        />
+      {{/if}}
     {{/let}}
   {{/if}}
 </GridStackItem>

--- a/packages/dashboards/addon/components/navi-widget.ts
+++ b/packages/dashboards/addon/components/navi-widget.ts
@@ -97,7 +97,7 @@ export default class NaviWidget extends Component<NaviWidgetArgs> {
    * whether or not there is data to display
    */
   get hasNoData() {
-    return this.data?.firstObject?.response?.meta.pagination?.numberOfResults === 0;
+    return this.data?.firstObject?.response?.rows?.length === 0;
   }
 
   @action

--- a/packages/dashboards/addon/components/navi-widget.ts
+++ b/packages/dashboards/addon/components/navi-widget.ts
@@ -93,6 +93,13 @@ export default class NaviWidget extends Component<NaviWidgetArgs> {
     return isSuccessful ? arr(value as WidgetData) : null;
   }
 
+  /**
+   * whether or not there is data to display
+   */
+  get hasNoData() {
+    return this.data?.firstObject?.response?.meta.pagination?.numberOfResults === 0;
+  }
+
   @action
   scrollIntoView(element: HTMLElement) {
     if (this.args.isHighlighted) {

--- a/packages/dashboards/tests/integration/components/navi-widget-test.js
+++ b/packages/dashboards/tests/integration/components/navi-widget-test.js
@@ -122,9 +122,21 @@ module('Integration | Component | navi widget', function (hooks) {
   });
 
   test('visualization', async function (assert) {
-    assert.expect(5);
+    assert.expect(6);
 
-    const data = arr([{ request: 'foo', response: { rows: [1, 2, 3] } }]),
+    const data = arr([
+        {
+          request: 'foo',
+          response: {
+            rows: [1, 2, 3],
+            meta: {
+              pagination: {
+                numberOfResults: 3,
+              },
+            },
+          },
+        },
+      ]),
       metadata = {
         xAxis: 'timeseries',
       },
@@ -190,6 +202,32 @@ module('Integration | Component | navi widget', function (hooks) {
 
     // Test visualization listening to events
     triggerEvent(containerComponent.element, 'resizestop');
+
+    const noData = arr([
+      {
+        request: 'foo',
+        response: {
+          rows: [],
+          meta: {
+            pagination: {
+              numberOfResults: 0,
+            },
+          },
+        },
+      },
+    ]);
+    this.set('taskInstance.value', noData);
+
+    await render(hbs`
+      <NaviWidget
+        @model={{this.widgetModel}}
+        @taskInstance={{this.taskInstance}}
+      />
+    `);
+
+    assert
+      .dom('.navi-widget__content--no-results')
+      .hasText('No results available.', 'visualization will not render without data');
   });
 
   test('delete action visibility', async function (assert) {

--- a/packages/dashboards/tests/integration/components/navi-widget-test.js
+++ b/packages/dashboards/tests/integration/components/navi-widget-test.js
@@ -226,7 +226,7 @@ module('Integration | Component | navi widget', function (hooks) {
     `);
 
     assert
-      .dom('.navi-widget__content--no-results')
+      .dom('.navi-widget__content.error-container')
       .hasText('No results available.', 'visualization will not render without data');
   });
 

--- a/packages/dashboards/tests/integration/components/navi-widget-test.js
+++ b/packages/dashboards/tests/integration/components/navi-widget-test.js
@@ -129,11 +129,6 @@ module('Integration | Component | navi widget', function (hooks) {
           request: 'foo',
           response: {
             rows: [1, 2, 3],
-            meta: {
-              pagination: {
-                numberOfResults: 3,
-              },
-            },
           },
         },
       ]),
@@ -208,11 +203,6 @@ module('Integration | Component | navi widget', function (hooks) {
         request: 'foo',
         response: {
           rows: [],
-          meta: {
-            pagination: {
-              numberOfResults: 0,
-            },
-          },
         },
       },
     ]);
@@ -257,6 +247,7 @@ module('Integration | Component | navi widget', function (hooks) {
     const data = arr([
       {
         response: {
+          rows: [1, 2, 3],
           meta: {
             errors: [
               {
@@ -302,6 +293,7 @@ module('Integration | Component | navi widget', function (hooks) {
     const newData = arr([
       {
         response: {
+          rows: [1, 2, 3],
           meta: {},
         },
       },

--- a/packages/reports/addon/components/report-view.hbs
+++ b/packages/reports/addon/components/report-view.hbs
@@ -1,4 +1,4 @@
-{{!-- Copyright 2021, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
+{{!-- Copyright 2022, Yahoo Holdings Inc. Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms. --}}
 <div id={{this.guid}} class="report-view" ...attributes {{did-insert this.setupElement}} {{did-update this.filtersUpdate @isFiltersCollapsed @report.request.filters.length}}>
   <div class="report-view__visualization-main">
     <ReportViewOverlay
@@ -16,7 +16,7 @@
         />
       </div>
       {{#animated-if (and @hasRequestRun (not this.isEditingVisualization)) use=this.visFadeTransition duration=200}}
-        <DenaliIcon 
+        <DenaliIcon
           @icon="chart-edit"
           class="report-view__visualization-edit-btn p-l-10 p-r-5 w-8 link"
           title="Edit {{this.visualizationTypeLabel}}"

--- a/packages/reports/addon/components/report-view.ts
+++ b/packages/reports/addon/components/report-view.ts
@@ -89,7 +89,7 @@ export default class ReportView extends Component<ReportViewArgs> {
    * whether or not there is data to display
    */
   get hasNoData() {
-    return this.args.response?.meta.pagination?.numberOfResults === 0;
+    return this.args.response?.rows?.length === 0;
   }
 
   @action

--- a/packages/reports/addon/components/report-view.ts
+++ b/packages/reports/addon/components/report-view.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2022, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  *
  * Usage:


### PR DESCRIPTION
## Description
The report view doesn't render visualizations when there is no data available; this PR fixes the dashboard view match the report view.

## Screenshots
Report view:
![Screen Shot 2022-06-08 at 3 33 50 PM](https://user-images.githubusercontent.com/55207313/172711972-afad12a8-ee16-46f3-ade4-3e4cac56d761.png)
Dashboard view:
![Screen Shot 2022-06-08 at 3 44 27 PM](https://user-images.githubusercontent.com/55207313/172716369-83d8e3a7-40b4-4827-a2d7-c276c0a7b618.png)

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
