### PR TITLE
Fix: visualization-toggle crash

### DIFF
--- a/packages/reports/addon/components/visualization-toggle.hbs
+++ b/packages/reports/addon/components/visualization-toggle.hbs
@@ -18,16 +18,16 @@
     </PowerSelect>
   </div>
   <DenaliToggle
-    @options={{get this.valid.categoryToVisualizations this.selectedCategory}}
+    @options={{this.categoryVisualizations}}
     @activeOption={{this.selectedVisualization}}
     @onChange={{@onVisualizationTypeUpdate}}
     @isSmall={{true}}
     as |visualization|
   >
-    <DenaliIcon 
-      @icon={{visualization.icon}} 
+    <DenaliIcon
+      @icon={{visualization.icon}}
       @size="small"
-      class="visualization-toggle__option-icon {{if (eq this.selectedVisualization visualization) "visualization-toggle__option--is-active"}}" 
+      class="visualization-toggle__option-icon {{if (eq this.selectedVisualization visualization) "visualization-toggle__option--is-active"}}"
       title={{visualization.niceName}}
     />
   </DenaliToggle>

--- a/packages/reports/addon/components/visualization-toggle.ts
+++ b/packages/reports/addon/components/visualization-toggle.ts
@@ -56,7 +56,7 @@ export default class VisualizationToggle extends Component<Args> {
   }
 
   get categoryVisualizations() {
-    let visualizations = this.valid.categoryToVisualizations[this.selectedCategory];
+    const visualizations = this.valid.categoryToVisualizations[this.selectedCategory];
     return visualizations ?? [];
   }
 

--- a/packages/reports/addon/components/visualization-toggle.ts
+++ b/packages/reports/addon/components/visualization-toggle.ts
@@ -55,6 +55,11 @@ export default class VisualizationToggle extends Component<Args> {
     return category ?? this.valid.categories[0];
   }
 
+  get categoryVisualizations() {
+    let visualizations = this.valid.categoryToVisualizations[this.selectedCategory];
+    return visualizations ?? [];
+  }
+
   get selectedVisualization() {
     return this.args.report.visualization.manifest;
   }

--- a/packages/reports/tests/integration/components/visualization-toggle-test.ts
+++ b/packages/reports/tests/integration/components/visualization-toggle-test.ts
@@ -163,4 +163,18 @@ module('Integration | Component | visualization toggle', function (hooks) {
       'Only categories from valid visualizations are shown'
     );
   });
+
+  test('component does not crash when category becomes invalid', async function (this: TestContext, assert) {
+    assert.expect(1);
+
+    const TableManifest = this.visualizationService.getVisualization('yavin:table');
+
+    this.validVisualizations = [];
+    //@ts-expect-error - fake report
+    this.report = { visualization: { manifest: TableManifest } };
+
+    await render(TEMPLATE);
+
+    assert.dom('.visualization-toggle').exists('Component Renders without crashing');
+  });
 });


### PR DESCRIPTION
## Description

crashes if selected category is no longer has any valid visualizations


## Proposed Changes

- Pass empty list to `DenaliToggle` instead of `undefined` in this case.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
