### PR TITLE
Fix: Perspective should default timeDimensions to UTC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15437,30 +15437,28 @@
         "lines-and-columns": "^1.1.6"
       }
     },
+    "parse-path": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.3.tgz",
+      "integrity": "sha512-9Cepbp2asKnWTJ9x2kpw6Fe8y9JDbqwahGCTvklzd/cEq5C5JC59x2Xb0Kx+x0QZ8bvNquGO8/BWP0cwBHzSAA==",
+      "dev": true,
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "protocols": "^1.4.0",
+        "qs": "^6.9.4",
+        "query-string": "^6.13.8"
+      }
+    },
     "parse-url": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-6.0.2.tgz",
-      "integrity": "sha512-uCSjOvD3T+6B/sPWhR+QowAZcU/o4bjPrVBQBGFxcDF6J6FraCGIaDBsdoQawiaaAVdHvtqBe3w3vKlfBKySOQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-6.0.0.tgz",
+      "integrity": "sha512-cYyojeX7yIIwuJzledIHeLUBVJ6COVLeT4eF+2P6aKVzwvgKQPndCBv3+yQ7pcWjqToYwaligxzSYNNmGoMAvw==",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
         "normalize-url": "^6.1.0",
-        "parse-path": "^4.0.4",
+        "parse-path": "^4.0.0",
         "protocols": "^1.4.0"
-      },
-      "dependencies": {
-        "parse-path": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.4.tgz",
-          "integrity": "sha512-Z2lWUis7jlmXC1jeOG9giRO2+FsuyNipeQ43HAjqAZjwSe3SEf+q/84FGPHoso3kyntbxa4c4i77t3m6fGf8cw==",
-          "dev": true,
-          "requires": {
-            "is-ssh": "^1.3.0",
-            "protocols": "^1.4.0",
-            "qs": "^6.9.4",
-            "query-string": "^6.13.8"
-          }
-        }
       }
     },
     "path-exists": {

--- a/packages/perspective/addon/components/perspective.ts
+++ b/packages/perspective/addon/components/perspective.ts
@@ -3,28 +3,75 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import { action } from '@ember/object';
-import perspective, { Schema, TableData } from '@finos/perspective';
+import perspective, { TableData } from '@finos/perspective';
 import '@finos/perspective-viewer';
 import '@finos/perspective-viewer-datagrid';
 import '@finos/perspective-viewer-d3fc';
-import YavinVisualizationComponent from 'navi-core/visualization/component';
+import YavinVisualizationComponent, { YavinVisualizationArgs } from 'navi-core/visualization/component';
 import { PerspectiveSettings } from '../manifest';
-import { isEqual } from 'lodash-es';
+import { isEqual, merge } from 'lodash-es';
 import { task, TaskGenerator } from 'ember-concurrency';
-import type { HTMLPerspectiveViewerElement, PerspectiveViewerConfig } from '@finos/perspective-viewer';
+import type { HTMLPerspectiveViewerElement } from '@finos/perspective-viewer';
 import type { Grain } from '@yavin/client/utils/date';
+import ColumnFragment from 'navi-core/addon/models/request/column';
+import { shouldPolyfill as shouldPolyfillSupportedValues, supportedValuesOf } from '@formatjs/intl-enumerator';
+import '@formatjs/intl-datetimeformat/polyfill';
+import '@formatjs/intl-datetimeformat/locale-data/en'; // locale-data for en
+import '@formatjs/intl-datetimeformat/add-all-tz'; // Add ALL tz data
 
 const worker = perspective.shared_worker();
 
+const UTC_TZ = 'UTC';
+if (shouldPolyfillSupportedValues()) {
+  Object.defineProperty(Intl, 'supportedValuesOf', {
+    value: supportedValuesOf,
+    enumerable: true,
+    writable: true, // allow override to inject utc if needed
+    configurable: false,
+  });
+}
+
+const UTC_SUPPORTED = (function doesSupportUTC() {
+  const date = new Date();
+  const formatted = new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'long', timeZone: 'UTC' }).format(
+    date
+  );
+  return formatted.includes(UTC_TZ);
+})();
+
+function forceUTCSupport() {
+  const supportedValues = Intl.supportedValuesOf('timeZone');
+  if (supportedValues.includes(UTC_TZ)) {
+    // UTC is already supported
+    return;
+  }
+  if (UTC_SUPPORTED) {
+    const originalSupportedValuesOf = Intl.supportedValuesOf;
+    //@ts-expect-error - overriding
+    Intl.supportedValuesOf = function overrideSupportedValuesOf(type) {
+      const supportedValues = originalSupportedValuesOf.call(this, ...arguments);
+      if (type === 'timeZone') {
+        return [...supportedValues, UTC_TZ];
+      }
+      return supportedValues;
+    };
+  }
+}
+
 export default class PerspectiveVisualization extends YavinVisualizationComponent<PerspectiveSettings> {
   isLoaded = false;
+
+  constructor(owner: unknown, args: YavinVisualizationArgs<PerspectiveSettings>) {
+    super(owner, args);
+    forceUTCSupport();
+  }
 
   @task *handleConfigUpdate(e: { target: HTMLPerspectiveViewerElement }): TaskGenerator<void> {
     const configuration = yield e.target.save();
     this.saveSettings(configuration);
   }
 
-  saveSettings(configuration: PerspectiveViewerConfig): void {
+  saveSettings(configuration: PerspectiveSettings['configuration'] = {}): void {
     const {
       isLoaded,
       args: { settings, isReadOnly },
@@ -33,24 +80,6 @@ export default class PerspectiveVisualization extends YavinVisualizationComponen
     if (isLoaded && !isReadOnly && !isEqual(configuration, settings?.configuration)) {
       this.args.onUpdateSettings({ configuration });
     }
-  }
-
-  async makeSchema(): Promise<Schema> {
-    const { response, request } = this.args;
-    // load some table data to infer a schema
-    const data = response.rows.slice(0, 10) as TableData;
-    const table = await worker.table(data);
-    const defaultSchema = await table.schema();
-    await table.delete();
-
-    const isDayAligned = (grain: Grain) => !['hour', 'minute', 'second'].includes(grain);
-    const dayAlignedTimeDimensions = request.columns.filter(
-      (c) => c.type === 'timeDimension' && isDayAligned(c.parameters.grain as Grain)
-    );
-    // override day aligned time dimensions to explicitly be `date` instead of `datetime`
-    const schemaOverrides: Schema = Object.fromEntries(dayAlignedTimeDimensions.map((d) => [d.canonicalName, 'date']));
-
-    return { ...defaultSchema, ...schemaOverrides };
   }
 
   setupSettingsBtn(viewer: HTMLPerspectiveViewerElement) {
@@ -66,18 +95,58 @@ export default class PerspectiveVisualization extends YavinVisualizationComponen
   async loadData(viewer: HTMLPerspectiveViewerElement): Promise<void> {
     const { response } = this.args;
     const data = response.rows as TableData;
-    const schema = await this.makeSchema();
+    const table = await worker.table(data);
     this.setupSettingsBtn(viewer);
-    const table = await worker.table(schema);
-    table.update(data);
     await viewer.load(table);
+  }
+
+  async getDefaultSettings(): Promise<PerspectiveSettings> {
+    const isDayAligned = (grain: Grain) => !['hour', 'minute', 'second'].includes(grain);
+
+    const { request, settings } = this.args;
+    const currentPlugin = settings.configuration?.plugin;
+    if (currentPlugin !== undefined && currentPlugin !== 'Datagrid') {
+      return {};
+    }
+    const columnConfig = Object.fromEntries(
+      request.columns
+        .filter((c) => c.type === 'timeDimension')
+        .map((column: ColumnFragment<'timeDimension'>) => {
+          const currentSettings = settings.configuration?.plugin_config?.columns?.[column.canonicalName];
+          const colTimeZone = column.columnMetadata.timeZone;
+          const timeZone =
+            // Use column specified timeZone if available, then try UTC, and fallback to undefined
+            Intl.supportedValuesOf('timeZone').find((tz) => tz === colTimeZone) ?? (UTC_SUPPORTED ? UTC_TZ : undefined);
+          const columnSettings = isDayAligned(column.parameters.grain as Grain)
+            ? {
+                timeZone,
+                // if a timeZone is already specified, don't do anything else
+                ...(currentSettings?.timeZone ? {} : { timeStyle: 'disabled' }),
+              }
+            : { timeZone };
+          return [column.canonicalName, columnSettings];
+        })
+    );
+
+    return {
+      configuration: {
+        plugin_config: {
+          columns: {
+            ...columnConfig,
+          },
+        },
+      },
+    };
   }
 
   @action
   async loadSettings(viewer: HTMLPerspectiveViewerElement): Promise<void> {
     this.isLoaded = false;
     const { settings } = this.args;
-    await viewer.restore(settings?.configuration ?? {});
+
+    const defaults = await this.getDefaultSettings();
+    const settingsWithDefaults = merge(defaults, settings);
+    await viewer.restore(settingsWithDefaults?.configuration ?? {});
     const configuration = await viewer.save();
     this.isLoaded = true;
     this.saveSettings(configuration); //save just incase loaded settings changed

--- a/packages/perspective/addon/manifest.ts
+++ b/packages/perspective/addon/manifest.ts
@@ -3,9 +3,12 @@
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
-import type { PerspectiveViewerConfig } from '@finos/perspective-viewer';
+import type { IPerspectiveViewerElement } from '@finos/perspective-viewer';
+import { Resolved } from 'ember-concurrency';
 import { YavinVisualizationManifest } from 'navi-core/visualization/manifest';
 import PerspectiveVisualization from './components/perspective';
+
+type PerspectiveViewerConfig = Exclude<Resolved<ReturnType<IPerspectiveViewerElement['save']>>, string | ArrayBuffer>;
 
 export interface PerspectiveSettings {
   configuration?: PerspectiveViewerConfig;

--- a/packages/perspective/package-lock.json
+++ b/packages/perspective/package-lock.json
@@ -10,11 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "@denali-design/ember": "^1.0.0-alpha.34",
-        "@finos/perspective": "^1.5.0",
-        "@finos/perspective-viewer": "^1.5.0",
-        "@finos/perspective-viewer-d3fc": "^1.5.0",
-        "@finos/perspective-viewer-datagrid": "^1.5.0",
-        "@finos/perspective-webpack-plugin": "^1.5.0",
+        "@finos/perspective": "^1.6.3",
+        "@finos/perspective-viewer": "^1.6.3",
+        "@finos/perspective-viewer-d3fc": "^1.6.3",
+        "@finos/perspective-viewer-datagrid": "^1.6.3",
+        "@finos/perspective-webpack-plugin": "^1.6.3",
+        "@formatjs/intl-datetimeformat": "^6.0.3",
+        "@formatjs/intl-enumerator": "^1.1.1",
         "ember-auto-import": "^2.4.0",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^5.3.2",
@@ -77,6 +79,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-qunit": "^7.2.0",
         "loader.js": "^4.7.0",
+        "moment": "^2.29.4",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.6.0",
         "qunit": "^2.17.2",
@@ -87,6 +90,9 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "moment": "^2.29.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4282,9 +4288,9 @@
       }
     },
     "node_modules/@finos/perspective": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@finos/perspective/-/perspective-1.5.0.tgz",
-      "integrity": "sha512-g57dcsdwaHleFp2m7wyZSnEcc8FAigd7Gvw/l5+gwyeZugQpezfmKf1loGYwjYzzun7EMlyvPK5kYbRauAcjVg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@finos/perspective/-/perspective-1.6.3.tgz",
+      "integrity": "sha512-n+YHdmbd52GKpQ1HTvQmV/UjcWMYbzFkOLPSZYtMK4mUVrgrAmP04EeTTGHCKCN6srBljIYC3O0mpoEAnq1R0A==",
       "dependencies": {
         "fflate": "^0.7.2",
         "ws": "^6.1.2"
@@ -4294,11 +4300,11 @@
       }
     },
     "node_modules/@finos/perspective-viewer": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@finos/perspective-viewer/-/perspective-viewer-1.5.0.tgz",
-      "integrity": "sha512-qtCDDm4jA1x0SRFbMlTMyBjxPU3mog/10gZPcvdN4XSLNXiEtqeb3zXcbVMXiEcvOsBHgGUs8poJ6Y54a/F5UQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@finos/perspective-viewer/-/perspective-viewer-1.6.3.tgz",
+      "integrity": "sha512-i2ZTdtvriyldG4DBJRPxvfSP9zXSALh21EYO/C5VzuCwOBlY6bEVS7XudGxLlSGhcg215ukcF9EgHOkb2Scw+Q==",
       "dependencies": {
-        "@finos/perspective": "^1.5.0",
+        "@finos/perspective": "^1.6.3",
         "fflate": "^0.7.2",
         "mobile-drag-drop-shadow-dom": "3.0.0",
         "monaco-editor": "0.24.0"
@@ -4308,12 +4314,12 @@
       }
     },
     "node_modules/@finos/perspective-viewer-d3fc": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@finos/perspective-viewer-d3fc/-/perspective-viewer-d3fc-1.5.0.tgz",
-      "integrity": "sha512-WZwcRlPZGcbJSz3fFF2fFn894SVvTyIyDAAXuLzpzumsQEQMlwCiqS9jJqTTxY5gFDkH59HRL6R6AmEvaLIXZQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@finos/perspective-viewer-d3fc/-/perspective-viewer-d3fc-1.6.3.tgz",
+      "integrity": "sha512-zyCHeErPTO7l5/i1PyGBKKVkfJyFvo1WY2LOYeLq+OqcjjZ7DoG5bjXN7b/MZuDlpsDb5hcEIPLzLRim5anb7g==",
       "dependencies": {
-        "@finos/perspective": "^1.5.0",
-        "@finos/perspective-viewer": "^1.5.0",
+        "@finos/perspective": "^1.6.3",
+        "@finos/perspective-viewer": "^1.6.3",
         "chroma-js": "^1.3.4",
         "d3": "^7.1.1",
         "d3-svg-legend": "^2.25.6",
@@ -4322,33 +4328,33 @@
       }
     },
     "node_modules/@finos/perspective-viewer-datagrid": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@finos/perspective-viewer-datagrid/-/perspective-viewer-datagrid-1.5.0.tgz",
-      "integrity": "sha512-wsLEsqOZ82Jx+ifkbatNN6LkXmos8wfQITY3Xjuetr1iRpGuEUg2Oiy/0EIVJW3ra7jQcd2wGUQQfMs5JAZbrQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@finos/perspective-viewer-datagrid/-/perspective-viewer-datagrid-1.6.3.tgz",
+      "integrity": "sha512-fKpVv8za6kPHgBizgpMD69k76R9npmmpxKcxmmAGllzZ0k+aI4i6q5UKdPdXKsufvtE+cULxaea6kPBpO9MGIQ==",
       "dependencies": {
-        "@finos/perspective": "^1.5.0",
-        "@finos/perspective-viewer": "^1.5.0",
+        "@finos/perspective": "^1.6.3",
+        "@finos/perspective-viewer": "^1.6.3",
         "chroma-js": "^1.3.4",
         "regular-table": "=0.5.6"
       }
     },
     "node_modules/@finos/perspective-webpack-plugin": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@finos/perspective-webpack-plugin/-/perspective-webpack-plugin-1.5.0.tgz",
-      "integrity": "sha512-USvMEIXoGdmqkfPmHAJE35PeQMW6CDlHswVhDmTVPseO3xI+gXwgT3lu2Mtt6wScOIBNjoiDKZ87+k9CcX+6VQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@finos/perspective-webpack-plugin/-/perspective-webpack-plugin-1.6.3.tgz",
+      "integrity": "sha512-4JGY3/dO1pe4gK0VrsWAuiykGYU4B+5lBnzPpBdhdZSFOXlqoW0iOFN5R/AxYGdfdaSHWVXa7X1U0dBu0dvTng==",
       "dependencies": {
         "arraybuffer-loader": "^1.0.2",
         "css-loader": "^0.28.7",
         "cssnano": "^4.1.10",
         "cssnano-preset-lite": "^1.0.1",
         "exports-loader": "^3.1.0",
-        "postcss": "^7.0.19",
-        "postcss-loader": "^4.3.0",
+        "postcss": "^8",
+        "postcss-loader": "^7",
         "string-replace-loader": "^3.0.1",
         "worker-loader": "^3.0.7"
       },
       "peerDependencies": {
-        "webpack": "^5.0.0"
+        "webpack": "^5.60.0"
       }
     },
     "node_modules/@finos/perspective-webpack-plugin/node_modules/ansi-regex": {
@@ -4577,27 +4583,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@finos/perspective-webpack-plugin/node_modules/picocolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
-    },
-    "node_modules/@finos/perspective-webpack-plugin/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/@finos/perspective-webpack-plugin/node_modules/postcss-modules-extract-imports": {
@@ -4896,14 +4881,6 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
-    "node_modules/@finos/perspective-webpack-plugin/node_modules/postcss/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@finos/perspective-webpack-plugin/node_modules/strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -4932,6 +4909,41 @@
       "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
       "dependencies": {
         "async-limiter": "~1.0.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.8.tgz",
+      "integrity": "sha512-fgLqyWlwmTEuqV/TSLEL/t9JOmHNLFvCdgzXB0jc2w+WOItPCOJ1T0eyN6fQBQKRPfSqqNlu+kWj7ijcOVTVVQ==",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "0.2.28",
+        "tslib": "2.4.0"
+      }
+    },
+    "node_modules/@formatjs/intl-datetimeformat": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-datetimeformat/-/intl-datetimeformat-6.0.3.tgz",
+      "integrity": "sha512-Ql5NEZzJyarMg0NmavkTdT6xo+8TnQwh1M9Du+eezLTlPPegYmnf9HeD1t6sY3HOSRaEiVAbR7ZI5Jj+fcWKww==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.8",
+        "@formatjs/intl-localematcher": "0.2.28",
+        "tslib": "2.4.0"
+      }
+    },
+    "node_modules/@formatjs/intl-enumerator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-enumerator/-/intl-enumerator-1.1.1.tgz",
+      "integrity": "sha512-RVIFhxdwisMgJ5o/2BVEDJL2DvGDLir/AcgvQLfCIHYWXcHJcYvvLqEoZqS0/wNXBtqB7VQVApQ0ZtO1eoueOA==",
+      "dependencies": {
+        "tslib": "2.4.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.28.tgz",
+      "integrity": "sha512-FLsc6Gifs1np/8HnCn/7Q+lHMmenrD5fuDhRT82yj0gi9O19kfaFwjQUw1gZsyILuRyT93GuzdifHj7TKRhBcw==",
+      "dependencies": {
+        "tslib": "2.4.0"
       }
     },
     "node_modules/@glimmer/component": {
@@ -6559,6 +6571,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "devOptional": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -8340,6 +8353,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -8359,6 +8373,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
@@ -8577,6 +8592,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "devOptional": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -10519,6 +10535,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -21324,6 +21341,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
       "optional": true
     },
     "node_modules/filesize": {
@@ -21339,6 +21357,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "devOptional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -21825,6 +21844,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -22062,6 +22082,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "devOptional": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -23026,6 +23047,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "devOptional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -23164,6 +23186,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -23201,6 +23224,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "devOptional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -23238,6 +23262,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "devOptional": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -24860,6 +24885,15 @@
       "resolved": "https://registry.npmjs.org/mobile-drag-drop-shadow-dom/-/mobile-drag-drop-shadow-dom-3.0.0.tgz",
       "integrity": "sha512-cNDH83lfYhllESH+ddjyxXdnjunLec0ldnygm3nWY1zMtfeA1tHoVsAasZy63QhnRuN4ps0pGuL8TolUK/sYjA=="
     },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/monaco-editor": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.24.0.tgz",
@@ -24994,6 +25028,7 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "dev": true,
       "optional": true
     },
     "node_modules/nanoid": {
@@ -25251,6 +25286,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26378,6 +26414,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "devOptional": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -27648,18 +27685,16 @@
       }
     },
     "node_modules/postcss-loader": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-4.3.0.tgz",
-      "integrity": "sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-7.0.1.tgz",
+      "integrity": "sha512-VRviFEyYlLjctSM93gAZtcJJ/iSkPZ79zWbN/1fSH+NisBByEiVLqpdVDrPLVSi8DX0oJo12kL/GppTBdKVXiQ==",
       "dependencies": {
         "cosmiconfig": "^7.0.0",
-        "klona": "^2.0.4",
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0",
-        "semver": "^7.3.4"
+        "klona": "^2.0.5",
+        "semver": "^7.3.7"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": ">= 14.15.0"
       },
       "funding": {
         "type": "opencollective",
@@ -27667,7 +27702,7 @@
       },
       "peerDependencies": {
         "postcss": "^7.0.0 || ^8.0.1",
-        "webpack": "^4.0.0 || ^5.0.0"
+        "webpack": "^5.0.0"
       }
     },
     "node_modules/postcss-loader/node_modules/cosmiconfig": {
@@ -27685,19 +27720,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/postcss-loader/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
     "node_modules/postcss-loader/node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -27713,23 +27735,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/postcss-loader/node_modules/schema-utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/postcss-merge-idents": {
@@ -30542,6 +30547,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "devOptional": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -33526,6 +33532,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "devOptional": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -33598,10 +33605,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -34308,6 +34314,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -38053,9 +38060,9 @@
       }
     },
     "@finos/perspective": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@finos/perspective/-/perspective-1.5.0.tgz",
-      "integrity": "sha512-g57dcsdwaHleFp2m7wyZSnEcc8FAigd7Gvw/l5+gwyeZugQpezfmKf1loGYwjYzzun7EMlyvPK5kYbRauAcjVg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@finos/perspective/-/perspective-1.6.3.tgz",
+      "integrity": "sha512-n+YHdmbd52GKpQ1HTvQmV/UjcWMYbzFkOLPSZYtMK4mUVrgrAmP04EeTTGHCKCN6srBljIYC3O0mpoEAnq1R0A==",
       "requires": {
         "fflate": "^0.7.2",
         "ws": "^6.1.2"
@@ -38072,11 +38079,11 @@
       }
     },
     "@finos/perspective-viewer": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@finos/perspective-viewer/-/perspective-viewer-1.5.0.tgz",
-      "integrity": "sha512-qtCDDm4jA1x0SRFbMlTMyBjxPU3mog/10gZPcvdN4XSLNXiEtqeb3zXcbVMXiEcvOsBHgGUs8poJ6Y54a/F5UQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@finos/perspective-viewer/-/perspective-viewer-1.6.3.tgz",
+      "integrity": "sha512-i2ZTdtvriyldG4DBJRPxvfSP9zXSALh21EYO/C5VzuCwOBlY6bEVS7XudGxLlSGhcg215ukcF9EgHOkb2Scw+Q==",
       "requires": {
-        "@finos/perspective": "^1.5.0",
+        "@finos/perspective": "^1.6.3",
         "fflate": "^0.7.2",
         "mobile-drag-drop-shadow-dom": "3.0.0",
         "monaco-editor": "0.24.0",
@@ -38084,12 +38091,12 @@
       }
     },
     "@finos/perspective-viewer-d3fc": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@finos/perspective-viewer-d3fc/-/perspective-viewer-d3fc-1.5.0.tgz",
-      "integrity": "sha512-WZwcRlPZGcbJSz3fFF2fFn894SVvTyIyDAAXuLzpzumsQEQMlwCiqS9jJqTTxY5gFDkH59HRL6R6AmEvaLIXZQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@finos/perspective-viewer-d3fc/-/perspective-viewer-d3fc-1.6.3.tgz",
+      "integrity": "sha512-zyCHeErPTO7l5/i1PyGBKKVkfJyFvo1WY2LOYeLq+OqcjjZ7DoG5bjXN7b/MZuDlpsDb5hcEIPLzLRim5anb7g==",
       "requires": {
-        "@finos/perspective": "^1.5.0",
-        "@finos/perspective-viewer": "^1.5.0",
+        "@finos/perspective": "^1.6.3",
+        "@finos/perspective-viewer": "^1.6.3",
         "chroma-js": "^1.3.4",
         "d3": "^7.1.1",
         "d3-svg-legend": "^2.25.6",
@@ -38098,28 +38105,28 @@
       }
     },
     "@finos/perspective-viewer-datagrid": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@finos/perspective-viewer-datagrid/-/perspective-viewer-datagrid-1.5.0.tgz",
-      "integrity": "sha512-wsLEsqOZ82Jx+ifkbatNN6LkXmos8wfQITY3Xjuetr1iRpGuEUg2Oiy/0EIVJW3ra7jQcd2wGUQQfMs5JAZbrQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@finos/perspective-viewer-datagrid/-/perspective-viewer-datagrid-1.6.3.tgz",
+      "integrity": "sha512-fKpVv8za6kPHgBizgpMD69k76R9npmmpxKcxmmAGllzZ0k+aI4i6q5UKdPdXKsufvtE+cULxaea6kPBpO9MGIQ==",
       "requires": {
-        "@finos/perspective": "^1.5.0",
-        "@finos/perspective-viewer": "^1.5.0",
+        "@finos/perspective": "^1.6.3",
+        "@finos/perspective-viewer": "^1.6.3",
         "chroma-js": "^1.3.4",
         "regular-table": "=0.5.6"
       }
     },
     "@finos/perspective-webpack-plugin": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@finos/perspective-webpack-plugin/-/perspective-webpack-plugin-1.5.0.tgz",
-      "integrity": "sha512-USvMEIXoGdmqkfPmHAJE35PeQMW6CDlHswVhDmTVPseO3xI+gXwgT3lu2Mtt6wScOIBNjoiDKZ87+k9CcX+6VQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@finos/perspective-webpack-plugin/-/perspective-webpack-plugin-1.6.3.tgz",
+      "integrity": "sha512-4JGY3/dO1pe4gK0VrsWAuiykGYU4B+5lBnzPpBdhdZSFOXlqoW0iOFN5R/AxYGdfdaSHWVXa7X1U0dBu0dvTng==",
       "requires": {
         "arraybuffer-loader": "^1.0.2",
         "css-loader": "^0.28.7",
         "cssnano": "^4.1.10",
         "cssnano-preset-lite": "^1.0.1",
         "exports-loader": "^3.1.0",
-        "postcss": "^7.0.19",
-        "postcss-loader": "^4.3.0",
+        "postcss": "^8",
+        "postcss-loader": "^7",
         "string-replace-loader": "^3.0.1",
         "worker-loader": "^3.0.7"
       },
@@ -38310,27 +38317,6 @@
               "requires": {
                 "has-flag": "^3.0.0"
               }
-            }
-          }
-        },
-        "picocolors": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
-        },
-        "postcss": {
-          "version": "7.0.39",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-          "requires": {
-            "picocolors": "^0.2.1",
-            "source-map": "^0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             }
           }
         },
@@ -38582,6 +38568,41 @@
             "has-flag": "^1.0.0"
           }
         }
+      }
+    },
+    "@formatjs/ecma402-abstract": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.8.tgz",
+      "integrity": "sha512-fgLqyWlwmTEuqV/TSLEL/t9JOmHNLFvCdgzXB0jc2w+WOItPCOJ1T0eyN6fQBQKRPfSqqNlu+kWj7ijcOVTVVQ==",
+      "requires": {
+        "@formatjs/intl-localematcher": "0.2.28",
+        "tslib": "2.4.0"
+      }
+    },
+    "@formatjs/intl-datetimeformat": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-datetimeformat/-/intl-datetimeformat-6.0.3.tgz",
+      "integrity": "sha512-Ql5NEZzJyarMg0NmavkTdT6xo+8TnQwh1M9Du+eezLTlPPegYmnf9HeD1t6sY3HOSRaEiVAbR7ZI5Jj+fcWKww==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.11.8",
+        "@formatjs/intl-localematcher": "0.2.28",
+        "tslib": "2.4.0"
+      }
+    },
+    "@formatjs/intl-enumerator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-enumerator/-/intl-enumerator-1.1.1.tgz",
+      "integrity": "sha512-RVIFhxdwisMgJ5o/2BVEDJL2DvGDLir/AcgvQLfCIHYWXcHJcYvvLqEoZqS0/wNXBtqB7VQVApQ0ZtO1eoueOA==",
+      "requires": {
+        "tslib": "2.4.0"
+      }
+    },
+    "@formatjs/intl-localematcher": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.28.tgz",
+      "integrity": "sha512-FLsc6Gifs1np/8HnCn/7Q+lHMmenrD5fuDhRT82yj0gi9O19kfaFwjQUw1gZsyILuRyT93GuzdifHj7TKRhBcw==",
+      "requires": {
+        "tslib": "2.4.0"
       }
     },
     "@glimmer/component": {
@@ -39991,6 +40012,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "devOptional": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -41550,7 +41572,8 @@
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "devOptional": true
     },
     "binaryextensions": {
       "version": "2.3.0",
@@ -41561,6 +41584,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
       "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
@@ -41739,6 +41763,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "devOptional": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -43445,6 +43470,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "devOptional": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -52279,6 +52305,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
       "optional": true
     },
     "filesize": {
@@ -52291,6 +52318,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "devOptional": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -52705,6 +52733,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -52871,6 +52900,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "devOptional": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -53644,6 +53674,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "devOptional": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -53736,7 +53767,8 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "devOptional": true
     },
     "is-finite": {
       "version": "1.1.0",
@@ -53759,6 +53791,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "devOptional": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -53783,7 +53816,8 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "devOptional": true
     },
     "is-number-object": {
       "version": "1.0.6",
@@ -55159,6 +55193,12 @@
       "resolved": "https://registry.npmjs.org/mobile-drag-drop-shadow-dom/-/mobile-drag-drop-shadow-dom-3.0.0.tgz",
       "integrity": "sha512-cNDH83lfYhllESH+ddjyxXdnjunLec0ldnygm3nWY1zMtfeA1tHoVsAasZy63QhnRuN4ps0pGuL8TolUK/sYjA=="
     },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "dev": true
+    },
     "monaco-editor": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.24.0.tgz",
@@ -55277,6 +55317,7 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "dev": true,
       "optional": true
     },
     "nanoid": {
@@ -55495,7 +55536,8 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "devOptional": true
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -56356,7 +56398,8 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "devOptional": true
     },
     "pidtree": {
       "version": "0.3.1",
@@ -57317,15 +57360,13 @@
       }
     },
     "postcss-loader": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-4.3.0.tgz",
-      "integrity": "sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-7.0.1.tgz",
+      "integrity": "sha512-VRviFEyYlLjctSM93gAZtcJJ/iSkPZ79zWbN/1fSH+NisBByEiVLqpdVDrPLVSi8DX0oJo12kL/GppTBdKVXiQ==",
       "requires": {
         "cosmiconfig": "^7.0.0",
-        "klona": "^2.0.4",
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0",
-        "semver": "^7.3.4"
+        "klona": "^2.0.5",
+        "semver": "^7.3.7"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -57340,16 +57381,6 @@
             "yaml": "^1.10.0"
           }
         },
-        "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
         "parse-json": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -57359,16 +57390,6 @@
             "error-ex": "^1.3.1",
             "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
-          }
-        },
-        "schema-utils": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-          "requires": {
-            "@types/json-schema": "^7.0.8",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
           }
         }
       }
@@ -59549,6 +59570,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "devOptional": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -61926,6 +61948,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "devOptional": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -61988,10 +62011,9 @@
       "integrity": "sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw=="
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -62579,6 +62601,7 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "dev": true,
           "optional": true,
           "requires": {
             "bindings": "^1.5.0",

--- a/packages/perspective/package.json
+++ b/packages/perspective/package.json
@@ -33,11 +33,13 @@
   },
   "dependencies": {
     "@denali-design/ember": "^1.0.0-alpha.34",
-    "@finos/perspective": "^1.5.0",
-    "@finos/perspective-viewer": "^1.5.0",
-    "@finos/perspective-viewer-d3fc": "^1.5.0",
-    "@finos/perspective-viewer-datagrid": "^1.5.0",
-    "@finos/perspective-webpack-plugin": "^1.5.0",
+    "@finos/perspective": "^1.6.3",
+    "@finos/perspective-viewer": "^1.6.3",
+    "@finos/perspective-viewer-d3fc": "^1.6.3",
+    "@finos/perspective-viewer-datagrid": "^1.6.3",
+    "@finos/perspective-webpack-plugin": "^1.6.3",
+    "@formatjs/intl-datetimeformat": "^6.0.3",
+    "@formatjs/intl-enumerator": "^1.1.1",
     "@yavin/client": "0.4.0",
     "ember-auto-import": "^2.4.0",
     "ember-cli-babel": "^7.26.11",
@@ -102,6 +104,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-qunit": "^7.2.0",
     "loader.js": "^4.7.0",
+    "moment": "^2.29.4",
     "navi-data": "0.4.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.0",
@@ -110,6 +113,9 @@
     "sass": "^1.49.7",
     "typescript": "^4.6.2",
     "webpack": "^5.65.0"
+  },
+  "peerDependencies": {
+    "moment": "^2.29.4"
   },
   "engines": {
     "node": "12.* || 14.* || >= 16"

--- a/packages/perspective/types/global.d.ts
+++ b/packages/perspective/types/global.d.ts
@@ -7,3 +7,8 @@ declare module '@yavin/perspective/templates/*' {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TODO<T = any> = T;
+
+declare namespace Intl {
+  type Key = 'calendar' | 'collation' | 'currency' | 'numberingSystem' | 'timeZone' | 'unit';
+  const supportedValuesOf: (input: Key) => string[];
+}


### PR DESCRIPTION
## Description
Adds a polyfill for Intl.supportedValuesOf and Intl.DateTimeFormat and forcefully adds the 'UTC' timeZone to supportedValuesOf if it is supported.

Also reverts the schema change for using `date` on day aligned grains and instead sets the timeStyle to disabled to allow for using UTC timeZone

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
