### PR TITLE
Update: Set up datasource/service plugins for client

### DIFF
--- a/packages/c3/ember-cli-build.js
+++ b/packages/c3/ember-cli-build.js
@@ -4,7 +4,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function (defaults) {
   let app = new EmberAddon(defaults, {
-    // Add options here
+    autoImport: {
+      watchDependencies: ['@yavin/client'],
+    },
   });
 
   /*

--- a/packages/client/src/config/datasource-plugins.ts
+++ b/packages/client/src/config/datasource-plugins.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2022, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import NativeWithCreate from '../models/native-with-create.js';
+import { Config, getInjector } from '../models/native-with-create.js';
+import invariant from 'tiny-invariant';
+import type { Injector } from '../models/native-with-create.js';
+import type NaviFactAdapter from '../adapters/facts/interface.js';
+import type NaviFactSerializer from '../serializers/facts/interface.js';
+import type NaviMetadataAdapter from '../adapters/metadata/interface.js';
+import type MetadataSerializer from '../serializers/metadata/interface.js';
+import type NaviDimensionAdapter from '../adapters/dimensions/interface.js';
+import type NaviDimensionSerializer from '../serializers/dimensions/interface.js';
+import type { ReturnTypesOfObject } from '../utils/types.js';
+import type { ClientConfig } from './datasources.js';
+
+export interface DataSourcePlugins {
+  facts: {
+    adapter: (injector: Injector) => NaviFactAdapter;
+    serializer: (injector: Injector) => NaviFactSerializer;
+  };
+  metadata: {
+    adapter: (injector: Injector) => NaviMetadataAdapter;
+    serializer: (injector: Injector) => MetadataSerializer;
+  };
+  dimensions: {
+    adapter: (injector: Injector) => NaviDimensionAdapter;
+    serializer: (injector: Injector) => NaviDimensionSerializer;
+  };
+}
+type ResolvedResolvedConfig = ReturnTypesOfObject<DataSourcePlugins>;
+
+type DataSourceService = keyof DataSourcePlugins;
+
+export class DataSourcePluginConfig extends NativeWithCreate {
+  @Config()
+  private declare clientConfig: ClientConfig;
+
+  #config: Record<string, DataSourcePlugins | undefined>;
+  #adapterCache = new Map<string, ResolvedResolvedConfig[DataSourceService]['adapter']>();
+  #serializerCache = new Map<string, ResolvedResolvedConfig[DataSourceService]['serializer']>();
+
+  constructor(injector: Injector, config: Record<string, DataSourcePlugins | undefined>) {
+    super(injector);
+    this.#config = config;
+  }
+
+  #getDataSourceType(dataSourceName: string) {
+    return this.clientConfig.getDataSource(dataSourceName).type;
+  }
+
+  #getPluginFor(type: string) {
+    return this.#config[type];
+  }
+
+  adapterFor<S extends keyof ResolvedResolvedConfig>(
+    dataSourceName: string,
+    service: S
+  ): ResolvedResolvedConfig[S]['adapter'] {
+    const dataSourceType = this.#getDataSourceType(dataSourceName);
+    const key = `${dataSourceType}.${service}`;
+    let adapter = this.#adapterCache.get(key);
+    if (!adapter) {
+      const dataSourcePlugin = this.#getPluginFor(dataSourceType);
+      invariant(dataSourcePlugin, `The dataSource plugin for ${dataSourceType} must be configured`);
+      adapter = dataSourcePlugin[service].adapter(getInjector(this));
+      this.#adapterCache.set(key, adapter);
+    }
+    return adapter;
+  }
+
+  serializerFor<S extends keyof ResolvedResolvedConfig>(
+    dataSourceName: string,
+    service: S
+  ): ResolvedResolvedConfig[S]['serializer'] {
+    const dataSourceType = this.#getDataSourceType(dataSourceName);
+    const key = `${dataSourceType}.${service}`;
+    let serializer = this.#serializerCache.get(key);
+    if (!serializer) {
+      const dataSourcePlugin = this.#getPluginFor(dataSourceType);
+      invariant(dataSourcePlugin, `The dataSource plugin for ${dataSourceType} must be configured`);
+      serializer = dataSourcePlugin[service].serializer(getInjector(this));
+      this.#serializerCache.set(key, serializer);
+    }
+    return serializer;
+  }
+}

--- a/packages/client/src/config/service-plugins.ts
+++ b/packages/client/src/config/service-plugins.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2022, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import type { Injector } from '../models/native-with-create.js';
+import type RequestDecoratorService from '../services/interfaces/request-decorator.js';
+import type MetadataService from '../services/interfaces/metadata.js';
+import type FactService from '../services/interfaces/fact.js';
+import type DimensionService from '../services/interfaces/dimension.js';
+import type FormatterService from '../services/interfaces/formatter.js';
+import type { ReturnTypesOfObject } from '../utils/types.js';
+
+export interface ServicePlugins {
+  requestDecorator: (injector: Injector) => RequestDecoratorService;
+  formatter: (injector: Injector) => FormatterService;
+  metadata: (injector: Injector) => MetadataService;
+  facts: (injector: Injector) => FactService;
+  dimensions: (injector: Injector) => DimensionService;
+}
+
+export type Services = ReturnTypesOfObject<ServicePlugins>;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -4,11 +4,69 @@
  */
 
 import { ClientConfig } from './config/datasources.js';
+import { DataSourcePluginConfig } from './config/datasource-plugins.js';
+import { getInjector, setInjector } from './models/native-with-create.js';
+import invariant from 'tiny-invariant';
 import type { YavinClientConfig } from './config/datasources.js';
+import type { DataSourcePlugins } from './config/datasource-plugins.js';
+import type { ServicePlugins, Services } from './config/service-plugins.js';
+import type FactService from './services/interfaces/fact.js';
+import type MetadataService from './services/interfaces/metadata.js';
+import type DimensionService from './services/interfaces/dimension.js';
+import type { ClientServices, Injector, LookupType } from './models/native-with-create.js';
+import type ServiceRegistry from './services/interfaces/registry.js';
+
+interface PluginConfig {
+  dataSourcePlugins: Record<string, DataSourcePlugins>;
+  servicePlugins: ServicePlugins;
+}
 
 export class Client {
+  get facts(): FactService {
+    return getInjector(this).lookup('service', 'navi-facts');
+  }
+  get metadata(): MetadataService {
+    return getInjector(this).lookup('service', 'navi-metadata');
+  }
+  get dimensions(): DimensionService {
+    return getInjector(this).lookup('service', 'navi-dimension');
+  }
+
   clientConfig: ClientConfig;
-  constructor(clientConfig: YavinClientConfig) {
+  pluginConfig: DataSourcePluginConfig;
+
+  constructor(clientConfig: YavinClientConfig, plugins: PluginConfig) {
     this.clientConfig = new ClientConfig(clientConfig);
+    setInjector(this, this.#createInjector(this.clientConfig, plugins.servicePlugins));
+    this.pluginConfig = new DataSourcePluginConfig(getInjector(this), plugins.dataSourcePlugins);
+  }
+
+  #createInjector(clientConfig: ClientConfig, servicePlugins: ServicePlugins): Injector {
+    const serviceToPluginNames: Record<keyof ServiceRegistry, keyof PluginConfig['servicePlugins']> = {
+      'request-decorator': 'requestDecorator',
+      'navi-formatter': 'formatter',
+      'navi-metadata': 'metadata',
+      'navi-dimension': 'dimensions',
+      'navi-facts': 'facts',
+    };
+    const serviceCache: Partial<Services> = {};
+    const injector: Injector = {
+      lookup<T extends ClientServices>(type: LookupType, service?: T): ClientConfig | ServiceRegistry[T] {
+        if (type === 'config') {
+          return clientConfig;
+        }
+        invariant(service, 'must be looking up service by name');
+        const serviceName = serviceToPluginNames[service];
+        let serviceInstance;
+        if (serviceCache[serviceName]) {
+          serviceInstance = serviceCache[serviceName];
+        } else {
+          serviceInstance = servicePlugins[serviceName](injector) as Services[typeof serviceName];
+          serviceCache[serviceName] = serviceInstance;
+        }
+        return serviceInstance as ServiceRegistry[T];
+      },
+    };
+    return injector;
   }
 }

--- a/packages/client/src/models/native-with-create.ts
+++ b/packages/client/src/models/native-with-create.ts
@@ -55,6 +55,10 @@ export function ClientService<T extends NativeWithCreate, S extends ClientServic
   };
 }
 
-export function getInjector<T extends NativeWithCreate>(obj: T) {
+export function getInjector(obj: any): Injector {
   return obj[INJECTOR];
+}
+
+export function setInjector(obj: any, injector: Injector) {
+  obj[INJECTOR] = injector;
 }

--- a/packages/client/src/utils/types.ts
+++ b/packages/client/src/utils/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright 2022, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+
+export type ReturnTypesOfObject<Interface extends Record<keyof Interface, any>> = {
+  [k in keyof Interface]: Interface[k] extends (...args: any[]) => any
+    ? ReturnType<Interface[k]>
+    : ReturnTypesOfObject<Interface[k]>;
+};

--- a/packages/client/test/tests/unit/config/datasources-plugin-test.ts
+++ b/packages/client/test/tests/unit/config/datasources-plugin-test.ts
@@ -1,0 +1,87 @@
+import { DataSourcePluginConfig } from '@yavin/client/config/datasource-plugins';
+import { ClientConfig } from '@yavin/client/config/datasources';
+import { Injector } from '@yavin/client/models/native-with-create';
+import { module, test } from 'qunit';
+
+const mockDataSource = { name: 'mockInstance', type: 'mock', displayName: 'Mocked', uri: 'mock://' };
+
+//@ts-expect-error - partial config
+const mockConfig = new ClientConfig({ dataSources: [mockDataSource] });
+const mockInjector = {
+  lookup: (type: string) => (type === 'config' ? mockConfig : undefined),
+} as unknown as Injector;
+let callCount: Record<string, number>;
+let PluginConfig: DataSourcePluginConfig;
+
+module('Unit | Config | Datasource Plugins', function (hooks) {
+  hooks.beforeEach(function (assert) {
+    callCount = {};
+    const returnMock = (mock: string) => {
+      callCount[mock] = 0;
+      return (injector: Injector) => {
+        callCount[mock] = callCount[mock] + 1;
+        assert.strictEqual(injector, mockInjector, 'injector is passed in to create function');
+        return mock;
+      };
+    };
+    PluginConfig = new DataSourcePluginConfig(mockInjector, {
+      mock: {
+        //@ts-expect-error - mock dimensions plugin
+        dimensions: { adapter: returnMock('mock:d:a'), serializer: returnMock('mock:d:s') },
+        //@ts-expect-error - mock facts plugin
+        facts: { adapter: returnMock('mock:f:a'), serializer: returnMock('mock:f:s') },
+        //@ts-expect-error - mock metadata plugin
+        metadata: { adapter: returnMock('mock:m:a'), serializer: returnMock('mock:m:s') },
+      },
+    });
+  });
+
+  test('adapterFor', function (assert) {
+    assert.expect(6);
+    assert.equal(
+      PluginConfig.adapterFor('mockInstance', 'facts'),
+      'mock:f:a',
+      'the facts adapter for mockInstance is instantiated'
+    );
+    assert.equal(
+      PluginConfig.adapterFor('mockInstance', 'metadata'),
+      'mock:m:a',
+      'the metadata adapter for mockInstance is instantiated'
+    );
+    assert.equal(
+      PluginConfig.adapterFor('mockInstance', 'dimensions'),
+      'mock:d:a',
+      'the dimensions adapter for mockInstance is instantiated'
+    );
+  });
+
+  test('serializerFor', function (assert) {
+    assert.expect(6);
+    assert.equal(
+      PluginConfig.serializerFor('mockInstance', 'facts'),
+      'mock:f:s',
+      'the facts serializer for mockInstance is instantiated'
+    );
+    assert.equal(
+      PluginConfig.serializerFor('mockInstance', 'metadata'),
+      'mock:m:s',
+      'the metadata serializer for mockInstance is instantiated'
+    );
+    assert.equal(
+      PluginConfig.serializerFor('mockInstance', 'dimensions'),
+      'mock:d:s',
+      'the dimensions serializer for mockInstance is instantiated'
+    );
+  });
+
+  test('lazy lookups', function (assert) {
+    assert.expect(5);
+    const mockFactsAdapter = 'mock:f:a';
+    assert.strictEqual(callCount[mockFactsAdapter], 0, 'No instances are created until looked up');
+    const first = PluginConfig.adapterFor('mockInstance', 'facts') as unknown as string;
+    assert.strictEqual(callCount[mockFactsAdapter], 1, 'An instance is created');
+    const second = PluginConfig.adapterFor('mockInstance', 'facts') as unknown as string;
+    assert.strictEqual(first, second, 'The same instance is returned on subsequent calls');
+    assert.strictEqual(callCount[mockFactsAdapter], 1, 'No new instances are created');
+  });
+});

--- a/packages/client/test/tests/unit/index-test.ts
+++ b/packages/client/test/tests/unit/index-test.ts
@@ -1,0 +1,42 @@
+import { Client } from '@yavin/client';
+import { Injector } from '@yavin/client/models/native-with-create';
+import { module, test } from 'qunit';
+
+module('Unit | Client', function () {
+  test('servicePlugins', function (assert) {
+    assert.expect(10);
+
+    let callCount: Record<string, number> = {};
+    const returnMock = (mock: string) => {
+      callCount[mock] = 0;
+      return (injector: Injector) => {
+        callCount[mock] = callCount[mock] + 1;
+        assert.strictEqual(typeof injector.lookup, 'function', 'injector is passed in to create function');
+        return mock;
+      };
+    };
+    const client = new Client(
+      //@ts-expect-error - empty config
+      {},
+      {
+        servicePlugins: {
+          metadata: returnMock('metadata'),
+          facts: returnMock('facts'),
+          dimensions: returnMock('dimensions'),
+        },
+      }
+    );
+
+    assert.deepEqual(callCount, { facts: 0, metadata: 0, dimensions: 0 }, 'No services are created until looked up');
+
+    const first = client.facts;
+    assert.equal(first, 'facts', 'It returns the custom facts service plugin');
+    assert.equal(client.metadata, 'metadata', 'It returns the custom metadata service plugin');
+    assert.equal(client.dimensions, 'dimensions', 'It returns the custom dimensions service plugin');
+
+    assert.deepEqual(callCount, { facts: 1, metadata: 1, dimensions: 1 }, 'All services have been created');
+    const second = client.facts;
+    assert.strictEqual(first, second, 'The same instance is returned on subsequent lookups');
+    assert.deepEqual(callCount, { facts: 1, metadata: 1, dimensions: 1 }, 'The fact service is not created again');
+  });
+});

--- a/packages/core/ember-cli-build.js
+++ b/packages/core/ember-cli-build.js
@@ -13,6 +13,9 @@ module.exports = function (defaults) {
     sassOptions: {
       includePaths: ['node_modules/ember-basic-dropdown/app/styles/'],
     },
+    autoImport: {
+      watchDependencies: ['@yavin/client'],
+    },
   });
 
   /*

--- a/packages/dashboards/ember-cli-build.js
+++ b/packages/dashboards/ember-cli-build.js
@@ -11,6 +11,9 @@ module.exports = function (defaults) {
       theme: false,
     },
     sassOptions: {},
+    autoImport: {
+      watchDependencies: ['@yavin/client'],
+    },
   });
 
   /*

--- a/packages/data/addon/services/navi-dimension.ts
+++ b/packages/data/addon/services/navi-dimension.ts
@@ -106,19 +106,19 @@ export default class NaviDimensionService extends Service implements DimensionSe
   }
 
   /**
-   * @param dataSourceType
-   * @returns  adapter instance for type
+   * @param dataSourceName
+   * @returns  adapter instance for dataSource
    */
-  private adapterFor(dataSourceType: string): NaviDimensionAdapter {
-    return getOwner(this).lookup(`adapter:dimensions/${dataSourceType}`);
+  private adapterFor(dataSourceName: string): NaviDimensionAdapter {
+    return this.yavinClient.pluginConfig.adapterFor(dataSourceName, 'dimensions');
   }
 
   /**
-   * @param dataSourceType
-   * @returns serializer instance for type
+   * @param dataSourceName
+   * @returns serializer instance for dataSource
    */
-  private serializerFor(dataSourceType: string): NaviDimensionSerializer {
-    return getOwner(this).lookup(`serializer:dimensions/${dataSourceType}`);
+  private serializerFor(dataSourceName: string): NaviDimensionSerializer {
+    return this.yavinClient.pluginConfig.serializerFor(dataSourceName, 'dimensions');
   }
 
   @waitFor
@@ -152,9 +152,9 @@ export default class NaviDimensionService extends Service implements DimensionSe
       return cacheResponse;
     }
 
-    const { type: dataSourceType } = this.yavinClient.clientConfig.getDataSource(dimension.columnMetadata.source);
-    const adapter = this.adapterFor(dataSourceType);
-    const serializer = this.serializerFor(dataSourceType);
+    const dataSourceName = dimension.columnMetadata.source;
+    const adapter = this.adapterFor(dataSourceName);
+    const serializer = this.serializerFor(dataSourceName);
     let moreResults = true;
     let paginationOptions: Pick<ServiceOptions, 'page' | 'perPage'> = {};
     let values: NaviDimensionModel[] = [];
@@ -199,10 +199,10 @@ export default class NaviDimensionService extends Service implements DimensionSe
     predicate: DimensionFilter[],
     options: ServiceOptions = {}
   ): TaskGenerator<NaviDimensionResponse> {
-    const { type: dataSourceType } = this.yavinClient.clientConfig.getDataSource(dimension.columnMetadata.source);
-    const adapter = this.adapterFor(dataSourceType);
+    const dataSourceName = dimension.columnMetadata.source;
+    const adapter = this.adapterFor(dataSourceName);
     const payload: unknown = yield adapter.find(dimension, predicate, options);
-    return this.serializerFor(dataSourceType).normalize(dimension, payload, options);
+    return this.serializerFor(dataSourceName).normalize(dimension, payload, options);
   }
 
   /**
@@ -228,10 +228,10 @@ export default class NaviDimensionService extends Service implements DimensionSe
       return this._dimensionCache.getSearchFromAll(allResponse, query);
     }
 
-    const { type: dataSourceType } = this.yavinClient.clientConfig.getDataSource(dimension.columnMetadata.source);
-    const adapter = this.adapterFor(dataSourceType);
+    const dataSourceName = dimension.columnMetadata.source;
+    const adapter = this.adapterFor(dataSourceName);
     const payload: unknown = yield adapter.search(dimension, query, options);
-    const results = this.serializerFor(dataSourceType).normalize(dimension, payload, options);
+    const results = this.serializerFor(dataSourceName).normalize(dimension, payload, options);
 
     return results;
   }

--- a/packages/data/addon/services/navi-facts.ts
+++ b/packages/data/addon/services/navi-facts.ts
@@ -26,19 +26,19 @@ export default class NaviFactsService extends Service implements FactService {
   declare yavinClient: YavinClientService;
 
   /**
-   * @param type
-   * @returns adapter instance for type
+   * @param dataSourceName
+   * @returns adapter instance for dataSource
    */
-  _adapterFor(type = 'bard'): NaviFactAdapter {
-    return getOwner(this).lookup(`adapter:facts/${type}`) as NaviFactAdapter;
+  _adapterFor(dataSourceName: string): NaviFactAdapter {
+    return this.yavinClient.pluginConfig.adapterFor(dataSourceName, 'facts');
   }
 
   /**
-   * @param type
-   * @returns serializer instance for type
+   * @param dataSourceName
+   * @returns serializer instance for dataSource
    */
-  _serializerFor(type = 'bard'): NaviFactSerializer {
-    return getOwner(this).lookup(`serializer:facts/${type}`) as NaviFactSerializer;
+  _serializerFor(dataSourceName: string): NaviFactSerializer {
+    return this.yavinClient.pluginConfig.serializerFor(dataSourceName, 'facts');
   }
 
   /**
@@ -48,8 +48,7 @@ export default class NaviFactsService extends Service implements FactService {
    * @returns url for the request
    */
   getURL(request: RequestV2, options: RequestOptions = {}) {
-    const { type: dataSourceType } = this.yavinClient.clientConfig.getDataSource(request.dataSource);
-    const adapter = this._adapterFor(dataSourceType);
+    const adapter = this._adapterFor(request.dataSource);
     let query;
     try {
       query = adapter.urlForFindQuery(request, options);
@@ -85,8 +84,7 @@ export default class NaviFactsService extends Service implements FactService {
    * @returns - url for the request
    */
   @task *getDownloadURLTask(request: RequestV2, options: RequestOptions): TaskGenerator<string> {
-    const { type: dataSourceType } = this.yavinClient.clientConfig.getDataSource(request.dataSource);
-    const adapter = this._adapterFor(dataSourceType);
+    const adapter = this._adapterFor(request.dataSource);
     return yield adapter.urlForDownloadQuery(request, options);
   }
 
@@ -97,9 +95,8 @@ export default class NaviFactsService extends Service implements FactService {
    * @returns - Promise with the bard response model object
    */
   @task *fetchTask(request: RequestV2, options: RequestOptions = {}): TaskGenerator<NaviFactsModel> {
-    const { type: dataSourceType } = this.yavinClient.clientConfig.getDataSource(request.dataSource);
-    const adapter = this._adapterFor(dataSourceType);
-    const serializer = this._serializerFor(dataSourceType);
+    const adapter = this._adapterFor(request.dataSource);
+    const serializer = this._serializerFor(request.dataSource);
 
     try {
       const payload: unknown = yield adapter.fetchDataForRequest(request, options);

--- a/packages/data/addon/services/yavin-client.ts
+++ b/packages/data/addon/services/yavin-client.ts
@@ -3,18 +3,76 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import Service from '@ember/service';
+import { getOwner } from '@ember/application';
 import { Client } from '@yavin/client';
 import config from 'ember-get-config';
+import type NaviMetadataAdapter from '@yavin/client/adapters/metadata/interface';
+import type MetadataSerializer from '@yavin/client/serializers/metadata/interface';
+import type NaviFactAdapter from '@yavin/client/adapters/facts/interface';
+import type NaviFactSerializer from '@yavin/client/serializers/facts/interface';
+import type NaviDimensionAdapter from '@yavin/client/adapters/dimensions/interface';
+import type NaviDimensionSerializer from '@yavin/client/serializers/dimensions/interface';
+import type { ServicePlugins } from '@yavin/client/config/service-plugins';
 
 export default class YavinClientService extends Service {
   #client: Client;
   constructor() {
     super(...arguments);
-    this.#client = new Client(config.navi);
+    const dataSourcePlugins = this.#getDataSourcePlugins();
+    const servicePlugins = this.#getServicePlugins();
+    this.#client = new Client(config.navi, {
+      dataSourcePlugins,
+      servicePlugins,
+    });
   }
 
+  #getDataSourcePlugins() {
+    const owner = getOwner(this);
+    const configuredDataSources = config.navi.dataSources.map(({ type }) => type);
+    const defaultDataSources = ['bard', 'elide'];
+    const allDataSources = [...new Set([...defaultDataSources, ...configuredDataSources])];
+
+    const getServicePlugin = <Adapter, Serializer>(service: string, type: string) => {
+      return {
+        adapter: () => owner.lookup(`adapter:${service}/${type}`) as Adapter,
+        serializer: () => owner.lookup(`serializer:${service}/${type}`) as Serializer,
+      };
+    };
+    const getDataSourcePlugin = (type: string) => ({
+      metadata: getServicePlugin<NaviMetadataAdapter, MetadataSerializer>('metadata', type),
+      facts: getServicePlugin<NaviFactAdapter, NaviFactSerializer>('facts', type),
+      dimensions: getServicePlugin<NaviDimensionAdapter, NaviDimensionSerializer>('dimensions', type),
+    });
+
+    return Object.fromEntries(allDataSources.map((type) => [type, getDataSourcePlugin(type)]));
+  }
+
+  #getServicePlugins(): ServicePlugins {
+    const owner = getOwner(this);
+
+    return {
+      requestDecorator: () => owner.lookup('service:request-decorator'),
+      formatter: () => owner.lookup('service:formatter'),
+      facts: () => owner.lookup('service:navi-facts'),
+      metadata: () => owner.lookup('service:navi-metadata'),
+      dimensions: () => owner.lookup('service:navi-dimension'),
+    };
+  }
+
+  get facts() {
+    return this.#client.facts;
+  }
+  get metadata() {
+    return this.#client.metadata;
+  }
+  get dimensions() {
+    return this.#client.dimensions;
+  }
   get clientConfig() {
     return this.#client.clientConfig;
+  }
+  get pluginConfig() {
+    return this.#client.pluginConfig;
   }
 }
 

--- a/packages/data/ember-cli-build.js
+++ b/packages/data/ember-cli-build.js
@@ -7,6 +7,9 @@ module.exports = function (defaults) {
     'ember-cli-babel': {
       includePolyfill: true,
     },
+    autoImport: {
+      watchDependencies: ['@yavin/client'],
+    },
   });
 
   /*

--- a/packages/data/tests/unit/services/navi-dimension-test.ts
+++ b/packages/data/tests/unit/services/navi-dimension-test.ts
@@ -72,6 +72,7 @@ module('Unit | Service | navi-dimension', function (hooks) {
     const dataSourceType = 'mock';
     const dataSourceName = 'test-example';
 
+    const originalDataSources = hostConfig.navi.dataSources;
     hostConfig.navi.dataSources = [
       { type: dataSourceType, uri: 'fake', name: dataSourceName, displayName: dataSourceName },
     ];
@@ -187,6 +188,7 @@ module('Unit | Service | navi-dimension', function (hooks) {
     call = 0;
     await service.all({ columnMetadata }, { perPage: 4, page: 1 });
     assert.strictEqual(call, 4, 'It took 2 calls to adapter/serializer to page through all the data');
+    hostConfig.navi.dataSources = originalDataSources;
   });
 
   test('all - pagination - elide', async function (this: TestContext, assert) {

--- a/packages/data/tests/unit/services/navi-dimension-test.ts
+++ b/packages/data/tests/unit/services/navi-dimension-test.ts
@@ -7,6 +7,7 @@ import GraphQLScenario from 'navi-data/mirage/scenarios/elide-one';
 import EmberObject from '@ember/object';
 import DimensionMetadataModel, { DimensionColumn } from '@yavin/client/models/metadata/dimension';
 import NaviDimensionResponse from '@yavin/client/models/navi-dimension-response';
+import hostConfig from 'ember-get-config';
 import type NaviDimensionAdapter from '@yavin/client/adapters/dimensions/interface';
 import type { TestContext as Context } from 'ember-test-helpers';
 import type { DimensionFilter, Options } from '@yavin/client/adapters/dimensions/interface';
@@ -16,7 +17,7 @@ import type { Server } from 'miragejs';
 import type { AsyncQueryResponse } from '@yavin/client/adapters/facts/interface';
 import type NaviDimensionSerializer from '@yavin/client/serializers/dimensions/interface';
 import type { ResponseV1 } from '@yavin/client/serializers/facts/interface';
-import type YavinClientService from 'navi-data/services/yavin-client';
+import YavinClientService from 'navi-data/services/yavin-client';
 
 interface TestContext extends Context {
   metadataService: NaviMetadataService;
@@ -68,11 +69,10 @@ module('Unit | Service | navi-dimension', function (hooks) {
 
   test('all - pagination - generic', async function (this: TestContext, assert) {
     assert.expect(15);
-    const client: YavinClientService = this.owner.lookup('service:yavin-client');
     const dataSourceType = 'mock';
     const dataSourceName = 'test-example';
 
-    client.clientConfig.dataSources = [
+    hostConfig.navi.dataSources = [
       { type: dataSourceType, uri: 'fake', name: dataSourceName, displayName: dataSourceName },
     ];
 
@@ -98,6 +98,9 @@ module('Unit | Service | navi-dimension', function (hooks) {
     }
     this.owner.register(`serializer:dimensions/${dataSourceType}`, MockSerializer);
 
+    // reload client to pick up new datasource, adapter, and serializer
+    this.owner.unregister('service:yavin-client');
+    this.owner.register('service:yavin-client', YavinClientService);
     const service = this.owner.lookup('service:navi-dimension') as NaviDimensionService;
     const columnMetadata = { source: dataSourceName } as DimensionMetadataModel;
 

--- a/packages/data/tests/unit/services/yavin-client-test.ts
+++ b/packages/data/tests/unit/services/yavin-client-test.ts
@@ -1,12 +1,80 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import config from 'ember-get-config';
+import type YavinClientService from 'navi-data/services/yavin-client';
+import type { YavinClientConfig } from '@yavin/client/config/datasources';
+import { DataSourcePlugins } from '@yavin/client/config/datasource-plugins';
 
+let YavinClient: YavinClientService;
 module('Unit | Service | yavin-client', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    let service = this.owner.lookup('service:yavin-client');
-    assert.ok(service);
+  hooks.beforeEach(function () {
+    YavinClient = this.owner.lookup('service:yavin-client');
+  });
+
+  test('service plugins', function (assert) {
+    assert.strictEqual(
+      YavinClient.facts,
+      this.owner.lookup('service:navi-facts'),
+      'the facts service can be overriden'
+    );
+    assert.strictEqual(
+      YavinClient.metadata,
+      this.owner.lookup('service:navi-metadata'),
+      'the metadata service can be overriden'
+    );
+    assert.strictEqual(
+      YavinClient.dimensions,
+      this.owner.lookup('service:navi-dimension'),
+      'the dimension service can be overriden'
+    );
+  });
+
+  test('client config', function (assert) {
+    assert.expect(6);
+    const { clientConfig } = YavinClient;
+    Object.keys(clientConfig).forEach((key: keyof YavinClientConfig) => {
+      assert.deepEqual(clientConfig[key], config.navi[key], `The ${key} config is equal`);
+    });
+  });
+
+  test('plugin config', function (assert) {
+    assert.expect(24);
+    const { pluginConfig } = YavinClient;
+    const services: (keyof DataSourcePlugins)[] = ['facts', 'metadata', 'dimensions'];
+    const equals = <const>[
+      ['bardOne', 'bardTwo'], // same dataSource types return same objects
+      ['bardOne', 'bardOne'], // adapters/serializers return the same instance for same dataSource
+      ['elideOne', 'elideTwo'], // same dataSource types return same objects
+    ];
+    equals.forEach(([left, right]) => {
+      services.forEach((service) => {
+        assert.strictEqual(
+          pluginConfig.adapterFor(left, service),
+          pluginConfig.adapterFor(right, service),
+          `the ${left} and ${right} ${service} adapters are equal`
+        );
+
+        assert.strictEqual(
+          pluginConfig.serializerFor(left, service),
+          pluginConfig.serializerFor(right, service),
+          `the ${left} and ${right} ${service} serializers are equal`
+        );
+      });
+    });
+
+    services.forEach((service) => {
+      assert.notEqual(
+        pluginConfig.adapterFor('bardOne', service),
+        pluginConfig.adapterFor('elideOne', service),
+        `the bardOne and elideOne data sources return different ${service} adapters`
+      );
+      assert.notEqual(
+        pluginConfig.serializerFor('bardOne', service),
+        pluginConfig.serializerFor('elideOne', service),
+        `the bardOne and elideOne data sources return different ${service} serializers`
+      );
+    });
   });
 });

--- a/packages/directory/ember-cli-build.js
+++ b/packages/directory/ember-cli-build.js
@@ -10,6 +10,9 @@ module.exports = function (defaults) {
     sassOptions: {
       includePaths: ['node_modules/ember-basic-dropdown/app/styles/'],
     },
+    autoImport: {
+      watchDependencies: ['@yavin/client'],
+    },
   });
 
   /*

--- a/packages/notifications/ember-cli-build.js
+++ b/packages/notifications/ember-cli-build.js
@@ -7,6 +7,7 @@ module.exports = function (defaults) {
     // Add options here
     autoImport: {
       exclude: ['navi-core'],
+      watchDependencies: ['@yavin/client'],
     },
   });
 

--- a/packages/perspective/ember-cli-build.js
+++ b/packages/perspective/ember-cli-build.js
@@ -5,6 +5,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function (defaults) {
   let app = new EmberAddon(defaults, {
     // Add options here
+    autoImport: {
+      watchDependencies: ['@yavin/client'],
+    },
   });
 
   /*

--- a/packages/reports/ember-cli-build.js
+++ b/packages/reports/ember-cli-build.js
@@ -13,6 +13,9 @@ module.exports = function (defaults) {
     sassOptions: {
       includePaths: ['node_modules/ember-basic-dropdown/app/styles/'],
     },
+    autoImport: {
+      watchDependencies: ['@yavin/client'],
+    },
   });
 
   /*


### PR DESCRIPTION
## Description
Set up `dataSourcePlugins` to allow adding custom data sources to the client and `servicePlugins` to allow for overriding the default services.

Also creates the plugins for bard/elide from the navi-data config and service overrides so now we can directly use `this.yavinClient.{facts,metadata,dimensions}`

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
