### PR TITLE
Fix: Set namespace to null when serializing v1 visualizations

### DIFF
--- a/packages/core/addon/serializers/visualization.ts
+++ b/packages/core/addon/serializers/visualization.ts
@@ -14,4 +14,14 @@ export default class VisualizationSerializer extends JSONSerializer {
     }
     return normalized;
   }
+
+  /**
+   * Adds namespace=null to v1 visualizations to overwrite any existing namespace
+   */
+  serialize() {
+    //@ts-expect-error using rest params
+    const visualization = super.serialize(...arguments) as Record<string, unknown>;
+    visualization.namespace = visualization.namespace ?? null;
+    return visualization;
+  }
 }

--- a/packages/core/tests/unit/models/report-test.js
+++ b/packages/core/tests/unit/models/report-test.js
@@ -66,6 +66,7 @@ const ExpectedReport = {
         dataSource: 'bardOne',
       },
       visualization: {
+        namespace: null,
         type: 'table',
         version: 2,
         metadata: {

--- a/packages/core/tests/unit/serializers/table-test.ts
+++ b/packages/core/tests/unit/serializers/table-test.ts
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+//@ts-ignore
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import type StoreService from '@ember-data/store';
+
+module('Unit | Serializer | table', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  test('serialize', async function (assert) {
+    const store = this.owner.lookup('service:store') as StoreService;
+    const tableProps = {
+      type: 'table',
+      version: 2,
+      metadata: {
+        columnAttributes: {},
+      },
+    };
+    const table = store.createFragment('table', tableProps);
+    const serialized = table.serialize();
+    assert.deepEqual(
+      serialized,
+      {
+        ...tableProps,
+        namespace: null,
+      },
+      'namespace should be set to null after serializing'
+    );
+  });
+});

--- a/packages/core/tests/unit/services/visualization-test.ts
+++ b/packages/core/tests/unit/services/visualization-test.ts
@@ -41,6 +41,7 @@ module('Unit | Service | visualization', function (hooks) {
         },
         type: 'table',
         version: 2,
+        namespace: null,
       },
       'it creates new table model'
     );
@@ -53,11 +54,12 @@ module('Unit | Service | visualization', function (hooks) {
     );
 
     assert.deepEqual(
-      (await table.normalizeModel({})).serialize(), // TODO: not quite right
+      (await table.normalizeModel({})).serialize(),
       {
         metadata: {},
         type: 'table',
         version: 2,
+        namespace: null,
       },
       'it normalizes settings'
     );

--- a/packages/dashboards/tests/unit/routes/dashboards/dashboard/widgets/new-test.js
+++ b/packages/dashboards/tests/unit/routes/dashboards/dashboard/widgets/new-test.js
@@ -23,6 +23,7 @@ const NEW_MODEL = {
   title: 'Untitled Widget',
   updatedOn: null,
   visualization: {
+    namespace: null,
     type: 'table',
     version: 2,
     metadata: {

--- a/packages/reports/tests/unit/routes/reports/new-test.ts
+++ b/packages/reports/tests/unit/routes/reports/new-test.ts
@@ -26,6 +26,7 @@ const NEW_MODEL = {
   title: 'Untitled Report',
   updatedOn: null,
   visualization: {
+    namespace: null,
     metadata: {
       columnAttributes: {},
     },

--- a/packages/reports/tests/unit/routes/reports/report-test.js
+++ b/packages/reports/tests/unit/routes/reports/report-test.js
@@ -75,7 +75,7 @@ module('Unit | Route | reports/report', function (hooks) {
 
     assert.deepEqual(
       route.setDefaultVisualization(mockReport).visualization,
-      { type: 'table', version: 2, metadata: { columnAttributes: {} } },
+      { type: 'table', version: 2, metadata: { columnAttributes: {} }, namespace: null },
       'Default visualization is set for null value in visualization'
     );
 

--- a/packages/reports/tests/unit/routes/reports/report/view-test.js
+++ b/packages/reports/tests/unit/routes/reports/report/view-test.js
@@ -102,6 +102,7 @@ module('Unit | Route | reports/report/view', function (hooks) {
               },
               type: 'table',
               version: 2,
+              namespace: null,
             },
             'visualization is updated'
           );

--- a/packages/reports/tests/unit/serializers/report-test.js
+++ b/packages/reports/tests/unit/serializers/report-test.js
@@ -70,6 +70,7 @@ module('Unit | Serializer | Report', function (hooks) {
           },
           title: 'RequestV2 testing report',
           visualization: {
+            namespace: null,
             metadata: {
               columnAttributes: {
                 c1: {
@@ -172,6 +173,7 @@ module('Unit | Serializer | Report', function (hooks) {
           },
           title: 'RequestV2 multi-param testing report',
           visualization: {
+            namespace: null,
             metadata: {
               columnAttributes: {
                 c1: {


### PR DESCRIPTION
## Description
Serialize v1 visualizations with namespace=null to overwrite any saved namespace saved in the database

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
