### PR TITLE
Row limit

### DIFF
--- a/packages/client/src/plugins/elide/adapters/facts.ts
+++ b/packages/client/src/plugins/elide/adapters/facts.ts
@@ -180,8 +180,8 @@ export default class ElideFactsAdapter extends NativeWithCreate implements NaviF
   private getPaginationOptions(request: Request, options: RequestOptions = {}) {
     // Elide does not have a `LIMIT` concept, so map limit value to pagination concepts
     let pagination: PaginationOptions | undefined;
+    const page = options.page ?? 1;
     if (options.perPage) {
-      const page = options.page ?? 1;
       pagination = {
         after: (page - 1) * options.perPage,
         first: options.perPage,
@@ -189,9 +189,26 @@ export default class ElideFactsAdapter extends NativeWithCreate implements NaviF
     }
 
     //user preference should override adapter options
-    if (request.limit) {
+    if (request.limit && options.perPage) {
+      if (request.limit <= options.perPage) {
+        pagination = {
+          after: 0,
+          first: request.limit,
+        };
+      } else {
+        pagination = {
+          after: (page - 1) * options.perPage,
+          first: options.perPage,
+        };
+      }
+    } else if (options.perPage) {
       pagination = {
-        after: 0,
+        after: (page - 1) * options.perPage,
+        first: options.perPage,
+      };
+    } else if (request.limit) {
+      pagination = {
+        after: (page - 1) * request.limit,
         first: request.limit,
       };
     }

--- a/packages/client/src/plugins/elide/adapters/facts.ts
+++ b/packages/client/src/plugins/elide/adapters/facts.ts
@@ -188,7 +188,7 @@ export default class ElideFactsAdapter extends NativeWithCreate implements NaviF
       };
     }
 
-    //user preference should override adapter options
+    ///Request limit override adapter options if limit is less than page size
     if (request.limit && options.perPage) {
       if (request.limit <= options.perPage) {
         pagination = {

--- a/packages/client/src/plugins/elide/adapters/facts.ts
+++ b/packages/client/src/plugins/elide/adapters/facts.ts
@@ -180,19 +180,19 @@ export default class ElideFactsAdapter extends NativeWithCreate implements NaviF
   private getPaginationOptions(request: Request, options: RequestOptions = {}) {
     // Elide does not have a `LIMIT` concept, so map limit value to pagination concepts
     let pagination: PaginationOptions | undefined;
-    if (request.limit) {
-      pagination = {
-        after: 0,
-        first: request.limit,
-      };
-    }
-
-    // Low level pagination options override request limit
     if (options.perPage) {
       const page = options.page ?? 1;
       pagination = {
         after: (page - 1) * options.perPage,
         first: options.perPage,
+      };
+    }
+
+    //user preference should override adapter options
+    if (request.limit) {
+      pagination = {
+        after: 0,
+        first: request.limit,
       };
     }
     return pagination;

--- a/packages/client/src/plugins/fili/adapters/facts.ts
+++ b/packages/client/src/plugins/fili/adapters/facts.ts
@@ -395,6 +395,7 @@ export default class FiliFactsAdapter extends NativeWithCreate implements NaviFa
     let pagination: { page: number; perPage: number } | undefined;
     const page = options.page ?? 1;
 
+    //Request limit override adapter options if limit is less than page size
     if (request.limit && options.perPage) {
       if (request.limit <= options.perPage) {
         pagination = {

--- a/packages/client/src/plugins/fili/adapters/facts.ts
+++ b/packages/client/src/plugins/fili/adapters/facts.ts
@@ -393,23 +393,31 @@ export default class FiliFactsAdapter extends NativeWithCreate implements NaviFa
   private _buildPagination(request: Request, options: RequestOptions = {}) {
     // Fili does not have a `LIMIT` concept, so map limit value to pagination concepts
     let pagination: { page: number; perPage: number } | undefined;
-    if (options.perPage) {
-      const page = options.page ?? 1;
+    const page = options.page ?? 1;
 
+    if (request.limit && options.perPage) {
+      if (request.limit <= options.perPage) {
+        pagination = {
+          page: 1,
+          perPage: request.limit,
+        };
+      } else {
+        pagination = {
+          page,
+          perPage: options.perPage,
+        };
+      }
+    } else if (options.perPage) {
       pagination = {
         page,
         perPage: options.perPage,
       };
-    }
-
-    //user preference should override adapter options
-    if (request.limit) {
+    } else if (request.limit) {
       pagination = {
-        page: 1,
+        page,
         perPage: request.limit,
       };
     }
-    console.log(request.limit);
     return pagination;
   }
 

--- a/packages/client/src/plugins/fili/adapters/facts.ts
+++ b/packages/client/src/plugins/fili/adapters/facts.ts
@@ -393,14 +393,6 @@ export default class FiliFactsAdapter extends NativeWithCreate implements NaviFa
   private _buildPagination(request: Request, options: RequestOptions = {}) {
     // Fili does not have a `LIMIT` concept, so map limit value to pagination concepts
     let pagination: { page: number; perPage: number } | undefined;
-    if (request.limit) {
-      pagination = {
-        page: 1,
-        perPage: request.limit,
-      };
-    }
-
-    // Low level pagination options override request limit
     if (options.perPage) {
       const page = options.page ?? 1;
 
@@ -409,6 +401,15 @@ export default class FiliFactsAdapter extends NativeWithCreate implements NaviFa
         perPage: options.perPage,
       };
     }
+
+    //user preference should override adapter options
+    if (request.limit) {
+      pagination = {
+        page: 1,
+        perPage: request.limit,
+      };
+    }
+    console.log(request.limit);
     return pagination;
   }
 

--- a/packages/client/test/tests/unit/plugins/fili/adapters/facts-test.ts
+++ b/packages/client/test/tests/unit/plugins/fili/adapters/facts-test.ts
@@ -1229,7 +1229,7 @@ module('Unit | Plugins | Fili | Adapters | facts', function (hooks) {
         page: 1,
         perPage: 22,
       },
-      'the request limit overrides the perPage option'
+      'request limit override adapter options if limit is less than page size'
     );
   });
 

--- a/packages/client/test/tests/unit/plugins/fili/adapters/facts-test.ts
+++ b/packages/client/test/tests/unit/plugins/fili/adapters/facts-test.ts
@@ -1227,9 +1227,9 @@ module('Unit | Plugins | Fili | Adapters | facts', function (hooks) {
         having: 'm1-gt[0]',
         format: 'json',
         page: 1,
-        perPage: 100,
+        perPage: 22,
       },
-      'it overrides the request limit with the pagination request options'
+      'the request limit overrides the perPage option'
     );
   });
 

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -296,8 +296,8 @@ module('Unit | Adapter | facts/elide', function (hooks) {
 
     assert.deepEqual(
       adapter['getPaginationOptions'](TestRequest, { perPage: 3, page: 2 }),
-      { first: 3, after: 3 },
-      'specifying `perPage` and `page` overrides request limit'
+      { first: 10000, after: 0 },
+      'specifying `perPage` and `page` does not override request limit'
     );
 
     const limitless = { ...TestRequest, limit: null };

--- a/packages/data/tests/unit/adapters/facts/elide-test.ts
+++ b/packages/data/tests/unit/adapters/facts/elide-test.ts
@@ -290,14 +290,20 @@ module('Unit | Adapter | facts/elide', function (hooks) {
 
     assert.deepEqual(
       adapter['getPaginationOptions'](TestRequest, {}),
-      { first: 10000, after: 0 },
+      { first: 10_000, after: 0 },
       'request `limit` is translated to the correct pagination options'
     );
 
     assert.deepEqual(
       adapter['getPaginationOptions'](TestRequest, { perPage: 3, page: 2 }),
-      { first: 10000, after: 0 },
-      'specifying `perPage` and `page` does not override request limit'
+      { first: 3, after: 3 },
+      'specifying `perPage` smaller than request limit overrides request limit'
+    );
+
+    assert.deepEqual(
+      adapter['getPaginationOptions'](TestRequest, { perPage: 20_000, page: 2 }),
+      { first: 10_000, after: 0 },
+      'specifying `perPage` larger respects the request limit'
     );
 
     const limitless = { ...TestRequest, limit: null };

--- a/packages/reports/addon/components/report-builder.hbs
+++ b/packages/reports/addon/components/report-builder.hbs
@@ -43,9 +43,9 @@
             />
           </button>
           {{#unless @isFiltersCollapsed}}
-            <span class="report-builder__container-header__message flex align-items-center">
-              Click <DenaliIcon @icon="filter-add" @size="small" class="report-builder__container-header__message--icon m-x-2" /> next to a dimension/metric to add a filter.
-            </span>
+            <DenaliInputGroup @label="Row Limit" class="report-builder__row-limit">
+              <DenaliInput placeholder="Row Limit" @size="small" @wrapperClass="w-20" type="number"/>
+            </DenaliInputGroup>
           {{/unless}}
         </span>
 

--- a/packages/reports/addon/components/report-builder.hbs
+++ b/packages/reports/addon/components/report-builder.hbs
@@ -44,7 +44,18 @@
           </button>
           {{#unless @isFiltersCollapsed}}
             <DenaliInputGroup @label="Row Limit" class="report-builder__row-limit">
-              <DenaliInput placeholder="Row Limit" @size="small" @wrapperClass="w-20" type="number"/>
+              {{#if (gt this.request.limit 10000)}}
+                <DenaliIcon @icon="warning" @size="small" id="report-builder__row-limit-warning" class="report-builder__row-limit-warning--icon"/>
+                <EmberTooltip targetId="report-builder__row-limit-warning" @popperContainer="body">
+                  You will likely have performance issues above 10,000 rows, use at your own risk.
+                </EmberTooltip>
+              {{/if}}
+              <DenaliInput placeholder="Row Limit"
+                @size="small"
+                @wrapperClass="w-20"
+                type="number"
+                value={{this.request.limit}}
+                {{on "input" (pipe (pick "target.value") (update-report-action "UPDATE_LIMIT"))}} />
             </DenaliInputGroup>
           {{/unless}}
         </span>

--- a/packages/reports/addon/components/report-builder.hbs
+++ b/packages/reports/addon/components/report-builder.hbs
@@ -44,16 +44,12 @@
           </button>
           {{#unless @isFiltersCollapsed}}
             <DenaliInputGroup @label="Row Limit" class="report-builder__row-limit">
-              {{#if (gt this.request.limit 10000)}}
-                <DenaliIcon @icon="warning" @size="small" id="report-builder__row-limit-warning" class="report-builder__row-limit-warning--icon"/>
-                <EmberTooltip targetId="report-builder__row-limit-warning" @popperContainer="body">
-                  You will likely have performance issues above 10,000 rows, use at your own risk.
-                </EmberTooltip>
-              {{/if}}
               <DenaliInput placeholder="Row Limit"
                 @size="small"
                 @wrapperClass="w-20"
                 type="number"
+                min="1"
+                max="10000"
                 value={{this.request.limit}}
                 {{on "input" (pipe (pick "target.value") (update-report-action "UPDATE_LIMIT"))}} />
             </DenaliInputGroup>

--- a/packages/reports/addon/consumers/request/limit.ts
+++ b/packages/reports/addon/consumers/request/limit.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2022, Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
+ */
+import { inject as service } from '@ember/service';
+import ActionConsumer from 'navi-core/consumers/action-consumer';
+import Route from '@ember/routing/route';
+import RequestActionDispatcher, { RequestActions } from 'navi-reports/services/request-action-dispatcher';
+import type ReportModel from 'navi-core/models/report';
+
+export default class LimitConsumer extends ActionConsumer {
+  @service
+  declare requestActionDispatcher: RequestActionDispatcher;
+
+  actions = {
+    [RequestActions.UPDATE_LIMIT](this: LimitConsumer, route: Route, limit: number | null) {
+      const { routeName } = route;
+      const { request } = route.modelFor(routeName) as ReportModel;
+      request.limit = limit;
+    },
+  };
+}

--- a/packages/reports/addon/consumers/request/limit.ts
+++ b/packages/reports/addon/consumers/request/limit.ts
@@ -13,10 +13,11 @@ export default class LimitConsumer extends ActionConsumer {
   declare requestActionDispatcher: RequestActionDispatcher;
 
   actions = {
-    [RequestActions.UPDATE_LIMIT](this: LimitConsumer, route: Route, limit: number | null) {
+    [RequestActions.UPDATE_LIMIT](this: LimitConsumer, route: Route, limit: string | number | null) {
       const { routeName } = route;
       const { request } = route.modelFor(routeName) as ReportModel;
-      request.limit = limit;
+      const limitNumber = typeof limit === 'string' ? parseInt(limit) : limit;
+      request.limit = !Number.isNaN(limitNumber) ? limitNumber : null;
     },
   };
 }

--- a/packages/reports/addon/consumers/request/limit.ts
+++ b/packages/reports/addon/consumers/request/limit.ts
@@ -16,7 +16,11 @@ export default class LimitConsumer extends ActionConsumer {
     [RequestActions.UPDATE_LIMIT](this: LimitConsumer, route: Route, limit: string | number | null) {
       const { routeName } = route;
       const { request } = route.modelFor(routeName) as ReportModel;
-      const limitNumber = typeof limit === 'string' ? parseInt(limit) : limit;
+      let limitNumber = typeof limit === 'string' ? parseInt(limit) : limit;
+      //cap at 10k for now
+      if (limitNumber !== null && limitNumber > 10_000) {
+        limitNumber = 10_000;
+      }
       request.limit = !Number.isNaN(limitNumber) ? limitNumber : null;
     },
   };

--- a/packages/reports/addon/services/request-action-dispatcher.ts
+++ b/packages/reports/addon/services/request-action-dispatcher.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, Yahoo Holdings Inc.
+ * Copyright 2022, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 import ActionDispatcher from 'navi-core/services/action-dispatcher';
@@ -26,6 +26,8 @@ export const RequestActions = <const>{
   UPSERT_SORT: 'upsertSort',
   REMOVE_SORT: 'removeSort',
 
+  UPDATE_LIMIT: 'updateLimit',
+
   PUSH_ROLLUP_COLUMN: 'pushRollupColumn',
   REMOVE_ROLLUP_COLUMN: 'removeRollupColumn',
   UPDATE_GRAND_TOTAL: 'updateGrandTotal',
@@ -40,6 +42,7 @@ export default class RequestActionDispatcher extends ActionDispatcher {
       'request/table',
       'request/sort',
       'request/fili',
+      'request/limit',
       'request/constraint',
       'request/rollup',
     ];

--- a/packages/reports/app/consumers/request/limit.js
+++ b/packages/reports/app/consumers/request/limit.js
@@ -1,0 +1,1 @@
+export { default } from 'navi-reports/consumers/request/limit';

--- a/packages/reports/app/styles/navi-reports/components/report-builder.scss
+++ b/packages/reports/app/styles/navi-reports/components/report-builder.scss
@@ -175,4 +175,11 @@
       }
     }
   }
+
+  &__row-limit {
+    &.input-group label {
+      font-size: 12px;
+      min-width: unset;
+    }
+  }
 }

--- a/packages/reports/app/styles/navi-reports/components/report-builder.scss
+++ b/packages/reports/app/styles/navi-reports/components/report-builder.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021, Yahoo Holdings Inc.
+ * Copyright 2022, Yahoo Holdings Inc.
  * Licensed under the terms of the MIT license. See accompanying LICENSE.md file for terms.
  */
 
@@ -180,6 +180,11 @@
     &.input-group label {
       font-size: 12px;
       min-width: unset;
+    }
+
+    &-warning--icon {
+      color: map-get($denali-colors, 'yellow', '700');
+      padding: 0 8px 0 0;
     }
   }
 }

--- a/packages/reports/app/styles/navi-reports/components/report-builder.scss
+++ b/packages/reports/app/styles/navi-reports/components/report-builder.scss
@@ -181,10 +181,5 @@
       font-size: 12px;
       min-width: unset;
     }
-
-    &-warning--icon {
-      color: map-get($denali-colors, 'yellow', '700');
-      padding: 0 8px 0 0;
-    }
   }
 }

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -2280,11 +2280,11 @@ module('Acceptance | Navi Report', function (hooks) {
 
     fillIn('.report-builder__row-limit input', 30000);
     limit = await getLimitFromApi();
-    assert.equal(limit, 10000, '10000 large inputs get adjusted back to max');
+    assert.equal(limit, 10000, '30000 large inputs get adjusted back to max');
 
     fillIn('.report-builder__row-limit input', 10000);
     limit = await getLimitFromApi();
-    assert.equal(limit, 10000, '30000 shows up as perPage limit in api');
+    assert.equal(limit, 10000, '10000 shows up as perPage limit in api');
 
     fillIn('.report-builder__row-limit input', '');
     limit = await getLimitFromApi();

--- a/packages/reports/tests/acceptance/report-test.js
+++ b/packages/reports/tests/acceptance/report-test.js
@@ -2259,7 +2259,7 @@ module('Acceptance | Navi Report', function (hooks) {
   });
 
   test('Row Limit control', async function (assert) {
-    assert.expect(10);
+    assert.expect(5);
     await visit('/reports/1/view');
 
     const getLimitFromApi = async () => {
@@ -2273,26 +2273,21 @@ module('Acceptance | Navi Report', function (hooks) {
 
     let limit = await getLimitFromApi();
     assert.equal(limit, null, 'Default sends no page limit to api, allowing default page');
-    assert.dom('#report-builder__row-limit-warning').doesNotExist('Warning does not exist in this case');
 
     fillIn('.report-builder__row-limit input', 10);
     limit = await getLimitFromApi();
     assert.equal(limit, 10, '10 shows up as perPage limit in api');
-    assert.dom('#report-builder__row-limit-warning').doesNotExist('Warning does not exist in this case');
 
     fillIn('.report-builder__row-limit input', 30000);
     limit = await getLimitFromApi();
-    assert.equal(limit, 30000, '30000 shows up as perPage limit in api');
-    assert.dom('#report-builder__row-limit-warning').exists('Warning should show on large page numbers');
+    assert.equal(limit, 10000, '10000 large inputs get adjusted back to max');
 
     fillIn('.report-builder__row-limit input', 10000);
     limit = await getLimitFromApi();
     assert.equal(limit, 10000, '30000 shows up as perPage limit in api');
-    assert.dom('#report-builder__row-limit-warning').doesNotExist('Warning does not exist in this case');
 
     fillIn('.report-builder__row-limit input', '');
     limit = await getLimitFromApi();
     assert.equal(limit, null, 'default page limit when you empty the fillIn');
-    assert.dom('#report-builder__row-limit-warning').doesNotExist('Warning does not exist in this case');
   });
 });

--- a/packages/reports/tests/unit/consumers/request/limit-test.ts
+++ b/packages/reports/tests/unit/consumers/request/limit-test.ts
@@ -41,7 +41,7 @@ module('Unit | Consumer | request limit', function (hooks) {
   });
 
   test('UPDATE LIMIT', function (assert) {
-    assert.expect(3);
+    assert.expect(5);
     run(() => {
       Consumer.send(RequestActions.UPDATE_LIMIT, Route, 10);
     });
@@ -52,12 +52,24 @@ module('Unit | Consumer | request limit', function (hooks) {
       Consumer.send(RequestActions.UPDATE_LIMIT, Route, 12000);
     });
 
-    assert.equal(CurrentModel.request.limit, 12000, 'Sets request limit to large number');
+    assert.equal(CurrentModel.request.limit, 10000, 'Sets request limit to max when given a large number');
 
     run(() => {
       Consumer.send(RequestActions.UPDATE_LIMIT, Route, null);
     });
 
     assert.equal(CurrentModel.request.limit, null, 'Sets request limit to null to pick up default');
+
+    run(() => {
+      Consumer.send(RequestActions.UPDATE_LIMIT, Route, '45');
+    });
+
+    assert.equal(CurrentModel.request.limit, 45, 'Strings get normalized to ints');
+
+    run(() => {
+      Consumer.send(RequestActions.UPDATE_LIMIT, Route, 'moose');
+    });
+
+    assert.equal(CurrentModel.request.limit, null, 'NaN get normalized to null');
   });
 });

--- a/packages/reports/tests/unit/consumers/request/limit-test.ts
+++ b/packages/reports/tests/unit/consumers/request/limit-test.ts
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+// @ts-ignore
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { RequestActions } from 'navi-reports/services/request-action-dispatcher';
+import type StoreService from '@ember-data/store';
+import type LimitConsumer from 'navi-reports/consumers/request/limit';
+import type RequestFragment from 'navi-core/models/request';
+import { run } from '@ember/runloop';
+
+let Store: StoreService;
+let Consumer: LimitConsumer;
+let CurrentModel: { request: RequestFragment };
+let Route: { modelFor: () => { request: RequestFragment }; routeName: string };
+
+module('Unit | Consumer | request limit', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    Store = this.owner.lookup('service:store');
+
+    Consumer = this.owner.lookup('consumer:request/limit');
+
+    CurrentModel = {
+      request: Store.createFragment('request', {
+        table: 'network',
+        limit: null,
+        dataSource: 'bardOne',
+        requestVersion: '2.0',
+        columns: [],
+        filters: [],
+        sorts: [],
+      }),
+    };
+
+    Route = {
+      modelFor: () => CurrentModel,
+      routeName: 'whatever',
+    };
+  });
+
+  test('UPDATE LIMIT', function (assert) {
+    assert.expect(3);
+    run(() => {
+      Consumer.send(RequestActions.UPDATE_LIMIT, Route, 10);
+    });
+
+    assert.equal(CurrentModel.request.limit, 10, 'Sets request limit to 10');
+
+    run(() => {
+      Consumer.send(RequestActions.UPDATE_LIMIT, Route, 12000);
+    });
+
+    assert.equal(CurrentModel.request.limit, 12000, 'Sets request limit to large number');
+
+    run(() => {
+      Consumer.send(RequestActions.UPDATE_LIMIT, Route, null);
+    });
+
+    assert.equal(CurrentModel.request.limit, null, 'Sets request limit to null to pick up default');
+  });
+});


### PR DESCRIPTION
## Description

Allow users to change the row limit passed the UI. Shows warning on large page limits.

## Proposed Changes

- Add UI for changing row limit above filter box. 
- Adjust pagination logic on adapters: `request.limit` will override `perPage` options if `request.limit is <= perPage`

## Screenshots
![Screen Shot 2022-09-21 at 10 28 18 AM](https://user-images.githubusercontent.com/99422/191549501-edd8f372-71eb-43f3-9d33-e0098ec75b78.png)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
