### PR TITLE
Fix: Empty widgets signal an error to tools.

### DIFF
--- a/packages/dashboards/addon/components/navi-widget.hbs
+++ b/packages/dashboards/addon/components/navi-widget.hbs
@@ -84,7 +84,7 @@
   {{#if @taskInstance.isSuccessful}}
     {{#let @model.visualization.manifest.visualizationComponent as |VisualizationComponent|}}
       {{#if this.hasNoData}}
-        <div class="navi-widget__content error-container">
+        <div class="navi-widget__content empty-container">
           No results available.
         </div>
       {{else}}

--- a/packages/dashboards/app/styles/navi-dashboards/common.scss
+++ b/packages/dashboards/app/styles/navi-dashboards/common.scss
@@ -6,7 +6,8 @@
 .navi-dashboard-collection-container,
 .navi-dashboard-container {
   .error-container,
-  .loader-container {
+  .loader-container,
+  .empty-container {
     align-items: center;
     border-radius: 2px;
     display: flex;

--- a/packages/dashboards/tests/integration/components/navi-widget-test.js
+++ b/packages/dashboards/tests/integration/components/navi-widget-test.js
@@ -216,7 +216,7 @@ module('Integration | Component | navi widget', function (hooks) {
     `);
 
     assert
-      .dom('.navi-widget__content.error-container')
+      .dom('.navi-widget__content.empty-container')
       .hasText('No results available.', 'visualization will not render without data');
   });
 


### PR DESCRIPTION
## Description

Our tools look for `error-container` in order to detect failed widgets. Empty widgets should not trigger this. So changing this to `empty-container`

## Proposed Changes

- `error-container` -> `empty-container` on widgets with no data.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
