### PR TITLE
Fix: Print Dashboard Layout matches browser dash.

### DIFF
--- a/packages/dashboards/addon/templates/dashboards-print/dashboards/dashboard/view.hbs
+++ b/packages/dashboards/addon/templates/dashboards-print/dashboards/dashboard/view.hbs
@@ -8,7 +8,13 @@
         </div>
       </div>
     {{else if this.isGrid}}
-      <GridStack @options={{hash column=@width staticGrid=true}}>
+      <GridStack @options={{hash
+            column=@width
+            staticGrid=true
+            animate=false
+            marginTop=0
+            marginBottom=20
+            cellHeight="80px"}}>
         {{#each @model.dashboard.presentation.layout as |layout index|}}
           {{#with (get-widget layout.widgetId) as |widget|}}
             {{#if widget}}


### PR DESCRIPTION
## Description

Print dashboard layout didn't match layout view in other dashboards

## Proposed Changes

- match gridstack settings

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
