### PR TITLE
Update: Move metadata service to client

### DIFF
--- a/packages/client/src/services/metadata.ts
+++ b/packages/client/src/services/metadata.ts
@@ -1,0 +1,187 @@
+/**
+ * Copyright 2022, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import NaviMetadataSerializer, {
+  EverythingMetadataPayload,
+  MetadataModelMap,
+} from '../serializers/metadata/interface.js';
+import NativeWithCreate, { Config } from '../models/native-with-create.js';
+import Keg from '../utils/classes/keg.js';
+import type MetadataModelRegistry from '../models/metadata/registry.js';
+import type NaviMetadataAdapter from '../adapters/metadata/interface.js';
+import type { ClientConfig, DataSourceConfig } from '../config/datasources.js';
+import type { RequestOptions } from '../adapters/facts/interface.js';
+import type MetadataServiceInterface from '../services/interfaces/metadata.js';
+import type { DataSourcePluginConfig } from '../config/datasource-plugins.js';
+import invariant from 'tiny-invariant';
+
+export type MetadataModelTypes = keyof MetadataModelRegistry;
+
+export default class MetadataService extends NativeWithCreate implements MetadataServiceInterface {
+  @Config('plugin')
+  declare pluginConfig: DataSourcePluginConfig;
+
+  @Config('client')
+  declare clientConfig: ClientConfig;
+
+  /**
+   * TODO: define keg registry types to remove casting in this class
+   */
+  private keg = new Keg();
+
+  /**
+   * @property {Array} loadedDataSources - list of data sources in which meta data has already been loaded
+   */
+  loadedDataSources: Set<string> = new Set();
+
+  private loadMetadataPromises: Record<string, Promise<void>> = {};
+
+  /**
+   * @param dataSourceName
+   * @returns  adapter instance for dataSource
+   */
+  private adapterFor(dataSourceName: string): NaviMetadataAdapter {
+    return this.pluginConfig.adapterFor(dataSourceName, 'metadata');
+  }
+
+  /**
+   * @param dataSourceName
+   * @returns serializer instance for dataSource
+   */
+  private serializerFor(dataSourceName: string): NaviMetadataSerializer {
+    return this.pluginConfig.serializerFor(dataSourceName, 'metadata');
+  }
+
+  private dataSourceFor(dataSourceName?: string): DataSourceConfig {
+    const { clientConfig } = this;
+    return dataSourceName ? clientConfig.getDataSource(dataSourceName) : clientConfig.getDefaultDataSource();
+  }
+
+  /**
+   * @param payload
+   * @param dataSourceName
+   */
+  private loadEverythingMetadataIntoKeg(payload: EverythingMetadataPayload, dataSourceName: string) {
+    this.loadMetadataForType('table', payload.tables, dataSourceName);
+    this.loadMetadataForType('metric', payload.metrics, dataSourceName);
+    this.loadMetadataForType('dimension', payload.dimensions, dataSourceName);
+    this.loadMetadataForType('timeDimension', payload.timeDimensions, dataSourceName);
+    this.loadMetadataForType('columnFunction', payload.columnFunctions || [], dataSourceName);
+    this.loadMetadataForType('requestConstraint', payload.requestConstraints, dataSourceName);
+    this.loadedDataSources.add(dataSourceName);
+  }
+
+  /**
+   * Loads metadata based on type
+   * @param type - type of metadata, table, dimension, or metric
+   * @param metadataObjects - array of metadata objects
+   */
+  private loadMetadataForType<K extends keyof MetadataModelRegistry>(
+    type: K,
+    metadataObjects: MetadataModelMap[K],
+    dataSourceName: string
+  ): Array<MetadataModelRegistry[K]> {
+    return this.keg.insertMany(`metadata/${type}`, metadataObjects, {
+      namespace: dataSourceName,
+    }) as Array<MetadataModelRegistry[K]>;
+  }
+
+  private async loadAndProcessMetadata(dataSourceName: string, options: RequestOptions): Promise<void> {
+    const payload = await this.adapterFor(dataSourceName).fetchEverything(options);
+    const normalized = this.serializerFor(dataSourceName).normalize('everything', payload, dataSourceName);
+    if (normalized) {
+      this.loadEverythingMetadataIntoKeg(normalized, dataSourceName);
+    }
+  }
+
+  loadMetadata(options: RequestOptions = {}): Promise<void> {
+    const { name: dataSourceName } = this.dataSourceFor(options.dataSourceName);
+    const existingPromise = this.loadMetadataPromises[dataSourceName];
+
+    if (existingPromise) {
+      return existingPromise;
+    }
+
+    const newPromise = this.loadAndProcessMetadata(dataSourceName, options);
+
+    //cache promise so we don't execute multiple load fetches
+    this.loadMetadataPromises[dataSourceName] = newPromise;
+
+    //if load fails remove from cache so we can retry
+    newPromise.catch(() => delete this.loadMetadataPromises[dataSourceName]);
+
+    return newPromise;
+  }
+
+  /**
+   * Provides an array of all loaded models for a given type
+   * @param type - model type
+   * @param dataSourceName - optional name of data source
+   */
+  all<K extends keyof MetadataModelRegistry>(type: K, dataSourceName?: string): Array<MetadataModelRegistry[K]> {
+    invariant(
+      !dataSourceName || this.loadedDataSources.has(dataSourceName),
+      `Metadata must have the requested data source loaded: ${dataSourceName}`
+    );
+    return this.keg.all(`metadata/${type}`, dataSourceName) as Array<MetadataModelRegistry[K]>;
+  }
+
+  /**
+   * Provides a single loaded model instance given an identifier
+   * @param type - model type
+   * @param id - identifier value of model
+   * @param dataSourceName - name of data source
+   */
+  getById<K extends keyof MetadataModelRegistry>(
+    type: K,
+    id: string,
+    dataSourceName: string
+  ): MetadataModelRegistry[K] | undefined {
+    invariant(dataSourceName, '`dataSourceName` argument required');
+    return this.keg.getById(`metadata/${type}`, id, dataSourceName) as MetadataModelRegistry[K];
+  }
+
+  /**
+   * Fetches from data source a single model instance given an identifier
+   * @param type - model type
+   * @param id - identifier value of model
+   * @param dataSourceName - name of data source
+   */
+  async fetchById<K extends keyof MetadataModelRegistry>(
+    type: K,
+    id: string,
+    dataSourceName: string
+  ): Promise<MetadataModelRegistry[K] | undefined> {
+    invariant(dataSourceName, '`dataSourceName` argument required');
+    const rawPayload = await this.adapterFor(dataSourceName).fetchById(type, id, { dataSourceName });
+    const normalized = rawPayload
+      ? this.serializerFor(dataSourceName).normalize(type, rawPayload, dataSourceName)
+      : undefined;
+
+    if (normalized) {
+      const model = this.loadMetadataForType(type, normalized, dataSourceName);
+      return model[0];
+    }
+    return undefined;
+  }
+
+  /**
+   * Provides a single loaded model instance or fetches one, given an identifier
+   * @param type - model type
+   * @param id - identifier value of model
+   * @param dataSourceName - name of data source
+   */
+  findById<K extends keyof MetadataModelRegistry>(
+    type: K,
+    id: string,
+    dataSourceName: string
+  ): Promise<MetadataModelRegistry[K] | undefined> {
+    invariant(dataSourceName, '`dataSourceName` argument required');
+    const kegRecord = this.keg.getById(`metadata/${type}`, id, dataSourceName);
+    if (kegRecord && !kegRecord.partialData) {
+      return Promise.resolve(this.getById(type, id, dataSourceName)) as Promise<MetadataModelRegistry[K]>;
+    }
+    return this.fetchById(type, id, dataSourceName);
+  }
+}

--- a/packages/data/addon/services/navi-facts.ts
+++ b/packages/data/addon/services/navi-facts.ts
@@ -35,9 +35,10 @@ export default class NaviFactsService extends FactService {
   @task *taskWrapper<T>(taskLike: () => Promise<T>): TaskGenerator<T> {
     const result = taskLike();
     try {
-      return yield waitForPromise(result);
+      // Wrap promise value since waitForPromise assumes they are unique
+      return yield waitForPromise(result.then((v) => Promise.resolve(v)));
     } finally {
-      maybeHalt(result);
+      yield waitForPromise(maybeHalt(result));
     }
   }
 

--- a/packages/data/addon/services/navi-facts.ts
+++ b/packages/data/addon/services/navi-facts.ts
@@ -35,7 +35,10 @@ export default class NaviFactsService extends FactService {
   @task *taskWrapper<T>(taskLike: () => Promise<T>): TaskGenerator<T> {
     const result = taskLike();
     try {
-      // Wrap promise value since waitForPromise assumes they are unique
+      /**
+       * Wrap promise because waitForPromise assumes they are unique
+       * and services might cache and return the same promise
+       */
       return yield waitForPromise(result.then((v) => Promise.resolve(v)));
     } finally {
       yield waitForPromise(maybeHalt(result));

--- a/packages/data/addon/services/navi-metadata.ts
+++ b/packages/data/addon/services/navi-metadata.ts
@@ -41,7 +41,10 @@ export default class NaviMetadataService extends MetadataService {
   @task *taskWrapper<T>(taskLike: () => Promise<T>): TaskGenerator<T> {
     const result = taskLike();
     try {
-      // Wrap promise value since waitForPromise assumes they are unique
+      /**
+       * Wrap promise because waitForPromise assumes they are unique
+       * and services might cache and return the same promise
+       */
       return yield waitForPromise(result.then((v) => Promise.resolve(v)));
     } finally {
       yield waitForPromise(maybeHalt(result));

--- a/packages/data/addon/services/navi-metadata.ts
+++ b/packages/data/addon/services/navi-metadata.ts
@@ -41,9 +41,10 @@ export default class NaviMetadataService extends MetadataService {
   @task *taskWrapper<T>(taskLike: () => Promise<T>): TaskGenerator<T> {
     const result = taskLike();
     try {
-      return yield waitForPromise(result);
+      // Wrap promise value since waitForPromise assumes they are unique
+      return yield waitForPromise(result.then((v) => Promise.resolve(v)));
     } finally {
-      maybeHalt(result);
+      yield waitForPromise(maybeHalt(result));
     }
   }
 

--- a/packages/data/addon/services/navi-metadata.ts
+++ b/packages/data/addon/services/navi-metadata.ts
@@ -2,189 +2,55 @@
  * Copyright 2020, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
-import Service from '@ember/service';
-import { inject as service } from '@ember/service';
-import { assert } from '@ember/debug';
-import NaviMetadataSerializer, {
-  EverythingMetadataPayload,
-  MetadataModelMap,
-} from '@yavin/client/serializers/metadata/interface';
-import { waitFor } from '@ember/test-waiters';
-import Keg from '@yavin/client/utils/classes/keg';
+import { getOwner } from '@ember/application';
+import { waitForPromise } from '@ember/test-waiters';
 import type MetadataModelRegistry from '@yavin/client/models/metadata/registry';
-import type NaviMetadataAdapter from '@yavin/client/adapters/metadata/interface';
-import type { DataSourceConfig } from '@yavin/client/config/datasources';
 import type { RequestOptions } from '@yavin/client/adapters/facts/interface';
-import type MetadataService from '@yavin/client/services/interfaces/metadata';
-import type YavinClientService from 'navi-data/services/yavin-client';
+import MetadataService from '@yavin/client/services/metadata';
+import { task, TaskGenerator } from 'ember-concurrency';
+import { maybeHalt } from '@yavin/client/utils/task';
+import { taskFor } from 'ember-concurrency-ts';
 
 export type MetadataModelTypes = keyof MetadataModelRegistry;
 
-export default class NaviMetadataService extends Service implements MetadataService {
-  @service
-  declare yavinClient: YavinClientService;
-
-  /**
-   * TODO: define keg registry types to remove casting in this class
-   */
-  private keg = new Keg();
-
-  /**
-   * @property {Array} loadedDataSources - list of data sources in which meta data has already been loaded
-   */
-  loadedDataSources: Set<string> = new Set();
-
-  private loadMetadataPromises: Record<string, Promise<void>> = {};
-
-  /**
-   * @param dataSourceName
-   * @returns  adapter instance for dataSource
-   */
-  private adapterFor(dataSourceName: string): NaviMetadataAdapter {
-    return this.yavinClient.pluginConfig.adapterFor(dataSourceName, 'metadata');
-  }
-
-  /**
-   * @param dataSourceName
-   * @returns serializer instance for dataSource
-   */
-  private serializerFor(dataSourceName: string): NaviMetadataSerializer {
-    return this.yavinClient.pluginConfig.serializerFor(dataSourceName, 'metadata');
-  }
-
-  private dataSourceFor(dataSourceName?: string): DataSourceConfig {
-    const { clientConfig } = this.yavinClient;
-    return dataSourceName ? clientConfig.getDataSource(dataSourceName) : clientConfig.getDefaultDataSource();
-  }
-
-  /**
-   * @param payload
-   * @param dataSourceName
-   */
-  private loadEverythingMetadataIntoKeg(payload: EverythingMetadataPayload, dataSourceName: string) {
-    this.loadMetadataForType('table', payload.tables, dataSourceName);
-    this.loadMetadataForType('metric', payload.metrics, dataSourceName);
-    this.loadMetadataForType('dimension', payload.dimensions, dataSourceName);
-    this.loadMetadataForType('timeDimension', payload.timeDimensions, dataSourceName);
-    this.loadMetadataForType('columnFunction', payload.columnFunctions || [], dataSourceName);
-    this.loadMetadataForType('requestConstraint', payload.requestConstraints, dataSourceName);
-    this.loadedDataSources.add(dataSourceName);
-  }
-
-  /**
-   * Loads metadata based on type
-   * @param type - type of metadata, table, dimension, or metric
-   * @param metadataObjects - array of metadata objects
-   */
-  private loadMetadataForType<K extends keyof MetadataModelRegistry>(
-    type: K,
-    metadataObjects: MetadataModelMap[K],
-    dataSourceName: string
-  ): Array<MetadataModelRegistry[K]> {
-    return this.keg.insertMany(`metadata/${type}`, metadataObjects, {
-      namespace: dataSourceName,
-    }) as Array<MetadataModelRegistry[K]>;
-  }
-
-  private async loadAndProcessMetadata(dataSourceName: string, options: RequestOptions): Promise<void> {
-    const payload = await this.adapterFor(dataSourceName).fetchEverything(options);
-    const normalized = this.serializerFor(dataSourceName).normalize('everything', payload, dataSourceName);
-    if (normalized) {
-      this.loadEverythingMetadataIntoKeg(normalized, dataSourceName);
-    }
-  }
-
-  @waitFor
+export default class NaviMetadataService extends MetadataService {
   loadMetadata(options: RequestOptions = {}): Promise<void> {
-    const { name: dataSourceName } = this.dataSourceFor(options.dataSourceName);
-    const existingPromise = this.loadMetadataPromises[dataSourceName];
-
-    if (existingPromise) {
-      return existingPromise;
-    }
-
-    const newPromise = this.loadAndProcessMetadata(dataSourceName, options);
-
-    //cache promise so we don't execute multiple load fetches
-    this.loadMetadataPromises[dataSourceName] = newPromise;
-
-    //if load fails remove from cache so we can retry
-    newPromise.catch(() => delete this.loadMetadataPromises[dataSourceName]);
-
-    return newPromise;
+    return taskFor(this.taskWrapper).perform(() => super.loadMetadata(options)) as Promise<void>;
   }
 
-  /**
-   * Provides an array of all loaded models for a given type
-   * @param type - model type
-   * @param dataSourceName - optional name of data source
-   */
-  all<K extends keyof MetadataModelRegistry>(type: K, dataSourceName?: string): Array<MetadataModelRegistry[K]> {
-    assert(
-      `Metadata must have the requested data source loaded: ${dataSourceName}`,
-      !dataSourceName || this.loadedDataSources.has(dataSourceName)
-    );
-    return this.keg.all(`metadata/${type}`, dataSourceName) as Array<MetadataModelRegistry[K]>;
-  }
-
-  /**
-   * Provides a single loaded model instance given an identifier
-   * @param type - model type
-   * @param id - identifier value of model
-   * @param dataSourceName - name of data source
-   */
-  getById<K extends keyof MetadataModelRegistry>(
-    type: K,
-    id: string,
-    dataSourceName: string
-  ): MetadataModelRegistry[K] | undefined {
-    assert('`dataSourceName` argument required', dataSourceName);
-    return this.keg.getById(`metadata/${type}`, id, dataSourceName) as MetadataModelRegistry[K];
-  }
-
-  /**
-   * Fetches from data source a single model instance given an identifier
-   * @param type - model type
-   * @param id - identifier value of model
-   * @param dataSourceName - name of data source
-   */
-  @waitFor
   async fetchById<K extends keyof MetadataModelRegistry>(
     type: K,
     id: string,
     dataSourceName: string
   ): Promise<MetadataModelRegistry[K] | undefined> {
-    assert('`dataSourceName` argument required', dataSourceName);
-    const rawPayload = await this.adapterFor(dataSourceName).fetchById(type, id, { dataSourceName });
-    const normalized = rawPayload
-      ? this.serializerFor(dataSourceName).normalize(type, rawPayload, dataSourceName)
-      : undefined;
-
-    if (normalized) {
-      const model = this.loadMetadataForType(type, normalized, dataSourceName);
-      return model[0];
-    }
-    return undefined;
+    return taskFor(this.taskWrapper).perform(() => super.fetchById(type, id, dataSourceName)) as Promise<
+      MetadataModelRegistry[K] | undefined
+    >;
   }
 
-  /**
-   * Provides a single loaded model instance or fetches one, given an identifier
-   * @param type - model type
-   * @param id - identifier value of model
-   * @param dataSourceName - name of data source
-   */
-  @waitFor
   findById<K extends keyof MetadataModelRegistry>(
     type: K,
     id: string,
     dataSourceName: string
   ): Promise<MetadataModelRegistry[K] | undefined> {
-    assert('`dataSourceName` argument required', dataSourceName);
-    const kegRecord = this.keg.getById(`metadata/${type}`, id, dataSourceName);
-    if (kegRecord && !kegRecord.partialData) {
-      return Promise.resolve(this.getById(type, id, dataSourceName)) as Promise<MetadataModelRegistry[K]>;
+    return taskFor(this.taskWrapper).perform(() => super.findById(type, id, dataSourceName)) as Promise<
+      MetadataModelRegistry[K] | undefined
+    >;
+  }
+
+  @task *taskWrapper<T>(taskLike: () => Promise<T>): TaskGenerator<T> {
+    const result = taskLike();
+    try {
+      return yield waitForPromise(result);
+    } finally {
+      maybeHalt(result);
     }
-    return this.fetchById(type, id, dataSourceName);
+  }
+
+  static create(args: unknown) {
+    const owner = getOwner(args);
+    const yavinClient = owner.lookup('service:yavin-client');
+    return new this(yavinClient.injector);
   }
 }
 


### PR DESCRIPTION
## Description
Moves the metadata service to client and adds an ember concurrency wrapper for test waiting/task cancelling (although the metadata service is promise based so it does not yet support it)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
