### PR TITLE
Update: Move fact service to client and make ember wrapper

### DIFF
--- a/packages/client/src/adapters/facts/interface.ts
+++ b/packages/client/src/adapters/facts/interface.ts
@@ -3,6 +3,7 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import type { Request } from '../../request.js';
+import type { Task } from 'effection';
 
 export type RequestOptions = {
   clientId?: string;
@@ -83,7 +84,7 @@ export interface TableExportResult {
   message: string;
 }
 export default interface NaviFactAdapter {
-  fetchDataForRequest(request: Request, options: RequestOptions): Promise<unknown>;
+  fetchDataForRequest(request: Request, options: RequestOptions): Promise<unknown> | Task<unknown>;
   urlForFindQuery(request: Request, options: RequestOptions): string;
-  urlForDownloadQuery(request: Request, options: RequestOptions): Promise<string>;
+  urlForDownloadQuery(request: Request, options: RequestOptions): Promise<string> | Task<unknown>;
 }

--- a/packages/client/src/adapters/facts/interface.ts
+++ b/packages/client/src/adapters/facts/interface.ts
@@ -86,5 +86,5 @@ export interface TableExportResult {
 export default interface NaviFactAdapter {
   fetchDataForRequest(request: Request, options: RequestOptions): Promise<unknown> | Task<unknown>;
   urlForFindQuery(request: Request, options: RequestOptions): string;
-  urlForDownloadQuery(request: Request, options: RequestOptions): Promise<string> | Task<unknown>;
+  urlForDownloadQuery(request: Request, options: RequestOptions): Promise<string> | Task<string>;
 }

--- a/packages/client/src/config/datasource-plugins.ts
+++ b/packages/client/src/config/datasource-plugins.ts
@@ -36,7 +36,7 @@ type ServiceAdapter = ResolvedResolvedConfig[DataSourceService]['adapter'];
 type ServiceSerializer = ResolvedResolvedConfig[DataSourceService]['serializer'];
 
 export class DataSourcePluginConfig extends NativeWithCreate {
-  @Config()
+  @Config('client')
   private declare clientConfig: ClientConfig;
 
   #config: Record<string, DataSourcePlugins | undefined>;

--- a/packages/client/src/plugins/elide/adapters/metadata.ts
+++ b/packages/client/src/plugins/elide/adapters/metadata.ts
@@ -17,7 +17,7 @@ import type { ClientConfig } from '../../../config/datasources.js';
 export type MetadataQueryType = keyof typeof queries;
 
 export default class ElideMetadataAdapter extends NativeWithCreate implements NaviMetadataAdapter {
-  @Config()
+  @Config('client')
   declare yavinConfig: ClientConfig;
 
   declare apolloClient: ApolloClient<unknown>;

--- a/packages/client/src/services/fact.ts
+++ b/packages/client/src/services/fact.ts
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2021, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import NaviFactsModel from '../models/navi-facts.js';
+import NaviFactResponse from '../models/navi-fact-response.js';
+import NativeWithCreate, { Config, getInjector } from '../models/native-with-create.js';
+import { ensureHalt } from '../utils/task.js';
+import { Operation, run, spawn, withLabels } from 'effection';
+import invariant from 'tiny-invariant';
+import type NaviFactAdapter from '../adapters/facts/interface.js';
+import type { RequestOptions } from '../adapters/facts/interface.js';
+import type { RequestV2 } from '../request.js';
+import type NaviFactSerializer from '../serializers/facts/interface.js';
+import type FactServiceInterface from '../services/interfaces/fact.js';
+import type { DataSourcePluginConfig } from '../config/datasource-plugins.js';
+
+export default class FactsService extends NativeWithCreate implements FactServiceInterface {
+  @Config('plugin')
+  declare pluginConfig: DataSourcePluginConfig;
+
+  /**
+   * @param dataSourceName
+   * @returns adapter instance for dataSource
+   */
+  protected adapterFor(dataSourceName: string): NaviFactAdapter {
+    return this.pluginConfig.adapterFor(dataSourceName, 'facts');
+  }
+
+  /**
+   * @param dataSourceName
+   * @returns serializer instance for dataSource
+   */
+  protected serializerFor(dataSourceName: string): NaviFactSerializer {
+    return this.pluginConfig.serializerFor(dataSourceName, 'facts');
+  }
+
+  /**
+   * Uses the adapter to get the bard query url for the request
+   * @param request - request object
+   * @param options - options object
+   * @returns url for the request
+   */
+  getURL(request: RequestV2, options: RequestOptions = {}) {
+    const adapter = this.adapterFor(request.dataSource);
+    let query;
+    try {
+      query = adapter.urlForFindQuery(request, options);
+    } catch (e) {
+      // nothing to do
+    }
+    return query;
+  }
+
+  getDownloadURL(request: RequestV2, options: RequestOptions): Promise<string> {
+    return run(withLabels(this.getDownloadURLTask(request, options), { name: 'getDownloadURL' }));
+  }
+
+  fetch(request: RequestV2, options: RequestOptions = {}): Promise<NaviFactsModel> {
+    return run(withLabels(this.fetchTask(request, options), { name: 'fetch' }));
+  }
+
+  fetchNext(response: NaviFactResponse, request: RequestV2): Promise<NaviFactsModel | null> {
+    return run(withLabels(this.fetchNextTask(response, request), { name: 'fetchNext' }), {});
+  }
+
+  fetchPrevious(response: NaviFactResponse, request: RequestV2): Promise<NaviFactsModel | null> {
+    return run(withLabels(this.fetchPreviousTask(response, request), { name: 'fetchPrevious' }));
+  }
+
+  /**
+   * Uses the adapter to get the download query url for the request
+   * @param request - request object
+   * @param options - options object
+   * @returns - url for the request
+   */
+  *getDownloadURLTask(request: RequestV2, options: RequestOptions): Operation<string> {
+    const adapter = this.adapterFor(request.dataSource);
+    const getUrl = adapter.urlForDownloadQuery(request, options);
+    yield ensureHalt(getUrl);
+    return yield getUrl;
+  }
+
+  /**
+   * Returns the response model for the request
+   * @param request - request object
+   * @param options - options object
+   * @returns - Promise with the bard response model object
+   */
+  *fetchTask(request: RequestV2, options: RequestOptions = {}): Operation<NaviFactsModel> {
+    const adapter = this.adapterFor(request.dataSource);
+    const serializer = this.serializerFor(request.dataSource);
+
+    try {
+      const fetchData: unknown = adapter.fetchDataForRequest(request, options);
+      yield ensureHalt(fetchData);
+      const payload: unknown = yield fetchData;
+      const response = serializer.normalize(payload, request, options);
+      invariant(response, 'The response is defined');
+      return new NaviFactsModel(getInjector(this), { request, response });
+    } catch (e) {
+      const errorModel: Error = serializer.extractError(e, request, options);
+      throw errorModel;
+    }
+  }
+
+  /**
+   * @param response
+   * @param request
+   * @return returns the promise with the next set of results or null
+   */
+  *fetchNextTask(response: NaviFactResponse, request: RequestV2): Operation<NaviFactsModel | null> {
+    if (response.meta.pagination) {
+      const { rowsPerPage, numberOfResults, currentPage } = response.meta.pagination;
+      const totalPages = numberOfResults / rowsPerPage;
+
+      if (currentPage < totalPages) {
+        const fetchNext = yield spawn(
+          this.fetchTask(request, {
+            page: currentPage + 1,
+            perPage: rowsPerPage,
+          })
+        );
+        return yield fetchNext;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @param response
+   * @param request
+   * @return returns the promise with the previous set of results or null
+   */
+  *fetchPreviousTask(response: NaviFactResponse, request: RequestV2): Operation<NaviFactsModel | null> {
+    if (response.meta.pagination) {
+      const { rowsPerPage, currentPage } = response.meta.pagination;
+      if (currentPage > 1) {
+        const fetchPrevious = yield spawn(
+          this.fetchTask(request, {
+            page: currentPage - 1,
+            perPage: rowsPerPage,
+          })
+        );
+        return yield fetchPrevious;
+      }
+    }
+    return null;
+  }
+}

--- a/packages/client/src/utils/task.ts
+++ b/packages/client/src/utils/task.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2022, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import { ensure, Task } from 'effection';
+
+export function isTask(maybeTask: unknown): maybeTask is Task {
+  return typeof maybeTask === 'object' && !!maybeTask && 'halt' in maybeTask;
+}
+
+export async function maybeHalt(maybeTask: unknown) {
+  if (isTask(maybeTask)) {
+    await maybeTask.halt();
+  }
+}
+
+export function ensureHalt(maybeTask: unknown) {
+  return ensure(async () => {
+    await maybeHalt(maybeTask);
+  });
+}

--- a/packages/client/test/tests/helpers/config.ts
+++ b/packages/client/test/tests/helpers/config.ts
@@ -1,54 +1,56 @@
 import { YavinClientConfig } from '@yavin/client/config/datasources';
 
-export const config: YavinClientConfig = {
-  dataSources: [
-    {
-      name: 'bardOne',
-      displayName: 'Bard One',
-      description: 'Interesting User Insights',
-      uri: 'https://data.naviapp.io',
-      type: 'bard',
-      options: {
-        enableDimensionSearch: true,
-        sinceOperatorEndPeriod: 'P3M',
-      },
-    },
-    {
-      name: 'bardTwo',
-      displayName: 'Bard Two',
-      description: 'Awesome Revenue Analytics',
-      uri: 'https://data2.naviapp.com',
-      type: 'bard',
-    },
-    {
-      name: 'elideOne',
-      displayName: 'Elide One',
-      description: 'Elide One Description',
-      uri: 'https://data.naviapp.io/graphql',
-      type: 'elide',
-      namespaces: [
-        {
-          name: 'DemoNamespace',
-          displayName: 'Demo Namespace',
-          description: 'Demo Namespace Description',
+export function mockConfig(): YavinClientConfig {
+  return {
+    dataSources: [
+      {
+        name: 'bardOne',
+        displayName: 'Bard One',
+        description: 'Interesting User Insights',
+        uri: 'https://data.naviapp.io',
+        type: 'bard',
+        options: {
+          enableDimensionSearch: true,
+          sinceOperatorEndPeriod: 'P3M',
         },
-      ],
+      },
+      {
+        name: 'bardTwo',
+        displayName: 'Bard Two',
+        description: 'Awesome Revenue Analytics',
+        uri: 'https://data2.naviapp.com',
+        type: 'bard',
+      },
+      {
+        name: 'elideOne',
+        displayName: 'Elide One',
+        description: 'Elide One Description',
+        uri: 'https://data.naviapp.io/graphql',
+        type: 'elide',
+        namespaces: [
+          {
+            name: 'DemoNamespace',
+            displayName: 'Demo Namespace',
+            description: 'Demo Namespace Description',
+          },
+        ],
+      },
+      {
+        name: 'elideTwo',
+        displayName: 'Elide Two',
+        description: 'Elide Two Description',
+        uri: 'https://data2.naviapp.com/graphql',
+        type: 'elide',
+      },
+    ],
+    defaultDataSource: 'bardOne',
+    cardinalities: {
+      small: 600,
+      medium: 50000,
     },
-    {
-      name: 'elideTwo',
-      displayName: 'Elide Two',
-      description: 'Elide Two Description',
-      uri: 'https://data2.naviapp.com/graphql',
-      type: 'elide',
+    dimensionCache: {
+      maxSize: 100,
+      timeoutMs: 10000,
     },
-  ],
-  defaultDataSource: 'bardOne',
-  cardinalities: {
-    small: 600,
-    medium: 50000,
-  },
-  dimensionCache: {
-    maxSize: 100,
-    timeoutMs: 10000,
-  },
-};
+  };
+}

--- a/packages/client/test/tests/helpers/injector.ts
+++ b/packages/client/test/tests/helpers/injector.ts
@@ -31,6 +31,8 @@ export const Mock = (config: MockConfig = {}) => {
     facts: (service: FactService) => Mock({ ...config, 'navi-facts': service }),
     decorator: (service: RequestDecoratorService) => Mock({ ...config, 'request-decorator': service }),
     config: (clientConfig: ClientConfig) => Mock({ ...config, client: clientConfig }),
+    plugin: (pluginConfig: (injector: Injector) => DataSourcePluginConfig) =>
+      Mock({ ...config, plugin: pluginConfig(mockInjector(config)) }),
     build: () => mockInjector(config),
   };
 };

--- a/packages/client/test/tests/unit/config/datasources-test.ts
+++ b/packages/client/test/tests/unit/config/datasources-test.ts
@@ -1,58 +1,8 @@
 import { module, test } from 'qunit';
 import { ClientConfig } from '@yavin/client/config/datasources';
+import { mockConfig } from '../../helpers/config';
 
-const configJson = {
-  dimensionCache: {
-    maxSize: 100,
-    timeoutMs: 10000,
-  },
-  dataSources: [
-    {
-      name: 'bardOne',
-      displayName: 'Bard One',
-      description: 'Interesting User Insights',
-      uri: 'https://data.naviapp.io',
-      type: 'bard',
-      options: {
-        enableDimensionSearch: true,
-        sinceOperatorEndPeriod: 'P3M',
-      },
-    },
-    {
-      name: 'bardTwo',
-      displayName: 'Bard Two',
-      description: 'Awesome Revenue Analytics',
-      uri: 'https://data2.naviapp.com',
-      type: 'bard',
-    },
-    {
-      name: 'elideOne',
-      displayName: 'Elide One',
-      description: 'Elide One Description',
-      uri: 'https://data.naviapp.io/graphql',
-      type: 'elide',
-      namespaces: [
-        {
-          name: 'DemoNamespace',
-          displayName: 'Demo Namespace',
-          description: 'Demo Namespace Description',
-        },
-      ],
-    },
-    {
-      name: 'elideTwo',
-      displayName: 'Elide Two',
-      description: 'Elide Two Description',
-      uri: 'https://data2.naviapp.com/graphql',
-      type: 'elide',
-    },
-  ],
-  defaultDataSource: 'bardOne',
-  cardinalities: {
-    small: 600,
-    medium: 50000,
-  },
-};
+const configJson = mockConfig();
 let clientConfig: ClientConfig;
 
 module('Unit | Config | Config', function (hooks) {

--- a/packages/client/test/tests/unit/models/metadata/dimension-test.ts
+++ b/packages/client/test/tests/unit/models/metadata/dimension-test.ts
@@ -221,6 +221,7 @@ module('Unit | Metadata Model | Dimension', function (hooks) {
           };
         },
       },
+      //@ts-expect-error - partial dimension payload
       {
         id: 'dimensionOne',
         source: 'bardOne',

--- a/packages/client/test/tests/unit/models/metadata/elide/dimension-test.ts
+++ b/packages/client/test/tests/unit/models/metadata/elide/dimension-test.ts
@@ -49,7 +49,7 @@ module('Unit | Model | metadata/elide/dimension', function (hooks) {
         assert.equal(type, 'service', 'service is looked up');
         assert.equal(name, 'navi-metadata', 'metadata service is looked up');
         return {
-          getById(type, id, dataSourceName) {
+          getById(type: string, id: string, dataSourceName: string) {
             assert.deepEqual(type, 'dimension', 'Looks up column as dimension');
             assert.deepEqual(id, Model.tableSource?.valueSource, 'Looks up column using table source');
             assert.deepEqual(dataSourceName, Model.source, 'Looks up column using current datasource');

--- a/packages/client/test/tests/unit/models/metadata/metric-test.ts
+++ b/packages/client/test/tests/unit/models/metadata/metric-test.ts
@@ -245,6 +245,7 @@ module('Unit | Metadata Model | Metric', function (hooks) {
           };
         },
       },
+      //@ts-expect-error - partial metric payload
       {
         id: 'metricOne',
         source: 'bardOne',

--- a/packages/client/test/tests/unit/plugins/fili/adapters/facts-test.ts
+++ b/packages/client/test/tests/unit/plugins/fili/adapters/facts-test.ts
@@ -7,10 +7,11 @@ import { Grain } from '@yavin/client/utils/date';
 import { ClientConfig } from '@yavin/client/config/datasources';
 import setupServer, { WithServer } from '../../../../helpers/server';
 import { Mock } from '../../../../helpers/injector';
-import { config } from '../../../../helpers/config';
+import { mockConfig } from '../../../../helpers/config';
 import { rest } from 'msw';
 import type MetadataService from '@yavin/client/services/interfaces/metadata';
 
+const config = mockConfig();
 const HOST = config.dataSources[0].uri;
 const HOST2 = config.dataSources[1].uri;
 

--- a/packages/client/test/tests/unit/services/fact-test.ts
+++ b/packages/client/test/tests/unit/services/fact-test.ts
@@ -1,16 +1,20 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
-import Pretender, { Server as PretenderServer } from 'pretender';
-import config from 'ember-get-config';
 import type { RequestOptions } from '@yavin/client/adapters/facts/interface';
 import type { RequestV2 } from '@yavin/client/request';
-import NaviFactsService from 'navi-data/services/navi-facts';
-import { TestContext } from 'ember-test-helpers';
+import NaviFactsService from '@yavin/client/services/fact';
 import { ResponseV1 } from '@yavin/client/serializers/facts/interface';
 import NaviFactResponse from '@yavin/client/models/navi-fact-response';
 import NaviAdapterError from '@yavin/client/errors/navi-adapter-error';
-
-let Server: PretenderServer;
+import setupServer, { WithServer } from '../../helpers/server';
+import { rest } from 'msw';
+import { mockConfig } from '../../helpers/config';
+import { Mock, nullInjector } from '../../helpers/injector';
+import { ClientConfig } from '@yavin/client/config/datasources';
+import { Injector, setInjector } from '@yavin/client/models/native-with-create';
+import { DataSourcePluginConfig } from '@yavin/client/config/datasource-plugins';
+import FiliFactsAdapter from '@yavin/client/plugins/fili/adapters/facts';
+import FiliFactsSerializer from '@yavin/client/plugins/fili/serializers/facts';
+import MetadataService from '@yavin/client/services/interfaces/metadata';
 
 const TestRequest: RequestV2 = {
   table: 'table1',
@@ -74,9 +78,12 @@ const Response: ResponseV1 = {
   },
 };
 
-const HOST = config.navi.dataSources[0].uri;
+const config = mockConfig();
+const HOST = config.dataSources[0].uri;
+let FactsService: NaviFactsService;
+let injector: Injector;
 
-function assertRequest(context: TestContext, callback: (request: RequestV2, options?: RequestOptions) => void) {
+function assertRequest(callback: (request: RequestV2, options?: RequestOptions) => void) {
   class TestService extends NaviFactsService {
     //@ts-expect-error - override base fetch method
     *fetchTask(request: RequestV2, options?: RequestOptions) {
@@ -84,52 +91,66 @@ function assertRequest(context: TestContext, callback: (request: RequestV2, opti
       return null;
     }
   }
-  context.owner.unregister('service:navi-facts');
-  context.owner.register('service:navi-facts', TestService);
+  return new TestService(injector);
 }
 
-module('Unit | Service | Navi Facts', function (hooks) {
-  setupTest(hooks);
+module('Unit | Service | Fact', function (hooks) {
+  setupServer(hooks);
 
-  hooks.beforeEach(function (this: TestContext) {
-    //setup Pretender
-    Server = new Pretender(function () {
-      this.get(`${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=id/`, function (request) {
-        if (request.queryParams.page && request.queryParams.perPage) {
-          return [
-            200,
-            { 'Content-Type': 'application/json' },
-            JSON.stringify({
+  hooks.beforeEach(function (this: WithServer) {
+    this.server.use(
+      rest.get(`${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=id/`, (req, res, ctx) => {
+        const queryParams = new URL(req.url).searchParams;
+        const page = queryParams.get('page');
+        const perPage = queryParams.get('perPage');
+        if (page && perPage) {
+          return res(
+            ctx.json({
               rows: [],
               meta: {
                 paginated: {
-                  page: request.queryParams.page,
-                  perPage: request.queryParams.perPage,
+                  page,
+                  perPage,
                 },
               },
-            }),
-          ];
+            })
+          );
         } else {
-          return [200, { 'Content-Type': 'application/json' }, JSON.stringify(Response)];
+          return res(ctx.json(Response));
         }
-      });
-    });
-  });
+      })
+    );
 
-  hooks.afterEach(function () {
-    //shutdown pretender
-    Server.shutdown();
+    FactsService = new NaviFactsService(nullInjector);
+    injector = Mock()
+      .config(new ClientConfig(config))
+      .decorator({ applyGlobalDecorators: (request) => request })
+      .facts(FactsService)
+      .meta({ getById: () => null } as unknown as MetadataService)
+      .plugin(
+        (injector) =>
+          new DataSourcePluginConfig(injector, {
+            //@ts-expect-error - only fact config
+            bard: {
+              facts: {
+                adapter: (injector) => new FiliFactsAdapter(injector),
+                serializer: (injector) => new FiliFactsSerializer(injector),
+              },
+            },
+          })
+      )
+      .build();
+
+    setInjector(FactsService, injector);
   });
 
   test('Service Exists', function (assert) {
-    const service: NaviFactsService = this.owner.lookup('service:navi-facts');
-    assert.ok(!!service, 'Service exists');
+    assert.ok(!!FactsService, 'Service exists');
   });
 
   test('getURL', function (assert) {
-    const service: NaviFactsService = this.owner.lookup('service:navi-facts');
     assert.deepEqual(
-      service.getURL(TestRequest),
+      FactsService.getURL(TestRequest),
       `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=id/?` +
         'dateTime=2015-01-03%2F2015-01-04T00%3A00%3A00.000&metrics=m1%2Cm2&' +
         'filters=d3%7Cid-in%5B%22v1%22%2C%22v2%22%5D%2Cd4%7Cid-in%5B%22v3%22%2C%22v4%22%5D&having=m1-gt%5B0%5D&' +
@@ -138,7 +159,7 @@ module('Unit | Service | Navi Facts', function (hooks) {
     );
 
     assert.deepEqual(
-      service.getURL(TestRequest, { format: 'jsonApi' }),
+      FactsService.getURL(TestRequest, { format: 'jsonApi' }),
       `${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=id/?` +
         'dateTime=2015-01-03%2F2015-01-04T00%3A00%3A00.000&metrics=m1%2Cm2&' +
         'filters=d3%7Cid-in%5B%22v1%22%2C%22v2%22%5D%2Cd4%7Cid-in%5B%22v3%22%2C%22v4%22%5D&having=m1-gt%5B0%5D&' +
@@ -148,8 +169,7 @@ module('Unit | Service | Navi Facts', function (hooks) {
   });
 
   test('fetch', async function (assert) {
-    const service: NaviFactsService = this.owner.lookup('service:navi-facts');
-    const model = await service.fetch(TestRequest);
+    const model = await FactsService.fetch(TestRequest);
     const { rows, meta } = model.response as NaviFactResponse;
     assert.deepEqual(
       { rows, meta },
@@ -174,14 +194,13 @@ module('Unit | Service | Navi Facts', function (hooks) {
 
     assert.deepEqual(
       model['factService'],
-      service,
+      FactsService,
       'Fetch returns a navi response model object with the service instance'
     );
   });
 
   test('fetch with pagination', async function (assert) {
-    const service: NaviFactsService = this.owner.lookup('service:navi-facts');
-    const model = await service.fetch(TestRequest, { page: 2, perPage: 10 });
+    const model = await FactsService.fetch(TestRequest, { page: 2, perPage: 10 });
     const { rows, meta } = model.response as NaviFactResponse;
     assert.deepEqual(
       { rows, meta },
@@ -198,22 +217,22 @@ module('Unit | Service | Navi Facts', function (hooks) {
     );
   });
 
-  test('fetch and catch error', async function (assert) {
+  test('fetch and catch error', async function (this: WithServer, assert) {
     assert.expect(6);
 
-    const service: NaviFactsService = this.owner.lookup('service:navi-facts');
     // Return an error object
-    Server.get(`${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=id/`, () => {
-      return [
-        507,
-        { 'Content-Type': 'application/json' },
-        JSON.stringify({
-          description: 'Result set too large. Try reducing interval or dimensions.',
-        }),
-      ];
-    });
+    this.server.use(
+      rest.get(`${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=id/`, (_req, res, ctx) => {
+        return res(
+          ctx.status(507),
+          ctx.json({
+            description: 'Result set too large. Try reducing interval or dimensions.',
+          })
+        );
+      })
+    );
 
-    await service.fetch(TestRequest).catch((response: NaviAdapterError) => {
+    await FactsService.fetch(TestRequest).catch((response: NaviAdapterError) => {
       assert.ok(true, 'A request error falls into the promise catch block');
       assert.equal(
         response.details[0],
@@ -223,16 +242,18 @@ module('Unit | Service | Navi Facts', function (hooks) {
     });
 
     // Return an error string
-    Server.get(`${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=id/`, () => {
-      return [500, { 'Content-Type': 'text/plain' }, 'Server Error'];
-    });
+    this.server.use(
+      rest.get(`${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=id/`, (req, res, ctx) => {
+        return res(ctx.status(500), ctx.text('Server Error'));
+      })
+    );
 
-    await service.fetch(TestRequest).catch((response: NaviAdapterError) => {
+    await FactsService.fetch(TestRequest).catch((response: NaviAdapterError) => {
       assert.ok(true, 'A request error falls into the promise catch block');
       assert.equal(response.details[0], 'Server Error', 'String error extracted');
     });
 
-    await service.fetch({ ...TestRequest, filters: [] }).catch((response: NaviAdapterError) => {
+    await FactsService.fetch({ ...TestRequest, filters: [] }).catch((response: NaviAdapterError) => {
       assert.ok(true, 'A request error falls into the promise catch block');
       assert.equal(
         response.details[0],
@@ -245,12 +266,11 @@ module('Unit | Service | Navi Facts', function (hooks) {
   test('fetchNext', async function (assert) {
     assert.expect(2);
 
-    assertRequest(this, (_request, options) => {
+    const service = assertRequest((_request, options) => {
       assert.equal(options?.page, 3, 'fetchNext calls fetch with updated options');
     });
-    const service: NaviFactsService = this.owner.lookup('service:navi-facts');
 
-    const response = new NaviFactResponse(this.owner.lookup('service:client-injector'), {
+    const response = new NaviFactResponse(nullInjector, {
       rows: [],
       meta: {
         pagination: {
@@ -276,12 +296,11 @@ module('Unit | Service | Navi Facts', function (hooks) {
   test('fetchPrevious', async function (assert) {
     assert.expect(2);
 
-    assertRequest(this, (_request, options) => {
+    const service = assertRequest((_request, options) => {
       assert.equal(options?.page, 1, 'fetchPrevious calls fetch with updated options');
     });
-    const service: NaviFactsService = this.owner.lookup('service:navi-facts');
 
-    const response = new NaviFactResponse(this.owner.lookup('service:client-injector'), {
+    const response = new NaviFactResponse(nullInjector, {
       rows: [],
       meta: {
         pagination: {

--- a/packages/client/test/tests/unit/services/fact-test.ts
+++ b/packages/client/test/tests/unit/services/fact-test.ts
@@ -243,7 +243,7 @@ module('Unit | Service | Fact', function (hooks) {
 
     // Return an error string
     this.server.use(
-      rest.get(`${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=id/`, (req, res, ctx) => {
+      rest.get(`${HOST}/v1/data/table1/grain1/d1;show=id/d2;show=id/`, (_req, res, ctx) => {
         return res(ctx.status(500), ctx.text('Server Error'));
       })
     );

--- a/packages/data/addon/adapters/facts/bard.ts
+++ b/packages/data/addon/adapters/facts/bard.ts
@@ -10,6 +10,7 @@ import { getOwner } from '@ember/application';
 export default class NaviFiliFactsAdapter extends FiliFactsAdapter {
   static create(args: unknown) {
     const owner = getOwner(args);
-    return new NaviFiliFactsAdapter(owner.lookup('service:client-injector'));
+    const yavinClient = owner.lookup('service:yavin-client');
+    return new this(yavinClient.injector);
   }
 }

--- a/packages/data/addon/serializers/facts/bard.ts
+++ b/packages/data/addon/serializers/facts/bard.ts
@@ -11,6 +11,7 @@ import { getOwner } from '@ember/application';
 export default class NaviFiliFactsSerializer extends FiliFactsSerializer {
   static create(args: unknown) {
     const owner = getOwner(args);
-    return new NaviFiliFactsSerializer(owner.lookup('service:client-injector'));
+    const yavinClient = owner.lookup('service:yavin-client');
+    return new this(yavinClient.injector);
   }
 }

--- a/packages/data/addon/services/navi-facts.ts
+++ b/packages/data/addon/services/navi-facts.ts
@@ -4,147 +4,47 @@
  *
  * Description: Navi facts service that executes and delivers the results
  */
-import Service from '@ember/service';
-import { inject as service } from '@ember/service';
 import { getOwner } from '@ember/application';
-import { assert } from '@ember/debug';
-import NaviFactsModel from '@yavin/client/models/navi-facts';
-import { task } from 'ember-concurrency';
-import { taskFor } from 'ember-concurrency-ts';
-import { waitFor } from '@ember/test-waiters';
-import type { TaskGenerator } from 'ember-concurrency';
-import type NaviFactAdapter from '@yavin/client/adapters/facts/interface';
+import { waitForPromise } from '@ember/test-waiters';
 import type { RequestOptions } from '@yavin/client/adapters/facts/interface';
 import type { RequestV2 } from '@yavin/client/request';
-import type NaviFactSerializer from '@yavin/client/serializers/facts/interface';
 import NaviFactResponse from '@yavin/client/models/navi-fact-response';
-import type FactService from '@yavin/client/services/interfaces/fact';
-import type YavinClientService from 'navi-data/services/yavin-client';
+import { maybeHalt } from '@yavin/client/utils/task';
+import FactService from '@yavin/client/services/fact';
+import { task, TaskGenerator } from 'ember-concurrency';
+import { taskFor } from 'ember-concurrency-ts';
+import type NaviFacts from '@yavin/client/models/navi-facts';
 
-export default class NaviFactsService extends Service implements FactService {
-  @service
-  declare yavinClient: YavinClientService;
-
-  /**
-   * @param dataSourceName
-   * @returns adapter instance for dataSource
-   */
-  _adapterFor(dataSourceName: string): NaviFactAdapter {
-    return this.yavinClient.pluginConfig.adapterFor(dataSourceName, 'facts');
-  }
-
-  /**
-   * @param dataSourceName
-   * @returns serializer instance for dataSource
-   */
-  _serializerFor(dataSourceName: string): NaviFactSerializer {
-    return this.yavinClient.pluginConfig.serializerFor(dataSourceName, 'facts');
-  }
-
-  /**
-   * Uses the adapter to get the bard query url for the request
-   * @param request - request object
-   * @param options - options object
-   * @returns url for the request
-   */
-  getURL(request: RequestV2, options: RequestOptions = {}) {
-    const adapter = this._adapterFor(request.dataSource);
-    let query;
-    try {
-      query = adapter.urlForFindQuery(request, options);
-    } catch (e) {
-      // nothing to do
-    }
-    return query;
-  }
-
+export default class NaviFactsService extends FactService {
   getDownloadURL(request: RequestV2, options: RequestOptions) {
-    return taskFor(this.getDownloadURLTask).perform(request, options);
+    return taskFor(this.taskWrapper).perform(() => super.getDownloadURL(request, options)) as Promise<string>;
   }
 
-  @waitFor
   fetch(request: RequestV2, options: RequestOptions = {}) {
-    return taskFor(this.fetchTask).perform(request, options);
+    return taskFor(this.taskWrapper).perform(() => super.fetch(request, options)) as Promise<NaviFacts>;
   }
 
-  @waitFor
   fetchNext(response: NaviFactResponse, request: RequestV2) {
-    return taskFor(this.fetchNextTask).perform(response, request);
+    return taskFor(this.taskWrapper).perform(() => super.fetchNext(response, request)) as Promise<NaviFacts | null>;
   }
 
-  @waitFor
   fetchPrevious(response: NaviFactResponse, request: RequestV2) {
-    return taskFor(this.fetchPreviousTask).perform(response, request);
+    return taskFor(this.taskWrapper).perform(() => super.fetchPrevious(response, request)) as Promise<NaviFacts | null>;
   }
 
-  /**
-   * Uses the adapter to get the download query url for the request
-   * @param request - request object
-   * @param options - options object
-   * @returns - url for the request
-   */
-  @task *getDownloadURLTask(request: RequestV2, options: RequestOptions): TaskGenerator<string> {
-    const adapter = this._adapterFor(request.dataSource);
-    return yield adapter.urlForDownloadQuery(request, options);
-  }
-
-  /**
-   * Returns the response model for the request
-   * @param request - request object
-   * @param options - options object
-   * @returns - Promise with the bard response model object
-   */
-  @task *fetchTask(request: RequestV2, options: RequestOptions = {}): TaskGenerator<NaviFactsModel> {
-    const adapter = this._adapterFor(request.dataSource);
-    const serializer = this._serializerFor(request.dataSource);
-
+  @task *taskWrapper<T>(taskLike: () => Promise<T>): TaskGenerator<T> {
+    const result = taskLike();
     try {
-      const payload: unknown = yield adapter.fetchDataForRequest(request, options);
-      const response = serializer.normalize(payload, request, options);
-      assert('The response is defined', response);
-      return new NaviFactsModel(getOwner(this).lookup('service:client-injector'), { request, response });
-    } catch (e) {
-      const errorModel: Error = serializer.extractError(e, request, options);
-      throw errorModel;
+      return yield waitForPromise(result);
+    } finally {
+      maybeHalt(result);
     }
   }
 
-  /**
-   * @param response
-   * @param request
-   * @return returns the promise with the next set of results or null
-   */
-  @task *fetchNextTask(response: NaviFactResponse, request: RequestV2): TaskGenerator<NaviFactsModel | null> {
-    if (response.meta.pagination) {
-      const { rowsPerPage, numberOfResults, currentPage } = response.meta.pagination;
-      const totalPages = numberOfResults / rowsPerPage;
-
-      if (currentPage < totalPages) {
-        return yield taskFor(this.fetchTask).perform(request, {
-          page: currentPage + 1,
-          perPage: rowsPerPage,
-        });
-      }
-    }
-    return null;
-  }
-
-  /**
-   * @param response
-   * @param request
-   * @return returns the promise with the previous set of results or null
-   */
-  @task *fetchPreviousTask(response: NaviFactResponse, request: RequestV2): TaskGenerator<NaviFactsModel | null> {
-    if (response.meta.pagination) {
-      const { rowsPerPage, currentPage } = response.meta.pagination;
-      if (currentPage > 1) {
-        return yield taskFor(this.fetchTask).perform(request, {
-          page: currentPage - 1,
-          perPage: rowsPerPage,
-        });
-      }
-    }
-    return null;
+  static create(args: unknown) {
+    const owner = getOwner(args);
+    const yavinClient = owner.lookup('service:yavin-client');
+    return new this(yavinClient.injector);
   }
 }
 

--- a/packages/data/addon/services/yavin-client.ts
+++ b/packages/data/addon/services/yavin-client.ts
@@ -6,6 +6,7 @@ import Service from '@ember/service';
 import { getOwner } from '@ember/application';
 import { Client } from '@yavin/client';
 import config from 'ember-get-config';
+import { getInjector } from '@yavin/client/models/native-with-create';
 import type NaviMetadataAdapter from '@yavin/client/adapters/metadata/interface';
 import type MetadataSerializer from '@yavin/client/serializers/metadata/interface';
 import type NaviFactAdapter from '@yavin/client/adapters/facts/interface';
@@ -73,6 +74,10 @@ export default class YavinClientService extends Service {
   }
   get pluginConfig() {
     return this.#client.pluginConfig;
+  }
+
+  get injector() {
+    return getInjector(this.#client);
   }
 }
 

--- a/packages/data/tests/unit/services/navi-facts-test.ts
+++ b/packages/data/tests/unit/services/navi-facts-test.ts
@@ -9,8 +9,6 @@ import { TestContext } from 'ember-test-helpers';
 import { ResponseV1 } from '@yavin/client/serializers/facts/interface';
 import NaviFactResponse from '@yavin/client/models/navi-fact-response';
 import NaviAdapterError from '@yavin/client/errors/navi-adapter-error';
-import { task, TaskGenerator } from 'ember-concurrency';
-import type NaviFacts from '@yavin/client/models/navi-facts';
 
 let Server: PretenderServer;
 
@@ -80,9 +78,10 @@ const HOST = config.navi.dataSources[0].uri;
 
 function assertRequest(context: TestContext, callback: (request: RequestV2, options?: RequestOptions) => void) {
   class TestService extends NaviFactsService {
-    @task *fetchTask(request: RequestV2, options?: RequestOptions): TaskGenerator<NaviFacts> {
-      callback(request, options);
-      return yield;
+    //@ts-expect-error - override base fetch method
+    *fetchTask(request: RequestV2, options?: RequestOptions) {
+      yield Promise.resolve(callback(request, options));
+      return null;
     }
   }
   context.owner.unregister('service:navi-facts');


### PR DESCRIPTION
## Description
Moves the fact service to the client package. We currently do not do any cancellation for fact queries from the UI, so we should refactor that later, but I've verified by adding a delay and calling `cancel()` on the task wrapper instance that it cascades down properly

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.