### PR TITLE
Fix: Abort locks up UI with unbound exception.

### DIFF
--- a/packages/client/src/errors/navi-adapter-error.ts
+++ b/packages/client/src/errors/navi-adapter-error.ts
@@ -36,6 +36,6 @@ export default class NaviAdapterError extends Error {
   }
 
   toString() {
-    return `${super.toString()}. Root cause: ${this.rootCause}`;
+    return `${super.toString()}.`;
   }
 }


### PR DESCRIPTION
## Description

Abort (like a timeout) causes a DOMException Abort, that is unbound, stringify the exception causes 'Illegal Invocation'

## Proposed Changes

- Temporary workaround
- Do not stringify rootCause for now.
- Fix might be through `ensure` to figure out why it's throwing an unbound DOMException 

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
