### PR TITLE
Fix: Perspective in prod builds and bad imports

### DIFF
--- a/packages/app/config/targets.js
+++ b/packages/app/config/targets.js
@@ -1,17 +1,6 @@
 'use strict';
 
-const browsers = [
-  'last 1 Chrome versions',
-  'last 1 Firefox versions',
-  'last 1 Safari versions',
-];
-
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
+const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
 module.exports = {
   browsers,

--- a/packages/dashboards/addon/routes/dashboards/dashboard/widgets/new.ts
+++ b/packages/dashboards/addon/routes/dashboards/dashboard/widgets/new.ts
@@ -4,7 +4,7 @@
  */
 import { A } from '@ember/array';
 import ReportsNewRoute from 'navi-reports/routes/reports/new';
-import type { Transition } from 'navi-core/addon/utils/type-utils';
+import type { Transition } from 'navi-core/utils/type-utils';
 import type { ReportLike } from 'navi-reports/routes/reports/report';
 
 export default class DashboardsDashboardWidgetsNewRoute extends ReportsNewRoute {

--- a/packages/dashboards/tests/dummy/config/targets.js
+++ b/packages/dashboards/tests/dummy/config/targets.js
@@ -2,13 +2,6 @@
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };

--- a/packages/data/app/utils/metric.js
+++ b/packages/data/app/utils/metric.js
@@ -1,1 +1,0 @@
-export { default } from 'navi-data/utils/metric';

--- a/packages/data/tests/dummy/config/targets.js
+++ b/packages/data/tests/dummy/config/targets.js
@@ -2,13 +2,6 @@
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };

--- a/packages/directory/tests/dummy/config/targets.js
+++ b/packages/directory/tests/dummy/config/targets.js
@@ -2,13 +2,6 @@
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };

--- a/packages/notifications/tests/dummy/config/targets.js
+++ b/packages/notifications/tests/dummy/config/targets.js
@@ -2,13 +2,6 @@
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };

--- a/packages/perspective/addon/components/perspective.ts
+++ b/packages/perspective/addon/components/perspective.ts
@@ -13,7 +13,7 @@ import { isEqual, merge } from 'lodash-es';
 import { task, TaskGenerator } from 'ember-concurrency';
 import type { HTMLPerspectiveViewerElement } from '@finos/perspective-viewer';
 import type { Grain } from '@yavin/client/utils/date';
-import ColumnFragment from 'navi-core/addon/models/request/column';
+import ColumnFragment from 'navi-core/models/request/column';
 import { shouldPolyfill as shouldPolyfillSupportedValues, supportedValuesOf } from '@formatjs/intl-enumerator';
 import '@formatjs/intl-datetimeformat/polyfill';
 import '@formatjs/intl-datetimeformat/locale-data/en'; // locale-data for en

--- a/packages/reports/addon/routes/reports-print/reports/new.ts
+++ b/packages/reports/addon/routes/reports-print/reports/new.ts
@@ -4,7 +4,7 @@
  */
 import ReportNewRoute from 'navi-reports/routes/reports/new';
 import type ReportModel from 'navi-core/models/report';
-import type { Transition } from 'navi-core/addon/utils/type-utils';
+import type { Transition } from 'navi-core/utils/type-utils';
 
 export default class ReportsPrintReportsNewRoute extends ReportNewRoute {
   /**

--- a/packages/reports/tests/dummy/config/targets.js
+++ b/packages/reports/tests/dummy/config/targets.js
@@ -2,13 +2,6 @@
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };


### PR DESCRIPTION
## Description
Because we add support for `ie 11` in prod builds, babel jumbles with the syntax for `class extends HTMLElement` which is required for defining custom html elements (not just messing with prototypes). So a change in perspective caused us to start pulling in this js file and transpiling it leading to throwing a `TypeError: Illegal Constructor` 

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
