### PR TITLE
Fix: Only update visualization metadata if there are changes

### DIFF
--- a/packages/dashboards/tests/acceptance/explore-widget-test.js
+++ b/packages/dashboards/tests/acceptance/explore-widget-test.js
@@ -105,6 +105,20 @@ module('Acceptance | Exploring Widgets', function (hooks) {
     assert.ok(currentURL().endsWith('/dashboards/1/widgets/2/view'), 'Explore action links to widget view route');
   });
 
+  test('Changing a widget visualization', async function (assert) {
+    assert.expect(1);
+
+    // Add a metric to widget 2, save, and return to dashboard route
+    await visit('/dashboards/1/widgets/2/view');
+
+    // Dimension series always attempt to rebuild, but the config should be the same
+    await clickItem('dimension', 'Age');
+
+    await click('.navi-report-widget__save-btn');
+
+    assert.dom('.navi-report-widget__save-btn').doesNotExist('Save widget button is hidden once widget is up to date');
+  });
+
   test('Changing and saving a widget', async function (assert) {
     assert.expect(4);
 

--- a/packages/reports/addon/routes/reports/report/view.ts
+++ b/packages/reports/addon/routes/reports/report/view.ts
@@ -5,7 +5,7 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { merge } from 'lodash-es';
+import { isEqual, merge } from 'lodash-es';
 import { reject } from 'rsvp';
 import { assert } from '@ember/debug';
 import { isForbidden } from 'navi-core/helpers/is-forbidden';
@@ -112,7 +112,9 @@ export default class ReportsReportViewRoute extends Route {
     const { manifest } = visualization;
 
     const newSettings = manifest.dataDidUpdate(report.visualization.metadata, request, response);
-    visualization.metadata = newSettings;
+    if (!isEqual(visualization.metadata, newSettings)) {
+      visualization.metadata = newSettings;
+    }
     report.updateVisualization(visualization);
   }
 


### PR DESCRIPTION
## Description
Dimension series always try to rebuild so in some situations after pressing save, even though the viz metadata is the same, the user is prompted to save their report/widget again

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
